### PR TITLE
Remove sys.exit(1) calls in model loading in favor of re-raise

### DIFF
--- a/stanza/models/depparse/trainer.py
+++ b/stanza/models/depparse/trainer.py
@@ -107,7 +107,7 @@ class Trainer(BaseTrainer):
             checkpoint = torch.load(filename, lambda storage, loc: storage)
         except BaseException:
             logger.exception("Cannot load model from {}".format(filename))
-            sys.exit(1)
+            raise
         self.args = checkpoint['config']
         self.vocab = MultiVocab.load_state_dict(checkpoint['vocab'])
         # load model

--- a/stanza/models/lemma/trainer.py
+++ b/stanza/models/lemma/trainer.py
@@ -201,7 +201,7 @@ class Trainer(object):
             checkpoint = torch.load(filename, lambda storage, loc: storage)
         except BaseException:
             logger.exception("Cannot load model from {}".format(filename))
-            sys.exit(1)
+            raise
         self.args = checkpoint['config']
         self.word_dict, self.composite_dict = checkpoint['dicts']
         if not self.args['dict_only']:

--- a/stanza/models/mwt/trainer.py
+++ b/stanza/models/mwt/trainer.py
@@ -141,7 +141,7 @@ class Trainer(object):
             checkpoint = torch.load(filename, lambda storage, loc: storage)
         except BaseException:
             logger.exception("Cannot load model from {}".format(filename))
-            sys.exit(1)
+            raise
         self.args = checkpoint['config']
         self.expansion_dict = checkpoint['dict']
         if not self.args['dict_only']:

--- a/stanza/models/ner/trainer.py
+++ b/stanza/models/ner/trainer.py
@@ -116,7 +116,7 @@ class Trainer(BaseTrainer):
             checkpoint = torch.load(filename, lambda storage, loc: storage)
         except BaseException:
             logger.exception("Cannot load model from {}".format(filename))
-            sys.exit(1)
+            raise
         self.args = checkpoint['config']
         if args: self.args.update(args)
         self.vocab = MultiVocab.load_state_dict(checkpoint['vocab'])

--- a/stanza/models/pos/trainer.py
+++ b/stanza/models/pos/trainer.py
@@ -109,7 +109,7 @@ class Trainer(BaseTrainer):
             checkpoint = torch.load(filename, lambda storage, loc: storage)
         except BaseException:
             logger.exception("Cannot load model from {}".format(filename))
-            sys.exit(1)
+            raise
         self.args = checkpoint['config']
         self.vocab = MultiVocab.load_state_dict(checkpoint['vocab'])
         # load model

--- a/stanza/models/tokenize/trainer.py
+++ b/stanza/models/tokenize/trainer.py
@@ -85,7 +85,7 @@ class Trainer(BaseTrainer):
             checkpoint = torch.load(filename, lambda storage, loc: storage)
         except BaseException:
             logger.exception("Cannot load model from {}".format(filename))
-            sys.exit(1)
+            raise
         self.args = checkpoint['config']
         self.model = Tokenizer(self.args, self.args['vocab_size'], self.args['emb_dim'], self.args['hidden_dim'], dropout=self.args['dropout'])
         self.model.load_state_dict(checkpoint['model'])


### PR DESCRIPTION
## Desciption
This removes the sys.exit(1) calls from model loading, and instead re-raises the exception (so it could be caught). This burned me on a recent project with an unexpected exit

## Fixes Issues
No issue currently filed

## Unit test coverage
Not covered explicitly

## Known breaking changes/behaviors
Since the uncaught exception will likely lead to an exit, it's unlikely to change anything.
