### PR TITLE
make Vocab more robust

### DIFF
--- a/stanza/text/vocab.py
+++ b/stanza/text/vocab.py
@@ -7,13 +7,16 @@ from ..util.resource import get_data_or_download
 
 
 class Vocab(object):
-    """Defines a bijection between N words and the integers 0 through N-1."""
+    """Defines a bijection between N words and the integers 0 through N-1.
+
+    UNK is always represented by the 0 index.
+    """
 
     def __init__(self, unk):
         """Construct a Vocab object.
 
         Args:
-            unk: a string to represent the unknown word (UNK).
+            unk: a string to represent the unknown word (UNK). It is always represented by the 0 index.
         """
         self.__word2index = OrderedDict()
         self.__counts = Counter()
@@ -33,7 +36,7 @@ class Vocab(object):
         return 'Vocab(%d words)' % len(self.__word2index)
 
     def __len__(self):
-        """Get total number of entries in vocab."""
+        """Get total number of entries in vocab (including UNK)."""
         return len(self.__word2index)
 
     def __getitem__(self, word):

--- a/stanza/text/vocab.py
+++ b/stanza/text/vocab.py
@@ -44,10 +44,7 @@ class Vocab(object):
 
         If the word is unknown, the index for UNK is returned.
         """
-        try:
-            return self.__word2index[word]
-        except KeyError:
-            return self.__word2index[self.__unk]
+        return self.__word2index.get(word, 0)
 
     def __contains__(self, word):
         return word in self.__word2index


### PR DESCRIPTION
### A list of changes
- make specifying an UNK token mandatory
	- ensuring that the 0 index is *always* assigned to UNK just makes `Vocab` more robust and less prone to getting internally inconsistent, e.g.
	   - we need to ensure that UNK is never pruned by `prune_rares`
	   - we need to ensure that UNK stays as 0 even when we sort by decreasing count
      - we don't want the user adding UNK later on their own at a different index
- eliminate `self.index2word`
	- this can become inconsistent with `self.word2index`
	- instead, we just make `self.word2index` an `OrderedDict`
- name mangle the attributes of `Vocab`
	- makes it harder for users to accidentally screw up `word2index`
- added classmethod to create a `Vocab` from a word2index dictionary
- `words2indices` no longer supports functionality to add new words to
the `Vocab`
	- instead, this functionality is supported by the `update` method
(analogous to calling `update` on a `dict`)

### Things that still need to be refactored to match the revised Vocab
(@vzhong, I just wanted to get your opinion before going ahead w/ a full refactor)
- subclasses
    - (they all just need to reference the now name-mangled attributes)
    - EmbeddedVocab
    - SennaVocab
    - GloveVocab
- TestVocab
    - needs to now assume UNK is mandatory