### PR TITLE
Remove global logger configuration

### DIFF
--- a/stanza/__init__.py
+++ b/stanza/__init__.py
@@ -2,26 +2,3 @@ from stanza.pipeline.core import Pipeline
 from stanza.models.common.doc import Document
 from stanza.utils.resources import download
 from stanza._version import __version__, __resources_version__
-
-import logging.config
-logging.config.dictConfig(
-    {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "standard": {
-                "format": "%(asctime)s %(levelname)s: %(message)s",
-                'datefmt': '%Y-%m-%d %H:%M:%S'
-                }
-            },
-        "handlers": {
-            "console": {
-                "class": "logging.StreamHandler",
-                "formatter": "standard",
-            }
-        },
-        "loggers": {
-            "": {"handlers": ["console"]}
-        },
-    }
-)


### PR DESCRIPTION
## Desciption
Removes a global logger configuration by the stanza library, because a library setting global logging configuration is unexpected.

## Fixes Issues
Fixes #278, issue originally started by commit https://github.com/stanfordnlp/stanza/commit/b6079be3d884449acee44c2a54b2afdf03cd8b11

## Known breaking changes/behaviors
If someone is relying on stanza (the library) setting a global logger, that will break. No user of this library should be doing that, but there are some CLI applications in the repo which might expect that. 