### PR TITLE
Use contextmanager to immediately close opened files

### DIFF
--- a/stanza/models/charlm.py
+++ b/stanza/models/charlm.py
@@ -57,9 +57,9 @@ def build_vocab(path, cutoff=0):
         counter = Counter()
         filenames = sorted(os.listdir(path))
         for filename in filenames:
-            lines = open(path + '/' + filename).readlines()
-            for line in lines:
-                counter.update(list(line))
+            with open(path + '/' + filename, encoding='utf-8') as fh:
+                for line in fh:
+                    counter.update(list(line))
         # remove infrequent characters from vocab
         for k in list(counter.keys()):
             if counter[k] < cutoff:
@@ -68,13 +68,15 @@ def build_vocab(path, cutoff=0):
         data = [sorted([x[0] for x in counter.most_common()])]
         vocab = CharVocab(data) # skip cutoff argument because this has been dealt with
     else:
-        lines = open(path).readlines() # reserve '\n'
+        with open(path, encoding='utf-8') as fh:
+            lines = fh.readlines() # reserve '\n'
         data = [list(line) for line in lines]
         vocab = CharVocab(data, cutoff=cutoff)
     return vocab
 
 def load_file(path, vocab, direction):
-    lines = open(path).readlines() # reserve '\n'
+    with open(path, encoding='utf-8') as fh:
+        lines = fh.readlines()  # reserve '\n'
     data = list(''.join(lines))
     idx = vocab['char'].map(data)
     if direction == 'backward': idx = idx[::-1]

--- a/stanza/models/ner_tagger.py
+++ b/stanza/models/ner_tagger.py
@@ -128,10 +128,12 @@ def train(args):
 
     # load data
     logger.info("Loading data with batch size {}...".format(args['batch_size']))
-    train_doc = Document(json.load(open(args['train_file'])))
+    with open(args['train_file'], encoding='utf-8') as fh:
+        train_doc = Document(json.load(fh))
     train_batch = DataLoader(train_doc, args['batch_size'], args, pretrain, evaluation=False)
     vocab = train_batch.vocab
-    dev_doc = Document(json.load(open(args['eval_file'])))
+    with open(args['eval_file'], encoding='utf-8') as fh:
+        dev_doc = Document(json.load(fh))
     dev_batch = DataLoader(dev_doc, args['batch_size'], args, pretrain, vocab=vocab, evaluation=True)
     dev_gold_tags = dev_batch.tags
 
@@ -232,7 +234,8 @@ def evaluate(args):
 
     # load data
     logger.info("Loading data with batch size {}...".format(args['batch_size']))
-    doc = Document(json.load(open(args['eval_file'])))
+    with open(args['eval_file'], encoding='utf-8') as fh:
+        doc = Document(json.load(fh))
     batch = DataLoader(doc, args['batch_size'], loaded_args, vocab=vocab, evaluation=True)
     
     logger.info("Start evaluation...")

--- a/stanza/utils/conll18_ud_eval.py
+++ b/stanza/utils/conll18_ud_eval.py
@@ -278,6 +278,8 @@ def load_conllu(file):
     if sentence_start is not None:
         raise UDError("The CoNLL-U file does not end with empty line")
 
+    file.close()
+
     return ud
 
 # Evaluate the gold and system treebanks (loaded using load_conllu).

--- a/stanza/utils/prepare_resources.py
+++ b/stanza/utils/prepare_resources.py
@@ -206,7 +206,8 @@ def copy_file(src, dst):
 
 
 def get_md5(path):
-    data = open(path, 'rb').read()
+    with open(path, 'rb') as fh:
+        data = fh.read()
     return hashlib.md5(data).hexdigest()
 
 
@@ -252,11 +253,14 @@ def process_dirs(args):
                 resources[lang][processor][package] = {'md5': md5, 'dependencies': dependencies}
             else:
                 resources[lang][processor][package] = {'md5': md5}
-    json.dump(resources, open(os.path.join(args.output_dir, 'resources.json'), 'w'), indent=2)
+
+    with open(os.path.join(args.output_dir, 'resources.json'), 'w', encoding='utf-8') as fh:
+        json.dump(resources, fh, indent=2)
 
 
 def process_defaults(args):
-    resources = json.load(open(os.path.join(args.output_dir, 'resources.json')))
+    with open(os.path.join(args.output_dir, 'resources.json'), encoding='utf-8') as fh:
+        resources = json.load(fh)
     for lang in resources:
         if lang not in default_treebanks: 
             print(lang + ' not in default treebanks!!!')
@@ -291,11 +295,13 @@ def process_defaults(args):
         resources[lang]['default_dependencies'] = default_dependencies
         resources[lang]['default_md5'] = default_md5
 
-    json.dump(resources, open(os.path.join(args.output_dir, 'resources.json'), 'w'), indent=2)
+    with open(os.path.join(args.output_dir, 'resources.json'), 'w', encoding='utf-8') as fh:
+        json.dump(resources, fh, indent=2)
 
 
 def process_lcode(args):
-    resources = json.load(open(os.path.join(args.output_dir, 'resources.json')))
+    with open(os.path.join(args.output_dir, 'resources.json'), encoding='utf-8') as fh:
+        resources = json.load(fh)
     resources_new = {}
     for lang in resources:
         if lang not in lcode2lang:
@@ -305,15 +311,19 @@ def process_lcode(args):
         resources[lang]['lang_name'] = lang_name
         resources_new[lang.lower()] = resources[lang.lower()]
         resources_new[lang_name.lower()] = {'alias': lang.lower()}
-    json.dump(resources_new, open(os.path.join(args.output_dir, 'resources.json'), 'w'), indent=2)
 
+    with open(os.path.join(args.output_dir, 'resources.json'), 'w', encoding='utf-8') as fh:
+        json.dump(resources, fh, indent=2)
 
 def process_misc(args):
-    resources = json.load(open(os.path.join(args.output_dir, 'resources.json')))
+    with open(os.path.join(args.output_dir, 'resources.json'), encoding='utf-8') as fh:
+        resources = json.load(fh)
     resources['no'] = {'alias': 'nb'}
     resources['zh'] = {'alias': 'zh-hans'}
     resources['url'] = 'http://nlp.stanford.edu/software/stanza'
-    json.dump(resources, open(os.path.join(args.output_dir, 'resources.json'), 'w'), indent=2)
+
+    with open(os.path.join(args.output_dir, 'resources.json'), 'w', encoding='utf-8') as fh:
+        json.dump(resources, fh, indent=2)
 
 
 def main():

--- a/stanza/utils/prepare_tokenizer_data.py
+++ b/stanza/utils/prepare_tokenizer_data.py
@@ -13,7 +13,7 @@ parser.add_argument('-m', '--mwt_output', default=None, type=str, help="Output f
 
 args = parser.parse_args()
 
-with open(args.plaintext_file, 'r') as f:
+with open(args.plaintext_file) as f:
     text = ''.join(f.readlines())
 textlen = len(text)
 

--- a/stanza/utils/resources.py
+++ b/stanza/utils/resources.py
@@ -50,7 +50,8 @@ def ensure_dir(dir):
     Path(dir).mkdir(parents=True, exist_ok=True)
 
 def get_md5(path):
-    data = open(path, 'rb').read()
+    with open(path, 'rb') as fh:
+        data = fh.read()
     return hashlib.md5(data).hexdigest()
 
 def unzip(dir, filename):
@@ -221,7 +222,8 @@ def download(lang='en', dir=DEFAULT_MODEL_DIR, package='default', processors={},
     # Download resources.json to obtain latest packages.
     logger.debug('Downloading resource file...')
     request_file(f'{DEFAULT_RESOURCES_URL}/resources_{__resources_version__}.json', os.path.join(dir, 'resources.json'))
-    resources = json.load(open(os.path.join(dir, 'resources.json')))
+    with open(os.path.join(dir, 'resources.json'), encoding='utf-8') as fh:
+        resources = json.load(fh)
     if lang not in resources:
         raise Exception(f'Unsupported language: {lang}.')
     if 'alias' in resources[lang]:

--- a/tests/test_server_request.py
+++ b/tests/test_server_request.py
@@ -150,8 +150,8 @@ advmod(tôt-15, plus-14)
 advmod(jours-13, tôt-15)
 punct(fait-4, .-16)
 """
-
-FRENCH_JSON_GOLD = json.loads(open(f'{TEST_WORKING_DIR}/out/example_french.json').read())
+with open(f'{TEST_WORKING_DIR}/out/example_french.json', encoding='utf-8') as fh:
+    FRENCH_JSON_GOLD = json.load(fh)
 
 ES_DOC = 'Andrés Manuel López Obrador es el presidente de México.'
 


### PR DESCRIPTION
Currently, it seems that there is a lot of older code mixed with new code. There are some design inconsistencies. One thing that is quite important, though, is the closing of file handles. 

I first made this PR because I am running into JSON decoding errors when using multiple processes and I thought this would fix that (related to locked files), but that is not the case. I'll make a separate issue.