### PR TITLE
added should_download flag to stanfordnlp.download to force download

### DIFF
--- a/demo/pipeline_demo.py
+++ b/demo/pipeline_demo.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
         exit()
 
     # download the models
-    stanfordnlp.download(args.lang, args.models_dir, confirm_if_exists=True)
+    stanfordnlp.download(args.lang, args.models_dir, force_download=False, confirm_if_exists=False)
     # set up a pipeline
     print('---')
     print('Building pipeline...')

--- a/stanfordnlp/utils/resources.py
+++ b/stanfordnlp/utils/resources.py
@@ -61,17 +61,18 @@ def load_config(config_file_path):
 
 
 # download a ud models zip file
-def download_ud_model(lang_name, resource_dir=None, should_unzip=True, confirm_if_exists=False):
+def download_ud_model(lang_name, resource_dir=None, should_unzip=True, should_download=False, confirm_if_exists=False):
     # ask if user wants to download
     if resource_dir is not None and os.path.exists(f"{resource_dir}/{lang_name}_models"):
         if confirm_if_exists:
             print("")
             print(f"The model directory already exists at \"{resource_dir}/{lang_name}_models\". Do you want to download the models again? [y/N]")
-            should_download = input()
-            should_download = should_download.strip().lower() in ['yes', 'y']
+            if not should_download:
+                should_download = input()
+                should_download = should_download.strip().lower() in ['yes', 'y']
         else:
             should_download = False
-    else:
+    elif not should_download:
         print('Would you like to download the models for: '+lang_name+' now? (Y/n)')
         should_download = input()
         should_download = should_download.strip().lower() in ['yes', 'y', '']
@@ -127,11 +128,11 @@ def unzip_ud_model(lang_name, zip_file_src, zip_file_target):
 
 
 # main download function
-def download(download_label, resource_dir=None, confirm_if_exists=False):
+def download(download_label, resource_dir=None, should_download=False, confirm_if_exists=False):
     if download_label in conll_shorthands:
-        download_ud_model(download_label, resource_dir=resource_dir, confirm_if_exists=confirm_if_exists)
+        download_ud_model(download_label, resource_dir=resource_dir, should_download=should_download, confirm_if_exists=confirm_if_exists)
     elif download_label in default_treebanks:
         print(f'Using the default treebank "{default_treebanks[download_label]}" for language "{download_label}".')
-        download_ud_model(default_treebanks[download_label], resource_dir=resource_dir, confirm_if_exists=confirm_if_exists)
+        download_ud_model(default_treebanks[download_label], resource_dir=resource_dir, should_download=should_download, confirm_if_exists=confirm_if_exists)
     else:
         raise ValueError(f'The language or treebank "{download_label}" is not currently supported by this function. Please try again with other languages or treebanks.')

--- a/stanfordnlp/utils/resources.py
+++ b/stanfordnlp/utils/resources.py
@@ -61,18 +61,19 @@ def load_config(config_file_path):
 
 
 # download a ud models zip file
-def download_ud_model(lang_name, resource_dir=None, should_unzip=True, should_download=False, confirm_if_exists=False):
+def download_ud_model(lang_name, resource_dir=None, should_unzip=True, force_download=False, confirm_if_exists=False):
     # ask if user wants to download
+    should_download = force_download
     if resource_dir is not None and os.path.exists(f"{resource_dir}/{lang_name}_models"):
         if confirm_if_exists:
             print("")
             print(f"The model directory already exists at \"{resource_dir}/{lang_name}_models\". Do you want to download the models again? [y/N]")
-            if not should_download:
+            if not force_download:
                 should_download = input()
                 should_download = should_download.strip().lower() in ['yes', 'y']
         else:
             should_download = False
-    elif not should_download:
+    elif not force_download:
         print('Would you like to download the models for: '+lang_name+' now? (Y/n)')
         should_download = input()
         should_download = should_download.strip().lower() in ['yes', 'y', '']
@@ -128,11 +129,11 @@ def unzip_ud_model(lang_name, zip_file_src, zip_file_target):
 
 
 # main download function
-def download(download_label, resource_dir=None, should_download=False, confirm_if_exists=False):
+def download(download_label, resource_dir=None, force_download=False, confirm_if_exists=False):
     if download_label in conll_shorthands:
-        download_ud_model(download_label, resource_dir=resource_dir, should_download=should_download, confirm_if_exists=confirm_if_exists)
+        download_ud_model(download_label, resource_dir=resource_dir, force_download=force_download, confirm_if_exists=confirm_if_exists)
     elif download_label in default_treebanks:
         print(f'Using the default treebank "{default_treebanks[download_label]}" for language "{download_label}".')
-        download_ud_model(default_treebanks[download_label], resource_dir=resource_dir, should_download=should_download, confirm_if_exists=confirm_if_exists)
+        download_ud_model(default_treebanks[download_label], resource_dir=resource_dir, force_download=force_download, confirm_if_exists=confirm_if_exists)
     else:
         raise ValueError(f'The language or treebank "{download_label}" is not currently supported by this function. Please try again with other languages or treebanks.')


### PR DESCRIPTION
I have added a flag `should_download` that set to `True` will automatically download models. This is useful when installing the library from scratch and deploying to containers (like Docker, etc.). The behaviors keeps the `confirm_if_exists` method. In this way it acts as `nltk` does when used like

```python
import stanfordnlp

stanfordnlp.download('en', resource_dir='/root', should_download=True, confirm_if_exists=False)
pipeline = stanfordnlp.Pipeline(models_dir='/root',  lang='en', use_gpu=False) # This sets up a default neural pipeline in English
doc = pipeline("George Washington went to Washington")

for sentence in doc.sentences:
    print(sentence)
    sentence.print_dependencies()
    sentence.print_tokens()
```