### PR TITLE
Revise Vocab object

### DIFF
--- a/stanza/text/vocab.py
+++ b/stanza/text/vocab.py
@@ -5,7 +5,7 @@ __author__ = 'victor, kelvinguu'
 from collections import Counter, namedtuple, OrderedDict
 from itertools import izip
 import numpy as np
-from copy import deepcopy
+from copy import deepcopy, copy
 import zipfile
 from ..util.resource import get_data_or_download
 
@@ -147,12 +147,18 @@ class Vocab(object):
         index2word = self._index2word_copy()
         return [index2word[i] for i in indices]
 
-    @property
-    def counts(self):
+    def count(self, w):
+        """Get the count for a word.
+
+        :param w: a string
         """
-        :return: a counter containing the number of occurrences of each word.
+        return self._counts[w]
+
+    def counts_copy(self):
         """
-        return self._counts
+        :return: a copy of the counter containing the number of occurrences of each word.
+        """
+        return copy(self._counts)
 
     def prune_rares(self, cutoff=2):
         """

--- a/stanza/text/vocab.py
+++ b/stanza/text/vocab.py
@@ -68,14 +68,6 @@ class Vocab(BaseVocab, OrderedDict):
         # assign an index for UNK
         self.add(self._unk, count=0)
 
-    def _index2word_copy(self):
-        """Get a copy of the mapping from indices to words.
-
-        :return: a list of strings
-        """
-        # TODO(kelvinguu): it would be nice to use `dict.viewkeys` so that it's not a copy,
-        # but unfortunately those are not indexable
-        return self.keys()  # works because self is an OrderedDict
     def __getitem__(self, word):
         """Get the index for a word.
 
@@ -136,6 +128,15 @@ class Vocab(BaseVocab, OrderedDict):
         :return: a copy of the counter containing the number of occurrences of each word.
         """
         return copy(self._counts)
+
+    def _index2word_copy(self):
+        """Get a copy of the mapping from indices to words.
+
+        :return: a list of strings
+        """
+        # TODO(kelvinguu): it would be nice to use `dict.viewkeys` so that it's not a copy,
+        # but unfortunately those are not indexable
+        return self.keys()  # works because self is an OrderedDict
 
     def prune_rares(self, cutoff=2):
         """

--- a/stanza/text/vocab.py
+++ b/stanza/text/vocab.py
@@ -126,12 +126,6 @@ class Vocab(BaseVocab, OrderedDict):
         """
         return self._counts[w]
 
-    def counts_copy(self):
-        """
-        :return: a copy of the counter containing the number of occurrences of each word.
-        """
-        return copy(self._counts)
-
     @property
     def _index2word(self):
         """Mapping from indices to words.

--- a/stanza/text/vocab.py
+++ b/stanza/text/vocab.py
@@ -5,7 +5,7 @@ __author__ = 'victor, kelvinguu'
 from collections import Counter, namedtuple, OrderedDict
 from itertools import izip
 import numpy as np
-from copy import deepcopy, copy
+from copy import copy
 import zipfile
 from ..util.resource import get_data_or_download
 

--- a/stanza/text/vocab.py
+++ b/stanza/text/vocab.py
@@ -94,7 +94,7 @@ class Vocab(BaseVocab, OrderedDict):
         there is a perfect bijection between these N words and the integers 0 through N-1.
         """
         if word not in self:
-            self[word] = len(self)
+            super(Vocab, self).__setitem__(word, len(self))
         self._counts[word] += count
         return self[word]
 

--- a/stanza/text/vocab.py
+++ b/stanza/text/vocab.py
@@ -10,7 +10,7 @@ import zipfile
 from ..util.resource import get_data_or_download
 
 
-class Vocab(object):
+class Vocab(OrderedDict):
     """A mapping between words and numerical indices. This class is used to facilitate the creation of word embedding matrices.
 
     Example:
@@ -29,7 +29,8 @@ class Vocab(object):
 
         :param unk: string to represent the unknown word (UNK). It is always represented by the 0 index.
         """
-        self._word2index = OrderedDict()
+        super(Vocab, self).__init__()
+
         self._counts = Counter()
         self._unk = unk
 
@@ -43,61 +44,17 @@ class Vocab(object):
         """
         # TODO(kelvinguu): it would be nice to use `dict.viewkeys` so that it's not a copy,
         # but unfortunately those are not indexable
-        return self._word2index.keys()  # works because word2index is an OrderedDict
-
-    def __iter__(self):
-        """
-        :return: An iterator over the (word, index) tuples in the vocabulary
-        """
-        return iter(self._word2index)
-
-    def iteritems(self):
-        """
-        :return: An iterator over the (word, index) tuples in the vocabulary
-        """
-        return self._word2index.iteritems()
-
-    def items(self):
-        """
-        :return: A list of (word, index) pairs from the vocabulary.
-        """
-        return self._word2index.items()
-
-    def keys(self):
-        """
-        :return: A list of words in the vocabulary.
-        """
-        return self._word2index.keys()
-
-    def iterkeys(self):
-        """
-        :return: An iterator over the words in the vocabulary.
-        """
-        return self._word2index.iterkeys()
-
-    def __repr__(self):
-        """Represent Vocab as a dictionary from words to indices."""
-        return str(self._word2index)
+        return self.keys()  # works because self is an OrderedDict
 
     def __str__(self):
-        return 'Vocab(%d words)' % len(self._word2index)
-
-    def __len__(self):
-        """Get total number of entries in vocab (including UNK)."""
-        return len(self._word2index)
+        return 'Vocab(%d words)' % len(self)
 
     def __getitem__(self, word):
         """Get the index for a word.
 
         If the word is unknown, the index for UNK is returned.
         """
-        return self._word2index.get(word, 0)
-
-    def __contains__(self, word):
-        """
-        :return: whether word is in the vocabulary
-        """
-        return word in self._word2index
+        return self.get(word, 0)
 
     def add(self, word, count=1):
         """Add a word to the vocabulary and return its index.
@@ -111,10 +68,10 @@ class Vocab(object):
         WARNING: this function assumes that if the Vocab currently has N words, then
         there is a perfect bijection between these N words and the integers 0 through N-1.
         """
-        if word not in self._word2index:
-            self._word2index[word] = len(self._word2index)
+        if word not in self:
+            self[word] = len(self)
         self._counts[word] += count
-        return self._word2index[word]
+        return self[word]
 
     def update(self, words):
         """
@@ -172,7 +129,7 @@ class Vocab(object):
         """
         # make a deep copy and reset its contents
         v = self.__class__(unk=self._unk)
-        for w in self._word2index:
+        for w in self:
             if self._counts[w] >= cutoff or w == self._unk:  # don't remove unk
                 v.add(w, count=self._counts[w])
         return v

--- a/stanza/text/vocab.py
+++ b/stanza/text/vocab.py
@@ -132,20 +132,6 @@ class Vocab(BaseVocab, OrderedDict):
         """
         return copy(self._counts)
 
-    def _refresh_index2word_cache(self):
-        try:
-            self._index2word_cache
-        except AttributeError:
-            # create if it doesn't exist
-            self._index2word_cache = self._compute_index2word()
-
-        # update if it is out of date
-        if len(self._index2word_cache) != len(self):
-            self._index2word_cache = self._compute_index2word()
-
-    def _compute_index2word(self):
-        return self.keys()  # works because self is an OrderedDict
-
     @property
     def _index2word(self):
         """Mapping from indices to words.
@@ -155,7 +141,19 @@ class Vocab(BaseVocab, OrderedDict):
         :return: a list of strings
         """
         # TODO(kelvinguu): it would be nice to just use `dict.viewkeys`, but unfortunately those are not indexable
-        self._refresh_index2word_cache()
+
+        compute_index2word = lambda: self.keys()  # this works because self is an OrderedDict
+
+        # create if it doesn't exist
+        try:
+            self._index2word_cache
+        except AttributeError:
+            self._index2word_cache = compute_index2word()
+
+        # update if it is out of date
+        if len(self._index2word_cache) != len(self):
+            self._index2word_cache = compute_index2word()
+
         return self._index2word_cache
 
     def prune_rares(self, cutoff=2):

--- a/stanza/text/vocab.py
+++ b/stanza/text/vocab.py
@@ -45,14 +45,6 @@ class Vocab(object):
         # but unfortunately those are not indexable
         return self._word2index.keys()  # works because word2index is an OrderedDict
 
-    def clear(self):
-        """
-        Resets all mappings and counts. The unk token is retained.
-        """
-        self._word2index.clear()
-        self._counts.clear()
-        self.add(self._unk, count=0)
-
     def __iter__(self):
         """
         :return: An iterator over the (word, index) tuples in the vocabulary
@@ -173,8 +165,7 @@ class Vocab(object):
         NOTE: UNK is never pruned.
         """
         # make a deep copy and reset its contents
-        v = deepcopy(self)
-        v.clear()
+        v = self.__class__(unk=self._unk)
         for w in self._word2index:
             if self._counts[w] >= cutoff or w == self._unk:  # don't remove unk
                 v.add(w, count=self._counts[w])
@@ -199,16 +190,6 @@ class Vocab(object):
             if word != self._unk:
                 v.add(word, count=count)
         return v
-
-    def clear_counts(self):
-        """
-        Removes counts for all tokens.
-
-        :return: the vocabulary object.
-        """
-        # TODO: this removes the entries too, rather than setting them to 0
-        self._counts.clear()
-        return self
 
     @classmethod
     def from_dict(cls, word2index, unk, counts=None):

--- a/stanza/text/vocab.py
+++ b/stanza/text/vocab.py
@@ -116,6 +116,9 @@ class Vocab(BaseVocab, OrderedDict):
         index2word = self._index2word_copy()
         return index2word[i]
 
+    def freeze(self):
+        return FrozenVocab(self)
+
     def count(self, w):
         """Get the count for a word.
 
@@ -252,6 +255,20 @@ class Vocab(BaseVocab, OrderedDict):
             if i == 0:
                 unk = word
         return cls.from_dict(word2index, unk, counts)
+
+
+class FrozenVocab(BaseVocab):
+    def __init__(self, vocab):
+        self._word2index = dict(vocab)  # make a copy
+        self._index2word = vocab._index2word_copy()
+        # since this vocab is frozen, we do not need to worry about
+        # word2index and index2word becoming inconsistent
+
+    def word2index(self, w):
+        return self._word2index.get(w, 0)
+
+    def index2word(self, i):
+        return self._index2word[i]
 
 
 class EmbeddedVocab(Vocab):

--- a/test/unit_tests/text/test_vocab.py
+++ b/test/unit_tests/text/test_vocab.py
@@ -42,21 +42,21 @@ class TestVocab(TestCase):
     def test_prune_rares(self):
         v = self.Vocab(unk='unk')
         v.update(['hi'] * 3 + ['bye'] * 5)
-        self.assertEqual({'hi': 3, 'bye': 5, 'unk': 0}, dict(v.counts_copy()))
+        self.assertEqual({'hi': 3, 'bye': 5, 'unk': 0}, dict(v._counts))
         p = v.prune_rares(cutoff=4)
-        self.assertEqual({'bye': 5, 'unk': 0}, dict(p.counts_copy()))
+        self.assertEqual({'bye': 5, 'unk': 0}, dict(p._counts))
 
     def test_sort_by_decreasing_count(self):
         v = self.Vocab(unk='unk')
         v.update('some words words for for for you you you you'.split())
         s = v.sort_by_decreasing_count()
         self.assertEqual(['unk', 'you', 'for', 'words', 'some'], list(iter(s)))
-        self.assertEqual({'unk': 0, 'you': 4, 'for': 3, 'words': 2, 'some': 1}, dict(s.counts_copy()))
+        self.assertEqual({'unk': 0, 'you': 4, 'for': 3, 'words': 2, 'some': 1}, dict(s._counts))
 
     def test_from_file(self):
         lines = ['unk\t10\n', 'cat\t4\n', 'bear\t6']
         vocab = self.Vocab.from_file(lines)
-        self.assertEqual(vocab.counts_copy(), Counter({'unk': 10, 'cat': 4, 'bear': 6}))
+        self.assertEqual(vocab._counts, Counter({'unk': 10, 'cat': 4, 'bear': 6}))
         self.assertEqual(dict(vocab), {'unk': 0, 'cat': 1, 'bear': 2})
 
 

--- a/test/unit_tests/text/test_vocab.py
+++ b/test/unit_tests/text/test_vocab.py
@@ -57,7 +57,7 @@ class TestVocab(TestCase):
         lines = ['unk\t10\n', 'cat\t4\n', 'bear\t6']
         vocab = Vocab.from_file(lines)
         self.assertEqual(vocab.counts_copy(), Counter({'unk': 10, 'cat': 4, 'bear': 6}))
-        self.assertEqual(dict(vocab._word2index), {'unk': 0, 'cat': 1, 'bear': 2})
+        self.assertEqual(dict(vocab), {'unk': 0, 'cat': 1, 'bear': 2})
 
 
 class TestSenna(TestVocab):

--- a/test/unit_tests/text/test_vocab.py
+++ b/test/unit_tests/text/test_vocab.py
@@ -16,14 +16,14 @@ class TestVocab(TestCase):
         self.assertEqual(len(v), 1)
         self.assertIn(unk, v)
         self.assertEqual(v[unk], 0)
-        self.assertEqual(v.counts[unk], 0)
+        self.assertEqual(v.count(unk), 0)
 
     def test_add(self):
         v = self.Vocab('**UNK**')
         v.add('hi')
         self.assertIn('hi', v)
         self.assertEqual(len(v), 2)
-        self.assertEqual(v.counts['hi'], 1)
+        self.assertEqual(v.count('hi'), 1)
         self.assertEqual(v['hi'], 1)
 
     def test_sent2index(self):
@@ -42,21 +42,21 @@ class TestVocab(TestCase):
     def test_prune_rares(self):
         v = self.Vocab(unk='unk')
         v.update(['hi'] * 3 + ['bye'] * 5)
-        self.assertEqual({'hi': 3, 'bye': 5, 'unk': 0}, dict(v.counts))
+        self.assertEqual({'hi': 3, 'bye': 5, 'unk': 0}, dict(v.counts_copy()))
         p = v.prune_rares(cutoff=4)
-        self.assertEqual({'bye': 5, 'unk': 0}, dict(p.counts))
+        self.assertEqual({'bye': 5, 'unk': 0}, dict(p.counts_copy()))
 
     def test_sort_by_decreasing_count(self):
         v = self.Vocab(unk='unk')
         v.update('some words words for for for you you you you'.split())
         s = v.sort_by_decreasing_count()
         self.assertEqual(['unk', 'you', 'for', 'words', 'some'], list(iter(s)))
-        self.assertEqual({'unk': 0, 'you': 4, 'for': 3, 'words': 2, 'some': 1}, dict(s.counts))
+        self.assertEqual({'unk': 0, 'you': 4, 'for': 3, 'words': 2, 'some': 1}, dict(s.counts_copy()))
 
     def test_from_file(self):
         lines = ['unk\t10\n', 'cat\t4\n', 'bear\t6']
         vocab = Vocab.from_file(lines)
-        self.assertEqual(vocab.counts, Counter({'unk': 10, 'cat': 4, 'bear': 6}))
+        self.assertEqual(vocab.counts_copy(), Counter({'unk': 10, 'cat': 4, 'bear': 6}))
         self.assertEqual(dict(vocab._word2index), {'unk': 0, 'cat': 1, 'bear': 2})
 
 

--- a/test/unit_tests/text/test_vocab.py
+++ b/test/unit_tests/text/test_vocab.py
@@ -55,9 +55,26 @@ class TestVocab(TestCase):
 
     def test_from_file(self):
         lines = ['unk\t10\n', 'cat\t4\n', 'bear\t6']
-        vocab = Vocab.from_file(lines)
+        vocab = self.Vocab.from_file(lines)
         self.assertEqual(vocab.counts_copy(), Counter({'unk': 10, 'cat': 4, 'bear': 6}))
         self.assertEqual(dict(vocab), {'unk': 0, 'cat': 1, 'bear': 2})
+
+
+class TestFrozen:
+
+    def test_words2indices(self):
+        v = Vocab('unk')
+        words = ['i', 'like', 'pie']
+        v.update(words)
+        v = v.freeze()
+        assert v.words2indices(words) == [1, 2, 3]
+        assert v.words2indices(['i', 'said']) == [1, 0]
+
+    def test_indices2words(self):
+        v = Vocab(unk='unk')
+        v.update(['i', 'like', 'pie'])
+        words = v.indices2words([1, 2, 3, 0])
+        assert words == ['i', 'like', 'pie', 'unk']
 
 
 class TestSenna(TestVocab):


### PR DESCRIPTION
- removed `clear` and `clear_counts` to make Vocab less stateful
- Vocab now inherits from BaseVocab, which only has the core methods
- Vocab now extends OrderedDict, which simplified its implementation
- `index2word` and `word2index` methods now available
- `_index2word` attribute is now cached for faster lookup speed
- added FrozenVocab object, for people who don't want to accidentally modify their vocab during experiments

