### PR TITLE
remove deprecation warning about use of uint8 in mask, by using bool

### DIFF
--- a/stanfordnlp/models/depparse/model.py
+++ b/stanfordnlp/models/depparse/model.py
@@ -153,7 +153,7 @@ class Parser(nn.Module):
             dist_kld = -torch.log((dist_target.float() - dist_pred)**2/2 + 1)
             unlabeled_scores += dist_kld.detach()
 
-        diag = torch.eye(head.size(-1)+1, dtype=torch.uint8, device=head.device).unsqueeze(0)
+        diag = torch.eye(head.size(-1)+1, dtype=torch.bool, device=head.device).unsqueeze(0)
         unlabeled_scores.masked_fill_(diag, -float('inf'))
 
         preds = []


### PR DESCRIPTION
There's an annoying warning whenever the dependency parser runs, about using an unsigned byte type for a mask.  Replacing this with a `torch.bool` seems to fix the problem.