### PR TITLE
Rename json

### DIFF
--- a/stanza/nlp/corenlp.py
+++ b/stanza/nlp/corenlp.py
@@ -113,18 +113,18 @@ class AnnotatedDocument(Document):
         PREVIEW_LEN = 50
         return "[Document: {}]".format(self.pb.text[:PREVIEW_LEN] + ("..." if len(self.pb.text) > PREVIEW_LEN else ""))
 
-    def to_dict(self):
+    def to_json(self):
         if self._json is None:
             raise AttributeError('No JSON representation.')
         return self._json
 
     @staticmethod
-    def from_dict(json_dict):
-        return AnnotatedDocument(AnnotatedDocument.dict_to_pb(json_dict), json_dict=json_dict)
+    def from_json(json_dict):
+        return AnnotatedDocument(AnnotatedDocument.json_to_pb(json_dict), json_dict=json_dict)
 
     @staticmethod
-    def dict_to_pb(json_dict):
-        sentences = [AnnotatedSentence.dict_to_pb(d) for d in json_dict['sentences']]
+    def json_to_pb(json_dict):
+        sentences = [AnnotatedSentence.json_to_pb(d) for d in json_dict['sentences']]
         doc = CoreNLP_pb2.Document()
         doc.sentence.extend(sentences)
         doc.text = AnnotatedDocument._reconstruct_text_from_sentence_pbs(sentences)
@@ -193,7 +193,7 @@ class AnnotatedSentence(Sentence):
             self.pb.text = AnnotatedSentence._reconstruct_text_from_token_pbs(self.pb.token)
             print(self.pb.text)
 
-    def to_dict(self):
+    def to_json(self):
         if self._json is None:
             raise AttributeError('No JSON representation.')
         return self._json
@@ -212,13 +212,13 @@ class AnnotatedSentence(Sentence):
         return "[Sentence: {}]".format(self.pb.text[:PREVIEW_LEN] + ("..." if len(self.pb.text) > PREVIEW_LEN else ""))
 
     @staticmethod
-    def from_dict(json_dict):
-        return AnnotatedSentence(AnnotatedSentence.dict_to_pb(json_dict), json_dict=json_dict)
+    def from_json(json_dict):
+        return AnnotatedSentence(AnnotatedSentence.json_to_pb(json_dict), json_dict=json_dict)
 
     @staticmethod
-    def dict_to_pb(json_dict):
+    def json_to_pb(json_dict):
         sent = CoreNLP_pb2.Sentence()
-        tokens = [AnnotatedToken.dict_to_pb(d) for d in json_dict['tokens']]
+        tokens = [AnnotatedToken.json_to_pb(d) for d in json_dict['tokens']]
         sent.token.extend(tokens)
         sent.text = AnnotatedSentence._reconstruct_text_from_token_pbs(sent.token)
         return sent
@@ -394,17 +394,17 @@ class AnnotatedToken(Token):
     def __repr__(self):
         return "[Token: {}]".format(self.pb.word)
 
-    def to_dict(self):
+    def to_json(self):
         if self._json is None:
             raise AttributeError('No JSON representation.')
         return self._json
 
     @staticmethod
-    def from_dict(json_dict):
-        return AnnotatedToken(AnnotatedToken.dict_to_pb(json_dict), json_dict=json_dict)
+    def from_json(json_dict):
+        return AnnotatedToken(AnnotatedToken.json_to_pb(json_dict), json_dict=json_dict)
 
     @staticmethod
-    def dict_to_pb(json_dict):
+    def json_to_pb(json_dict):
         tok = CoreNLP_pb2.Token()
 
         def assign_if_present(pb_key, dict_key):

--- a/stanza/nlp/corenlp.py
+++ b/stanza/nlp/corenlp.py
@@ -39,8 +39,8 @@ class CoreNLPClient(object):
         except requests.HTTPError:
             raise AnnotationException(r.text)
 
-    def annotate_dict(self, text, annotators=None):
-        """Return a dict from the CoreNLP server, containing annotations of the text.
+    def annotate_json(self, text, annotators=None):
+        """Return a JSON dict from the CoreNLP server, containing annotations of the text.
 
         :param (str) text: Text to annotate.
         :param (list[str]) annotators: a list of annotator names

--- a/test/unit_tests/ml/test_embeddings.py
+++ b/test/unit_tests/ml/test_embeddings.py
@@ -23,13 +23,13 @@ def dict_embeddings():
 
 
 def test_to_dict(embeddings, dict_embeddings):
-    d = embeddings.to_dict()
+    d = embeddings.to_json()
     assert d == dict_embeddings
 
 
 def test_from_dict(embeddings, dict_embeddings):
     emb = Embeddings.from_dict(dict_embeddings, 'unk')
-    assert emb.to_dict() == dict_embeddings
+    assert emb.to_json() == dict_embeddings
 
 
 def test_get_item(embeddings):
@@ -67,4 +67,4 @@ def test_k_nearest_approx(embeddings):
 
 def test_subset(embeddings):
     sub = embeddings.subset(['a', 'what'])
-    assert sub.to_dict() == {'a': [6, 7, 8], 'unk': [0, 1, 2], 'what': [3, 4, 5]}
+    assert sub.to_json() == {'a': [6, 7, 8], 'unk': [0, 1, 2], 'what': [3, 4, 5]}

--- a/test/unit_tests/ml/test_embeddings.py
+++ b/test/unit_tests/ml/test_embeddings.py
@@ -23,13 +23,13 @@ def dict_embeddings():
 
 
 def test_to_dict(embeddings, dict_embeddings):
-    d = embeddings.to_json()
+    d = embeddings.to_dict()
     assert d == dict_embeddings
 
 
 def test_from_dict(embeddings, dict_embeddings):
     emb = Embeddings.from_dict(dict_embeddings, 'unk')
-    assert emb.to_json() == dict_embeddings
+    assert emb.to_dict() == dict_embeddings
 
 
 def test_get_item(embeddings):
@@ -67,4 +67,4 @@ def test_k_nearest_approx(embeddings):
 
 def test_subset(embeddings):
     sub = embeddings.subset(['a', 'what'])
-    assert sub.to_json() == {'a': [6, 7, 8], 'unk': [0, 1, 2], 'what': [3, 4, 5]}
+    assert sub.to_dict() == {'a': [6, 7, 8], 'unk': [0, 1, 2], 'what': [3, 4, 5]}

--- a/test/unit_tests/nlp/test_corenlp.py
+++ b/test/unit_tests/nlp/test_corenlp.py
@@ -77,7 +77,7 @@ def json_dict():
 
 def test_token_dict_to_pb(json_dict):
   token_dict = json_dict['sentences'][0]['tokens'][0]
-  token = AnnotatedToken.dict_to_pb(token_dict)
+  token = AnnotatedToken.json_to_pb(token_dict)
   assert token.after == u' '
   assert token.before == u''
   assert token.beginChar == 0
@@ -89,13 +89,13 @@ def test_token_dict_to_pb(json_dict):
 def test_sentence_dict_to_pb(json_dict):
   orig_text = 'Really?'
   sent_dict = json_dict['sentences'][1]
-  sent = AnnotatedSentence.dict_to_pb(sent_dict)
+  sent = AnnotatedSentence.json_to_pb(sent_dict)
   assert sent.text == orig_text
   assert sent.token[1].word == u'?'
 
 
 def test_document_dict_to_pb(json_dict):
   orig_text = 'Belgian swimmers beat the United States. Really?'
-  doc = AnnotatedDocument.dict_to_pb(json_dict)
+  doc = AnnotatedDocument.json_to_pb(json_dict)
   assert doc.text == orig_text
   assert doc.sentence[1].text == 'Really?'


### PR DESCRIPTION
Renamed JSON-related methods to be more informative. E.g. `from_json` instead of `from_dict`.

I often prefer to serialize CoreNLP annotations to JSON rather than protobuf, for easier readability. I think we'll be supporting the JSON representation for some time to come, so I thought I'd make these methods more explicit.

Sorry, I hope this doesn't break too much code in downstream repos.