### PR TITLE
Introduce depparse_pretagged boolean flag to depparse processor

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-
-# Default ignored files
-/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+
+# Default ignored files
+/workspace.xml

--- a/stanfordnlp/pipeline/core.py
+++ b/stanfordnlp/pipeline/core.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_PROCESSORS_LIST = f'{TOKENIZE},{MWT},{POS},{LEMMA},{DEPPARSE}'
 
 NAME_TO_PROCESSOR_CLASS = {TOKENIZE: TokenizeProcessor, MWT: MWTProcessor, POS: POSProcessor,
-        LEMMA: LemmaProcessor, DEPPARSE: DepparseProcessor, NER: NERProcessor}
+                           LEMMA: LemmaProcessor, DEPPARSE: DepparseProcessor, NER: NERProcessor}
 
 PIPELINE_SETTINGS = ['lang', 'shorthand', 'mode']
 
@@ -74,6 +74,7 @@ class PipelineRequirementsException(Exception):
 
     def __str__(self):
         return self.message
+
 
 class Pipeline:
 
@@ -159,6 +160,7 @@ class Pipeline:
         return doc
 
     def __call__(self, doc):
-        assert any([isinstance(doc, str), isinstance(doc, list)]), 'input should be either str or list'
+        assert any([isinstance(doc, str), isinstance(doc, list),
+                    isinstance(doc, Document)]), 'input should be either str, list or Document'
         doc = self.process(doc)
         return doc

--- a/stanfordnlp/pipeline/core.py
+++ b/stanfordnlp/pipeline/core.py
@@ -35,7 +35,7 @@ PROCESSOR_SETTINGS = {
     MWT: ['batch_size', 'dict_only', 'ensemble_dict'],
     POS: ['batch_size'],
     LEMMA: ['batch_size', 'beam_size', 'dict_only', 'ensemble_dict', 'use_identity'],
-    DEPPARSE: ['batch_size', 'preanalyzed'],
+    DEPPARSE: ['batch_size', 'pretagged'],
     NER: ['batch_size']
 }
 
@@ -46,7 +46,7 @@ BOOLEAN_PROCESSOR_SETTINGS = {
     TOKENIZE: ['pretokenized'],
     MWT: ['dict_only', 'ensemble_dict'],
     LEMMA: ['dict_only', 'edit', 'ensemble_dict', 'use_identity'],
-    DEPPARSE: ['preanalyzed']
+    DEPPARSE: ['pretagged']
 }
 
 BOOLEAN_PROCESSOR_SETTINGS_LIST = \

--- a/stanfordnlp/pipeline/core.py
+++ b/stanfordnlp/pipeline/core.py
@@ -35,7 +35,7 @@ PROCESSOR_SETTINGS = {
     MWT: ['batch_size', 'dict_only', 'ensemble_dict'],
     POS: ['batch_size'],
     LEMMA: ['batch_size', 'beam_size', 'dict_only', 'ensemble_dict', 'use_identity'],
-    DEPPARSE: ['batch_size'],
+    DEPPARSE: ['batch_size', 'preanalyzed'],
     NER: ['batch_size']
 }
 
@@ -45,7 +45,8 @@ PROCESSOR_SETTINGS_LIST = \
 BOOLEAN_PROCESSOR_SETTINGS = {
     TOKENIZE: ['pretokenized'],
     MWT: ['dict_only', 'ensemble_dict'],
-    LEMMA: ['dict_only', 'edit', 'ensemble_dict', 'use_identity']
+    LEMMA: ['dict_only', 'edit', 'ensemble_dict', 'use_identity'],
+    DEPPARSE: ['preanalyzed']
 }
 
 BOOLEAN_PROCESSOR_SETTINGS_LIST = \

--- a/stanfordnlp/pipeline/depparse_processor.py
+++ b/stanfordnlp/pipeline/depparse_processor.py
@@ -18,7 +18,18 @@ class DepparseProcessor(UDProcessor):
     # set of processor requirements for this processor
     REQUIRES_DEFAULT = set([TOKENIZE, POS])
 
+    def __init__(self, config, pipeline, use_gpu):
+        self._preanalyzed = None
+        super().__init__(config, pipeline, use_gpu)
+
+    def _set_up_requires(self):
+        if self._preanalyzed:
+            self._requires = set()
+        else:
+            self._requires = self.__class__.REQUIRES_DEFAULT
+
     def _set_up_model(self, config, use_gpu):
+        self._preanalyzed = config.get('preanalyzed')
         self._pretrain = Pretrain(config['pretrain_path'])
         self._trainer = Trainer(pretrain=self.pretrain, model_file=config['model_path'], use_cuda=use_gpu)
 

--- a/stanfordnlp/pipeline/depparse_processor.py
+++ b/stanfordnlp/pipeline/depparse_processor.py
@@ -19,17 +19,17 @@ class DepparseProcessor(UDProcessor):
     REQUIRES_DEFAULT = set([TOKENIZE, POS])
 
     def __init__(self, config, pipeline, use_gpu):
-        self._preanalyzed = None
+        self._pretagged = None
         super().__init__(config, pipeline, use_gpu)
 
     def _set_up_requires(self):
-        if self._preanalyzed:
+        if self._pretagged:
             self._requires = set()
         else:
             self._requires = self.__class__.REQUIRES_DEFAULT
 
     def _set_up_model(self, config, use_gpu):
-        self._preanalyzed = config.get('preanalyzed')
+        self._pretagged = config.get('pretagged')
         self._pretrain = Pretrain(config['pretrain_path'])
         self._trainer = Trainer(pretrain=self.pretrain, model_file=config['model_path'], use_cuda=use_gpu)
 

--- a/tests/test_depparse.py
+++ b/tests/test_depparse.py
@@ -66,9 +66,9 @@ def test_depparse():
     assert EN_DOC_DEPENDENCY_PARSES_GOLD == '\n\n'.join([sent.dependencies_string() for sent in doc.sentences])
 
 
-def test_depparse_with_preanalyzed_doc():
+def test_depparse_with_pretagged_doc():
     nlp = stanfordnlp.Pipeline(**{'processors': 'depparse', 'models_dir': '.', 'lang': 'en',
-                                  'depparse_preanalyzed': True})
+                                  'depparse_pretagged': True})
 
     doc = stanfordnlp.Document(CoNLL.conll2dict(input_str=EN_DOC_CONLLU_PREANALYZED))
     processed_doc = nlp(doc)
@@ -77,6 +77,6 @@ def test_depparse_with_preanalyzed_doc():
         [sent.dependencies_string() for sent in processed_doc.sentences])
 
 
-def test_raises_requirements_exception_if_preanalyzed_not_passed():
+def test_raises_requirements_exception_if_pretagged_not_passed():
     with pytest.raises(PipelineRequirementsException):
         stanfordnlp.Pipeline(**{'processors': 'depparse', 'models_dir': '.', 'lang': 'en'})

--- a/tests/test_depparse.py
+++ b/tests/test_depparse.py
@@ -11,7 +11,7 @@ from tests import *
 # data for testing
 EN_DOC = "Barack Obama was born in Hawaii.  He was elected president in 2008.  Obama attended Harvard."
 
-EN_DOC_CONLLU_PREANALYZED = """
+EN_DOC_CONLLU_PRETAGGED = """
 1	Barack	_	PROPN	NNP	Number=Sing	0	_	_	_
 2	Obama	_	PROPN	NNP	Number=Sing	1	_	_	_
 3	was	_	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	_	_	_
@@ -70,7 +70,7 @@ def test_depparse_with_pretagged_doc():
     nlp = stanfordnlp.Pipeline(**{'processors': 'depparse', 'models_dir': '.', 'lang': 'en',
                                   'depparse_pretagged': True})
 
-    doc = stanfordnlp.Document(CoNLL.conll2dict(input_str=EN_DOC_CONLLU_PREANALYZED))
+    doc = stanfordnlp.Document(CoNLL.conll2dict(input_str=EN_DOC_CONLLU_PRETAGGED))
     processed_doc = nlp(doc)
 
     assert EN_DOC_DEPENDENCY_PARSES_GOLD == '\n\n'.join(

--- a/tests/test_depparse.py
+++ b/tests/test_depparse.py
@@ -4,8 +4,8 @@ Basic tests of the depparse processor boolean flags
 import pytest
 
 import stanfordnlp
-from stanfordnlp.models.common.conll import CoNLLFile
 from stanfordnlp.pipeline.core import PipelineRequirementsException
+from stanfordnlp.utils.conll import CoNLL
 from tests import *
 
 # data for testing
@@ -70,10 +70,9 @@ def test_depparse_with_preanalyzed_doc():
     nlp = stanfordnlp.Pipeline(**{'processors': 'depparse', 'models_dir': '.', 'lang': 'en',
                                   'depparse_preanalyzed': True})
 
-    doc = stanfordnlp.Document('')
-    doc.conll_file = CoNLLFile(input_str=EN_DOC_CONLLU_PREANALYZED)
+    doc = stanfordnlp.Document(CoNLL.conll2dict(input_str=EN_DOC_CONLLU_PREANALYZED))
+    processed_doc = nlp.process(doc)
 
-    processed_doc = nlp(doc)
     assert EN_DOC_DEPENDENCY_PARSES_GOLD == '\n\n'.join(
         [sent.dependencies_string() for sent in processed_doc.sentences])
 

--- a/tests/test_depparse.py
+++ b/tests/test_depparse.py
@@ -71,7 +71,7 @@ def test_depparse_with_preanalyzed_doc():
                                   'depparse_preanalyzed': True})
 
     doc = stanfordnlp.Document(CoNLL.conll2dict(input_str=EN_DOC_CONLLU_PREANALYZED))
-    processed_doc = nlp.process(doc)
+    processed_doc = nlp(doc)
 
     assert EN_DOC_DEPENDENCY_PARSES_GOLD == '\n\n'.join(
         [sent.dependencies_string() for sent in processed_doc.sentences])

--- a/tests/test_depparse.py
+++ b/tests/test_depparse.py
@@ -1,0 +1,83 @@
+"""
+Basic tests of the depparse processor boolean flags
+"""
+import pytest
+
+import stanfordnlp
+from stanfordnlp.models.common.conll import CoNLLFile
+from stanfordnlp.pipeline.core import PipelineRequirementsException
+from tests import *
+
+# data for testing
+EN_DOC = "Barack Obama was born in Hawaii.  He was elected president in 2008.  Obama attended Harvard."
+
+EN_DOC_CONLLU_PREANALYZED = """
+1	Barack	_	PROPN	NNP	Number=Sing	0	_	_	_
+2	Obama	_	PROPN	NNP	Number=Sing	1	_	_	_
+3	was	_	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	_	_	_
+4	born	_	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	3	_	_	_
+5	in	_	ADP	IN	_	4	_	_	_
+6	Hawaii	_	PROPN	NNP	Number=Sing	5	_	_	_
+7	.	_	PUNCT	.	_	6	_	_	_
+
+1	He	_	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	0	_	_	_
+2	was	_	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	_	_	_
+3	elected	_	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	2	_	_	_
+4	president	_	PROPN	NNP	Number=Sing	3	_	_	_
+5	in	_	ADP	IN	_	4	_	_	_
+6	2008	_	NUM	CD	NumType=Card	5	_	_	_
+7	.	_	PUNCT	.	_	6	_	_	_
+
+1	Obama	_	PROPN	NNP	Number=Sing	0	_	_	_
+2	attended	_	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	_	_	_
+3	Harvard	_	PROPN	NNP	Number=Sing	2	_	_	_
+4	.	_	PUNCT	.	_	3	_	_	_
+
+
+""".lstrip()
+
+EN_DOC_DEPENDENCY_PARSES_GOLD = """
+('Barack', '4', 'nsubj:pass')
+('Obama', '1', 'flat')
+('was', '4', 'aux:pass')
+('born', '0', 'root')
+('in', '6', 'case')
+('Hawaii', '4', 'obl')
+('.', '4', 'punct')
+
+('He', '3', 'nsubj:pass')
+('was', '3', 'aux:pass')
+('elected', '0', 'root')
+('president', '3', 'xcomp')
+('in', '6', 'case')
+('2008', '3', 'obl')
+('.', '3', 'punct')
+
+('Obama', '2', 'nsubj')
+('attended', '0', 'root')
+('Harvard', '2', 'obj')
+('.', '2', 'punct')
+""".strip()
+
+
+def test_depparse():
+    nlp = stanfordnlp.Pipeline(models_dir=TEST_MODELS_DIR, lang='en')
+    doc = nlp(EN_DOC)
+    assert EN_DOC_DEPENDENCY_PARSES_GOLD == '\n\n'.join([sent.dependencies_string() for sent in doc.sentences])
+
+
+def test_depparse_with_preanalyzed_doc():
+    nlp = stanfordnlp.Pipeline(**{'processors': 'depparse', 'models_dir': '.', 'lang': 'en',
+                                  'depparse_preanalyzed': True})
+
+    doc = stanfordnlp.Document('')
+    doc.conll_file = CoNLLFile(input_str=EN_DOC_CONLLU_PREANALYZED)
+
+    processed_doc = nlp(doc)
+    assert EN_DOC_DEPENDENCY_PARSES_GOLD == '\n\n'.join(
+        [sent.dependencies_string() for sent in processed_doc.sentences])
+
+
+def test_raises_requirements_exception_if_preanalyzed_not_passed():
+    with pytest.raises(PipelineRequirementsException):
+        stanfordnlp.Pipeline(**{'processors': 'depparse', 'models_dir': '.', 'lang': 'en'})


### PR DESCRIPTION
Note: @qipeng, as suggested, I'm reposting #142 (with a few adjustments), this time against the current `dev` branch

This PR is posted as a response to #141 - since @yuhaozhang stated that this could be a useful feature to have in the future, I thought about adding it myself and posting a PR. 

The changes introduce a boolean flag in `depparse` processor allowing for processing documents which were already preanalyzed. This way a user can create a stanfordnlp Pipeline with `depparse` only and omit its requirements (namely `tokenize` and `pos`).  
```python
nlp = stanfordnlp.Pipeline(processors='depparse', lang='en', depparse_preanalyzed=True)
```
The behavior was tested and the tests can be found in `tests/test_depparse.py`. 

I modified the `Pipeline.__call__` dunder method in order to keep a uniform interface for all pipeline configurations. The modified method accepts the `Document` as the pipeline's input along with the previous `str` and `list` types. However, I'm thinking maybe it should be backed with another kind of flag (e.g. `accept_preprocessed_data`). Alternatively, I could leave the dunder method as it was and make the user call `Pipeline.process(<Document object>)` directly. 

Let me know what you think. I'll be happy to adjust the changes to your feedback. 
Thanks!

