### PR TITLE
Introduce depparse_preanalyzed boolean flag to depparse processor

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-
-# Default ignored files
-/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+
+# Default ignored files
+/workspace.xml

--- a/stanfordnlp/pipeline/core.py
+++ b/stanfordnlp/pipeline/core.py
@@ -45,8 +45,9 @@ PROCESSOR_SETTINGS = {
     'depparse': ['batch_size', 'beta2', 'char', 'char_emb_dim', 'char_hidden_dim', 'char_num_layers',
                  'char_rec_dropout', 'composite_deep_biaff_hidden_dim', 'deep_biaff_hidden_dim', 'distance', 'dropout',
                  'eval_interval', 'hidden_dim', 'linearization', 'log_step', 'lr', 'max_grad_norm', 'max_steps',
-                 'max_steps_before_stop', 'num_layers', 'optim', 'pretrain', 'rec_dropout', 'sample_train', 'seed',
-                 'shorthand', 'tag_emb_dim', 'transformed_dim', 'word_dropout', 'word_emb_dim', 'wordvec_dir']
+                 'max_steps_before_stop', 'num_layers', 'optim', 'preanalyzed', 'pretrain', 'rec_dropout',
+                 'sample_train', 'seed', 'shorthand', 'tag_emb_dim', 'transformed_dim', 'word_dropout', 'word_emb_dim',
+                 'wordvec_dir']
 }
 
 PROCESSOR_SETTINGS_LIST = \
@@ -55,7 +56,8 @@ PROCESSOR_SETTINGS_LIST = \
 BOOLEAN_PROCESSOR_SETTINGS = {
     TOKENIZE: ['pretokenized'],
     MWT: ['dict_only'],
-    LEMMA: ['dict_only', 'edit', 'ensemble_dict', 'pos', 'use_identity']
+    LEMMA: ['dict_only', 'edit', 'ensemble_dict', 'pos', 'use_identity'],
+    DEPPARSE: ['preanalyzed']
 }
 
 BOOLEAN_PROCESSOR_SETTINGS_LIST = \

--- a/stanfordnlp/pipeline/depparse_processor.py
+++ b/stanfordnlp/pipeline/depparse_processor.py
@@ -17,7 +17,18 @@ class DepparseProcessor(UDProcessor):
     # set of processor requirements for this processor
     REQUIRES_DEFAULT = set([TOKENIZE, POS])
 
+    def __init__(self, config, pipeline, use_gpu):
+        self._preanalyzed = None
+        super().__init__(config, pipeline, use_gpu)
+
+    def _set_up_requires(self):
+        if self._preanalyzed:
+            self._requires = set()
+        else:
+            self._requires = self.__class__.REQUIRES_DEFAULT
+
     def _set_up_model(self, config, use_gpu):
+        self._preanalyzed = config.get('preanalyzed')
         self._pretrain = Pretrain(config['pretrain_path'])
         self._trainer = Trainer(pretrain=self.pretrain, model_file=config['model_path'], use_cuda=use_gpu)
 

--- a/tests/test_depparse.py
+++ b/tests/test_depparse.py
@@ -1,0 +1,83 @@
+"""
+Basic tests of the depparse processor boolean flags
+"""
+import pytest
+
+import stanfordnlp
+from stanfordnlp.models.common.conll import CoNLLFile
+from stanfordnlp.pipeline.core import PipelineRequirementsException
+from tests import *
+
+# data for testing
+EN_DOC = "Barack Obama was born in Hawaii.  He was elected president in 2008.  Obama attended Harvard."
+
+EN_DOC_CONLLU_PREANALYZED = """
+1	Barack	_	PROPN	NNP	Number=Sing	0	_	_	_
+2	Obama	_	PROPN	NNP	Number=Sing	1	_	_	_
+3	was	_	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	_	_	_
+4	born	_	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	3	_	_	_
+5	in	_	ADP	IN	_	4	_	_	_
+6	Hawaii	_	PROPN	NNP	Number=Sing	5	_	_	_
+7	.	_	PUNCT	.	_	6	_	_	_
+
+1	He	_	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	0	_	_	_
+2	was	_	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	_	_	_
+3	elected	_	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	2	_	_	_
+4	president	_	PROPN	NNP	Number=Sing	3	_	_	_
+5	in	_	ADP	IN	_	4	_	_	_
+6	2008	_	NUM	CD	NumType=Card	5	_	_	_
+7	.	_	PUNCT	.	_	6	_	_	_
+
+1	Obama	_	PROPN	NNP	Number=Sing	0	_	_	_
+2	attended	_	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	_	_	_
+3	Harvard	_	PROPN	NNP	Number=Sing	2	_	_	_
+4	.	_	PUNCT	.	_	3	_	_	_
+
+
+""".lstrip()
+
+EN_DOC_DEPENDENCY_PARSES_GOLD = """
+('Barack', '4', 'nsubj:pass')
+('Obama', '1', 'flat')
+('was', '4', 'aux:pass')
+('born', '0', 'root')
+('in', '6', 'case')
+('Hawaii', '4', 'obl')
+('.', '4', 'punct')
+
+('He', '3', 'nsubj:pass')
+('was', '3', 'aux:pass')
+('elected', '0', 'root')
+('president', '3', 'xcomp')
+('in', '6', 'case')
+('2008', '3', 'obl')
+('.', '3', 'punct')
+
+('Obama', '2', 'nsubj')
+('attended', '0', 'root')
+('Harvard', '2', 'obj')
+('.', '2', 'punct')
+""".strip()
+
+
+def test_depparse():
+    nlp = stanfordnlp.Pipeline(models_dir=TEST_MODELS_DIR, lang='en')
+    doc = nlp(EN_DOC)
+    assert EN_DOC_DEPENDENCY_PARSES_GOLD == '\n\n'.join([sent.dependencies_string() for sent in doc.sentences])
+
+
+def test_depparse_with_preanalyzed_doc():
+    nlp = stanfordnlp.Pipeline(**{'processors': 'depparse', 'models_dir': '.', 'lang': 'en',
+                                  'depparse_preanalyzed': True})
+
+    doc = stanfordnlp.Document('')
+    doc.conll_file = CoNLLFile(input_str=EN_DOC_CONLLU_PREANALYZED)
+
+    processed_doc = nlp(doc)
+    assert EN_DOC_DEPENDENCY_PARSES_GOLD == '\n\n'.join(
+        [sent.dependencies_string() for sent in processed_doc.sentences])
+
+
+def test_raises_requirements_exception_if_preanalyzed_not_passed():
+    with pytest.raises(PipelineRequirementsException):
+        stanfordnlp.Pipeline(**{'processors': 'depparse', 'models_dir': '.', 'lang': 'en'})

--- a/tests/test_english_pipeline.py
+++ b/tests/test_english_pipeline.py
@@ -23,7 +23,7 @@ EN_DOC_TOKENS_GOLD = """
 <Token index=1;words=[<Word index=1;text=He;lemma=he;upos=PRON;xpos=PRP;feats=Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs;governor=3;dependency_relation=nsubj:pass>]>
 <Token index=2;words=[<Word index=2;text=was;lemma=be;upos=AUX;xpos=VBD;feats=Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin;governor=3;dependency_relation=aux:pass>]>
 <Token index=3;words=[<Word index=3;text=elected;lemma=elect;upos=VERB;xpos=VBN;feats=Tense=Past|VerbForm=Part|Voice=Pass;governor=0;dependency_relation=root>]>
-<Token index=4;words=[<Word index=4;text=president;lemma=president;upos=NOUN;xpos=NN;feats=Number=Sing;governor=3;dependency_relation=obj>]>
+<Token index=4;words=[<Word index=4;text=president;lemma=president;upos=PROPN;xpos=NNP;feats=Number=Sing;governor=3;dependency_relation=xcomp>]>
 <Token index=5;words=[<Word index=5;text=in;lemma=in;upos=ADP;xpos=IN;feats=_;governor=6;dependency_relation=case>]>
 <Token index=6;words=[<Word index=6;text=2008;lemma=2008;upos=NUM;xpos=CD;feats=NumType=Card;governor=3;dependency_relation=obl>]>
 <Token index=7;words=[<Word index=7;text=.;lemma=.;upos=PUNCT;xpos=.;feats=_;governor=3;dependency_relation=punct>]>
@@ -46,7 +46,7 @@ EN_DOC_WORDS_GOLD = """
 <Word index=1;text=He;lemma=he;upos=PRON;xpos=PRP;feats=Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs;governor=3;dependency_relation=nsubj:pass>
 <Word index=2;text=was;lemma=be;upos=AUX;xpos=VBD;feats=Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin;governor=3;dependency_relation=aux:pass>
 <Word index=3;text=elected;lemma=elect;upos=VERB;xpos=VBN;feats=Tense=Past|VerbForm=Part|Voice=Pass;governor=0;dependency_relation=root>
-<Word index=4;text=president;lemma=president;upos=NOUN;xpos=NN;feats=Number=Sing;governor=3;dependency_relation=obj>
+<Word index=4;text=president;lemma=president;upos=PROPN;xpos=NNP;feats=Number=Sing;governor=3;dependency_relation=xcomp>
 <Word index=5;text=in;lemma=in;upos=ADP;xpos=IN;feats=_;governor=6;dependency_relation=case>
 <Word index=6;text=2008;lemma=2008;upos=NUM;xpos=CD;feats=NumType=Card;governor=3;dependency_relation=obl>
 <Word index=7;text=.;lemma=.;upos=PUNCT;xpos=.;feats=_;governor=3;dependency_relation=punct>
@@ -69,7 +69,7 @@ EN_DOC_DEPENDENCY_PARSES_GOLD = """
 ('He', '3', 'nsubj:pass')
 ('was', '3', 'aux:pass')
 ('elected', '0', 'root')
-('president', '3', 'obj')
+('president', '3', 'xcomp')
 ('in', '6', 'case')
 ('2008', '3', 'obl')
 ('.', '3', 'punct')
@@ -92,7 +92,7 @@ EN_DOC_CONLLU_GOLD = """
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj:pass	_	_
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	_
 3	elected	elect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	_
-4	president	president	NOUN	NN	Number=Sing	3	obj	_	_
+4	president	president	PROPN	NNP	Number=Sing	3	xcomp	_	_
 5	in	in	ADP	IN	_	6	case	_	_
 6	2008	2008	NUM	CD	NumType=Card	3	obl	_	_
 7	.	.	PUNCT	.	_	3	punct	_	_


### PR DESCRIPTION
This PR is posted as a response to #141 - since @yuhaozhang stated that this could be a useful feature to have in the future, I thought about adding it myself and posting a PR. 

1. The changes introduce a boolean flag in `depparse` processor allowing for processing documents which were already preanalyzed. This way a user can create a stanfordnlp Pipeline with `depparse` only and omit its requirements (namely `tokenize` and `pos`).  The behavior was tested and the tests can be found in `tests/test_depparse.py`.

2. Additionally, I've fixed the string constants in `tests/test_english_pipeline.py`, since the output of the `en_ewt_models` differed a bit (I've seen that prior to introducing my changes). 

Let me know what you think. I'll be happy to adjust the changes to your feedback. 
Thanks!

