### PR TITLE
Use decorators for customized processors and processor variants

### DIFF
--- a/stanza/pipeline/core.py
+++ b/stanza/pipeline/core.py
@@ -14,6 +14,7 @@ from distutils.util import strtobool
 from stanza.pipeline._constants import *
 from stanza.models.common.doc import Document
 from stanza.pipeline.processor import Processor, ProcessorRequirementsException
+from stanza.pipeline.registry import NAME_TO_PROCESSOR_CLASS, PIPELINE_NAMES
 from stanza.pipeline.tokenize_processor import TokenizeProcessor
 from stanza.pipeline.mwt_processor import MWTProcessor
 from stanza.pipeline.pos_processor import POSProcessor
@@ -21,15 +22,12 @@ from stanza.pipeline.lemma_processor import LemmaProcessor
 from stanza.pipeline.depparse_processor import DepparseProcessor
 from stanza.pipeline.sentiment_processor import SentimentProcessor
 from stanza.pipeline.ner_processor import NERProcessor
-from stanza.utils.resources import DEFAULT_MODEL_DIR, PIPELINE_NAMES, \
+from stanza.utils.resources import DEFAULT_MODEL_DIR, \
     maintain_processor_list, add_dependencies, build_default_config, set_logging_level, process_pipeline_parameters, sort_processors
 from stanza.utils.helper_func import make_table
 
 logger = logging.getLogger('stanza')
 
-NAME_TO_PROCESSOR_CLASS = {TOKENIZE: TokenizeProcessor, MWT: MWTProcessor, POS: POSProcessor,
-                           LEMMA: LemmaProcessor, DEPPARSE: DepparseProcessor, NER: NERProcessor,
-                           SENTIMENT: SentimentProcessor}
 
 class PipelineRequirementsException(Exception):
     """
@@ -55,10 +53,10 @@ class PipelineRequirementsException(Exception):
 
 
 class Pipeline:
-    
+
     def __init__(self, lang='en', dir=DEFAULT_MODEL_DIR, package='default', processors={}, logging_level='INFO', verbose=None, use_gpu=True, **kwargs):
         self.lang, self.dir, self.kwargs = lang, dir, kwargs
-        
+
         # set global logging level
         set_logging_level(logging_level, verbose)
         self.logging_level = logging.getLevelName(logger.level)
@@ -98,7 +96,7 @@ class Pipeline:
         pipeline_level_configs = {'lang': lang, 'mode': 'predict'}
         self.use_gpu = torch.cuda.is_available() and use_gpu
         logger.info("Use device: {}".format("gpu" if self.use_gpu else "cpu"))
-        
+
         # set up processors
         pipeline_reqs_exceptions = []
         for item in self.load_list:

--- a/stanza/pipeline/depparse_processor.py
+++ b/stanza/pipeline/depparse_processor.py
@@ -8,9 +8,10 @@ from stanza.models.common.utils import unsort
 from stanza.models.depparse.data import DataLoader
 from stanza.models.depparse.trainer import Trainer
 from stanza.pipeline._constants import *
-from stanza.pipeline.processor import UDProcessor
+from stanza.pipeline.processor import UDProcessor, register_processor
 
 
+@register_processor(name=DEPPARSE)
 class DepparseProcessor(UDProcessor):
 
     # set of processor requirements this processor fulfills

--- a/stanza/pipeline/depparse_processor.py
+++ b/stanza/pipeline/depparse_processor.py
@@ -24,13 +24,13 @@ class DepparseProcessor(UDProcessor):
         super().__init__(config, pipeline, use_gpu)
 
     def _set_up_requires(self):
+        self._pretagged = self._config.get('pretagged')
         if self._pretagged:
             self._requires = set()
         else:
             self._requires = self.__class__.REQUIRES_DEFAULT
 
     def _set_up_model(self, config, use_gpu):
-        self._pretagged = config.get('pretagged')
         self._pretrain = Pretrain(config['pretrain_path'])
         self._trainer = Trainer(pretrain=self.pretrain, model_file=config['model_path'], use_cuda=use_gpu)
 

--- a/stanza/pipeline/lemma_processor.py
+++ b/stanza/pipeline/lemma_processor.py
@@ -6,8 +6,9 @@ from stanza.models.common import doc
 from stanza.models.lemma.data import DataLoader
 from stanza.models.lemma.trainer import Trainer
 from stanza.pipeline._constants import *
-from stanza.pipeline.processor import UDProcessor
+from stanza.pipeline.processor import UDProcessor, register_processor
 
+@register_processor(name=LEMMA)
 class LemmaProcessor(UDProcessor):
 
     # set of processor requirements this processor fulfills

--- a/stanza/pipeline/mwt_processor.py
+++ b/stanza/pipeline/mwt_processor.py
@@ -7,9 +7,9 @@ import io
 from stanza.models.mwt.data import DataLoader
 from stanza.models.mwt.trainer import Trainer
 from stanza.pipeline._constants import *
-from stanza.pipeline.processor import UDProcessor
+from stanza.pipeline.processor import UDProcessor, register_processor
 
-
+@register_processor(MWT)
 class MWTProcessor(UDProcessor):
 
     # set of processor requirements this processor fulfills

--- a/stanza/pipeline/ner_processor.py
+++ b/stanza/pipeline/ner_processor.py
@@ -8,10 +8,11 @@ from stanza.models.common.utils import unsort
 from stanza.models.ner.data import DataLoader
 from stanza.models.ner.trainer import Trainer
 from stanza.pipeline._constants import *
-from stanza.pipeline.processor import UDProcessor
+from stanza.pipeline.processor import UDProcessor, register_processor
 
 logger = logging.getLogger('stanza')
 
+@register_processor(name=NER)
 class NERProcessor(UDProcessor):
 
     # set of processor requirements this processor fulfills

--- a/stanza/pipeline/pos_processor.py
+++ b/stanza/pipeline/pos_processor.py
@@ -8,9 +8,9 @@ from stanza.models.common.utils import unsort
 from stanza.models.pos.data import DataLoader
 from stanza.models.pos.trainer import Trainer
 from stanza.pipeline._constants import *
-from stanza.pipeline.processor import UDProcessor
+from stanza.pipeline.processor import UDProcessor, register_processor
 
-
+@register_processor(name=POS)
 class POSProcessor(UDProcessor):
 
     # set of processor requirements this processor fulfills

--- a/stanza/pipeline/processor.py
+++ b/stanza/pipeline/processor.py
@@ -65,7 +65,7 @@ class Processor(ABC):
         # given pipeline constructing this processor, check if requirements are met, throw exception if not
         self._check_requirements()
 
-        if hasattr(self, '_variant') and self._variant.TAKE_OVER:
+        if hasattr(self, '_variant') and self._variant.OVERRIDE:
             self.process = self._variant.process
 
     @abstractmethod
@@ -117,7 +117,7 @@ class Processor(ABC):
 class ProcessorVariant(ABC):
     """ Base class for all processor variants """
 
-    TAKE_OVER = False # Set to true to take over all the processing from the processor
+    OVERRIDE = False # Set to true to override all the processing from the processor
 
     @abstractmethod
     def process(self, doc):
@@ -125,7 +125,7 @@ class ProcessorVariant(ABC):
         Process a document that is potentially preprocessed by the processor.
         This is the main method of a processor variant.
 
-        If `TAKE_OVER` is set to True, all preprocessing by the processor would be bypassed, and the processor variant
+        If `OVERRIDE` is set to True, all preprocessing by the processor would be bypassed, and the processor variant
         would serve as a drop-in replacement of the entire processor, and has to be able to interpret all the configs
         that are typically handled by the processor it replaces.
         """

--- a/stanza/pipeline/processor.py
+++ b/stanza/pipeline/processor.py
@@ -4,7 +4,7 @@ Base classes for processors
 
 from abc import ABC, abstractmethod
 
-from stanza.pipeline.registry import NAME_TO_PROCESSOR_CLASS, PIPELINE_NAMES
+from stanza.pipeline.registry import NAME_TO_PROCESSOR_CLASS, PIPELINE_NAMES, PROCESSOR_VARIANTS
 
 class ProcessorRequirementsException(Exception):
     """ Exception indicating a processor's requirements will not be met """
@@ -90,6 +90,18 @@ class Processor(ABC):
             raise ProcessorRequirementsException(load_names, self, provided_reqs)
 
 
+class ProcessorVariant(ABC):
+    """ Base class for all processor variants """
+
+    @abstractmethod
+    def process(self, doc):
+        """
+        Process a document that is potentially preprocessed by the processor.
+        This is the main method of a processor variant.
+        """
+        pass
+
+
 class UDProcessor(Processor):
     """ Base class for the neural UD Processors (tokenize,mwt,pos,lemma,depparse,sentiment) """
     def __init__(self, config, pipeline, use_gpu):
@@ -160,5 +172,11 @@ def register_processor(name):
     def wrapper(Cls):
         NAME_TO_PROCESSOR_CLASS[name] = Cls
         PIPELINE_NAMES.append(name)
+        return Cls
+    return wrapper
+
+def register_processor_variant(name, variant):
+    def wrapper(Cls):
+        PROCESSOR_VARIANTS[name][variant] = Cls
         return Cls
     return wrapper

--- a/stanza/pipeline/processor.py
+++ b/stanza/pipeline/processor.py
@@ -51,6 +51,23 @@ class ProcessorRequirementsException(Exception):
 class Processor(ABC):
     """ Base class for all processors """
 
+    def __init__(self, config, pipeline, use_gpu):
+        # overall config for the processor
+        self._config = config
+        # pipeline building this processor (presently processors are only meant to exist in one pipeline)
+        self._pipeline = pipeline
+        self._set_up_variants(config, use_gpu)
+        # run set up process
+        # set up what annotations are required based on config
+        self._set_up_requires()
+        # set up what annotations are provided based on config
+        self._set_up_provides()
+        # given pipeline constructing this processor, check if requirements are met, throw exception if not
+        self._check_requirements()
+
+        if hasattr(self, '_variant') and self._variant.TAKE_OVER:
+            self.process = self._variant.process
+
     @abstractmethod
     def process(self, doc):
         """ Process a Document.  This is the main method of a processor. """
@@ -63,6 +80,13 @@ class Processor(ABC):
     def _set_up_requires(self):
         """ Set up requirements for this processor.  Default is to use a class defined list. """
         self._requires = self.__class__.REQUIRES_DEFAULT
+
+    def _set_up_variants(self, config, use_gpu):
+        processor_name = list(self.__class__.PROVIDES_DEFAULT)[0]
+        if any(config.get(f'with_{variant}', False) for variant in PROCESSOR_VARIANTS[processor_name]):
+            self._trainer = None
+            variant_name = [variant for variant in PROCESSOR_VARIANTS[processor_name] if config.get(f'with_{variant}', False)][0]
+            self._variant = PROCESSOR_VARIANTS[processor_name][variant_name](config)
 
     @property
     def config(self):
@@ -93,36 +117,36 @@ class Processor(ABC):
 class ProcessorVariant(ABC):
     """ Base class for all processor variants """
 
+    TAKE_OVER = False # Set to true to take over all the processing from the processor
+
     @abstractmethod
     def process(self, doc):
         """
         Process a document that is potentially preprocessed by the processor.
         This is the main method of a processor variant.
+
+        If `TAKE_OVER` is set to True, all preprocessing by the processor would be bypassed, and the processor variant
+        would serve as a drop-in replacement of the entire processor, and has to be able to interpret all the configs
+        that are typically handled by the processor it replaces.
         """
         pass
 
 
 class UDProcessor(Processor):
     """ Base class for the neural UD Processors (tokenize,mwt,pos,lemma,depparse,sentiment) """
+
     def __init__(self, config, pipeline, use_gpu):
-        # overall config for the processor
-        self._config = None
-        # pipeline building this processor (presently processors are only meant to exist in one pipeline)
-        self._pipeline = pipeline
+        super().__init__(config, pipeline, use_gpu)
+
         # UD model resources, set up is processor specific
         self._pretrain = None
         self._trainer = None
         self._vocab = None
-        self._set_up_model(config, use_gpu)
-        # run set up process
+        if not hasattr(self, '_variant'):
+            self._set_up_model(config, use_gpu)
+
         # build the final config for the processor
         self._set_up_final_config(config)
-        # set up what annotations are required based on config
-        self._set_up_requires()
-        # set up what annotations are provided based on config
-        self._set_up_provides()
-        # given pipeline constructing this processor, check if requirements are met, throw exception if not
-        self._check_requirements()
 
     @abstractmethod
     def _set_up_model(self, config, gpu):

--- a/stanza/pipeline/processor.py
+++ b/stanza/pipeline/processor.py
@@ -4,6 +4,7 @@ Base classes for processors
 
 from abc import ABC, abstractmethod
 
+from stanza.pipeline.registry import NAME_TO_PROCESSOR_CLASS, PIPELINE_NAMES
 
 class ProcessorRequirementsException(Exception):
     """ Exception indicating a processor's requirements will not be met """
@@ -154,3 +155,10 @@ class UDProcessor(Processor):
             return True
         else:
             return False
+
+def register_processor(name):
+    def wrapper(Cls):
+        NAME_TO_PROCESSOR_CLASS[name] = Cls
+        PIPELINE_NAMES.append(name)
+        return Cls
+    return wrapper

--- a/stanza/pipeline/registry.py
+++ b/stanza/pipeline/registry.py
@@ -1,0 +1,5 @@
+from collections import defaultdict
+
+NAME_TO_PROCESSOR_CLASS = dict()
+PIPELINE_NAMES = []
+PROCESSOR_VARIANTS = defaultdict(dict)

--- a/stanza/pipeline/sentiment_processor.py
+++ b/stanza/pipeline/sentiment_processor.py
@@ -14,8 +14,9 @@ import stanza.models.classifiers.cnn_classifier as cnn_classifier
 from stanza.models.common import doc
 from stanza.models.common.pretrain import Pretrain
 from stanza.pipeline._constants import *
-from stanza.pipeline.processor import UDProcessor
+from stanza.pipeline.processor import UDProcessor, register_processor
 
+@register_processor(SENTIMENT)
 class SentimentProcessor(UDProcessor):
     # set of processor requirements this processor fulfills
     PROVIDES_DEFAULT = set([SENTIMENT])

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -9,7 +9,7 @@ from stanza.models.tokenize.data import DataLoader
 from stanza.models.tokenize.trainer import Trainer
 from stanza.models.tokenize.utils import output_predictions
 from stanza.pipeline._constants import *
-from stanza.pipeline.processor import UDProcessor
+from stanza.pipeline.processor import UDProcessor, register_processor
 from stanza.utils.postprocess_vietnamese_tokenizer_data import paras_to_chunks
 from stanza.models.common import doc
 from stanza.utils.jieba import JiebaTokenizer
@@ -18,6 +18,7 @@ from stanza.utils.spacy import SpacyTokenizer
 logger = logging.getLogger('stanza')
 
 # class for running the tokenizer
+@register_processor(name=TOKENIZE)
 class TokenizeProcessor(UDProcessor):
 
     # set of processor requirements this processor fulfills

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -33,11 +33,6 @@ class TokenizeProcessor(UDProcessor):
         # set up trainer
         if config.get('pretokenized'):
             self._trainer = None
-        elif any(config.get(f'with_{variant}', False) for variant in PROCESSOR_VARIANTS[TOKENIZE]):
-            self._trainer = None
-            variant_name = [variant for variant in PROCESSOR_VARIANTS[TOKENIZE] if config.get(f'with_{variant}', False)][0]
-            self._tokenizer_variant = PROCESSOR_VARIANTS[TOKENIZE][variant_name](config.get('lang'))
-            logger.info(f"Using {variant_name} as tokenizer")
         else:
             self._trainer = Trainer(model_file=config['model_path'], use_cuda=use_gpu)
 
@@ -72,8 +67,8 @@ class TokenizeProcessor(UDProcessor):
 
         if self.config.get('pretokenized'):
             raw_text, document = self.process_pre_tokenized_text(document)
-        elif hasattr(self, '_tokenizer_variant'):
-            return self._tokenizer_variant.process(document)
+        elif hasattr(self, '_variant'):
+            return self._variant.process(document)
         else:
             raw_text = '\n\n'.join(document) if isinstance(document, list) else document
             # set up batches

--- a/stanza/utils/jieba.py
+++ b/stanza/utils/jieba.py
@@ -5,6 +5,8 @@ Utilities related to using Jieba in the pipeline.
 import re
 
 from stanza.models.common import doc
+from stanza.pipeline._constants import TOKENIZE
+from stanza.pipeline.processor import ProcessorVariant, register_processor_variant
 
 def check_jieba():
     """
@@ -18,7 +20,8 @@ def check_jieba():
         )
     return True
 
-class JiebaTokenizer():
+@register_processor_variant(TOKENIZE, 'jieba')
+class JiebaTokenizer(ProcessorVariant):
     def __init__(self, lang='zh-hans'):
         """ Construct a Jieba-based tokenizer by loading the Jieba pipeline.
 
@@ -31,7 +34,7 @@ class JiebaTokenizer():
         import jieba
         self.nlp = jieba
 
-    def tokenize(self, text):
+    def process(self, text):
         """ Tokenize a document with the Jieba tokenizer and wrap the results into a Doc object.
         """
         if not isinstance(text, str):

--- a/stanza/utils/resources.py
+++ b/stanza/utils/resources.py
@@ -113,7 +113,7 @@ def maintain_processor_list(resources, lang, package, processors):
                 processor_list[key] = value
             # allow lemma to be set to "identity"
             elif key == LEMMA and value == 'identity':
-                logger.debug(f'Found {key}: {value}. Using identical lemmatizer.')
+                logger.debug(f'Found {key}: {value}. Using identity lemmatizer.')
                 processor_list[key] = value
             # not a processor in the officially supported processor list
             elif key not in resources[lang]:

--- a/stanza/utils/resources.py
+++ b/stanza/utils/resources.py
@@ -14,6 +14,7 @@ import logging
 
 from stanza.utils.helper_func import make_table
 from stanza.pipeline._constants import TOKENIZE, MWT, POS, LEMMA, DEPPARSE, NER, SENTIMENT, SUPPORTED_TOKENIZERS
+from stanza.pipeline.registry import PIPELINE_NAMES
 from stanza._version import __resources_version__
 
 logger = logging.getLogger('stanza')
@@ -22,7 +23,6 @@ logger = logging.getLogger('stanza')
 HOME_DIR = str(Path.home())
 DEFAULT_RESOURCES_URL = 'https://raw.githubusercontent.com/stanfordnlp/stanza-resources/master'
 DEFAULT_MODEL_DIR = os.getenv('STANZA_RESOURCES_DIR', os.path.join(HOME_DIR, 'stanza_resources'))
-PIPELINE_NAMES = [TOKENIZE, MWT, POS, LEMMA, DEPPARSE, NER, SENTIMENT]
 
 # given a language and models path, build a default configuration
 def build_default_config(resources, lang, dir, load_list):
@@ -101,21 +101,25 @@ def maintain_processor_list(resources, lang, package, processors):
             assert(isinstance(key, str) and isinstance(value, str))
             # check if keys and values can be found
             if key in resources[lang] and value in resources[lang][key]:
-                logger.debug(f'Find {key}: {value}.')
+                logger.debug(f'Found {key}: {value}.')
                 processor_list[key] = value
             # allow values to be default in some cases
             elif key in resources[lang]['default_processors'] and value == 'default':
-                logger.debug(f'Find {key}: {resources[lang]["default_processors"][key]}.')
+                logger.debug(f'Found {key}: {resources[lang]["default_processors"][key]}.')
                 processor_list[key] = resources[lang]['default_processors'][key]
             # allow tokenize to be set to "spacy" or "jieba"
             elif key == TOKENIZE and value in SUPPORTED_TOKENIZERS:
-                logger.debug(f'Find {key}: {value}. Using external {value} library as tokenizer.')
+                logger.debug(f'Found {key}: {value}. Using external {value} library as tokenizer.')
                 processor_list[key] = value
             # allow lemma to be set to "identity"
             elif key == LEMMA and value == 'identity':
-                logger.debug(f'Find {key}: {value}. Using identical lemmatizer.')
+                logger.debug(f'Found {key}: {value}. Using identical lemmatizer.')
                 processor_list[key] = value
-            # cannot find and warn user
+            # not a processor in the officially supported processor list
+            elif key not in resources[lang]:
+                logger.debug(f'{key}: {value} is not officially supported by Stanza, loading it anyway.')
+                processor_list[key] = value
+            # cannot find the package for a processor and warn user
             else:
                 logger.warning(f'Can not find {key}: {value} from official model list. Ignoring it.')
     # resolve package
@@ -124,7 +128,7 @@ def maintain_processor_list(resources, lang, package, processors):
         if package == 'default':
             for key, value in resources[lang]['default_processors'].items():
                 if key not in processor_list:
-                    logger.debug(f'Find {key}: {value}.')
+                    logger.debug(f'Found {key}: {value}.')
                     processor_list[key] = value
         else:
             flag = False
@@ -133,7 +137,7 @@ def maintain_processor_list(resources, lang, package, processors):
                 if package in resources[lang][key]:
                     flag = True
                     if key not in processor_list:
-                        logger.debug(f'Find {key}: {package}.')
+                        logger.debug(f'Found {key}: {package}.')
                         processor_list[key] = package
                     else:
                         logger.debug(f'{key}: {package} is overwritten by {key}: {processors[key]}.')
@@ -149,7 +153,7 @@ def add_dependencies(resources, lang, processor_list):
         dependencies = default_dependencies.get(processor, None)
         # skip dependency checking for special spacy/jieba tokenizer and identity lemmatizer
         if not any([processor == TOKENIZE and package in SUPPORTED_TOKENIZERS, processor == LEMMA and package == 'identity']):
-            dependencies = resources[lang][processor][package].get('dependencies', dependencies)
+            dependencies = resources[lang].get(processor, {}).get(package, {}).get('dependencies', dependencies)
         if dependencies:
             dependencies = [[dependency['model'], dependency['package']] for dependency in dependencies]
         item.append(dependencies)

--- a/stanza/utils/spacy.py
+++ b/stanza/utils/spacy.py
@@ -3,6 +3,8 @@ Utilities related to using spaCy in the pipeline.
 """
 
 from stanza.models.common import doc
+from stanza.pipeline._constants import TOKENIZE
+from stanza.pipeline.processor import ProcessorVariant, register_processor_variant
 
 def check_spacy():
     """
@@ -16,6 +18,7 @@ def check_spacy():
         )
     return True
 
+@register_processor_variant(TOKENIZE, 'spacy')
 class SpacyTokenizer():
     def __init__(self, lang='en'):
         """ Construct a spaCy-based tokenizer by loading the spaCy pipeline.
@@ -30,7 +33,7 @@ class SpacyTokenizer():
             raise ImportError(
                 "spaCy 2.0+ is used but not installed on your machine. Go to https://spacy.io/usage for installation instructions."
             )
-        
+
         # Create a Tokenizer with the default settings for English
         # including punctuation rules and exceptions
         self.nlp = English()
@@ -38,14 +41,14 @@ class SpacyTokenizer():
         # we need to add a sentencizer for fast rule-based ssplit
         sentencizer = self.nlp.create_pipe('sentencizer')
         self.nlp.add_pipe(sentencizer)
-    
-    def tokenize(self, text):
+
+    def process(self, text):
         """ Tokenize a document with the spaCy tokenizer and wrap the results into a Doc object.
         """
         if not isinstance(text, str):
             raise Exception("Must supply a string to the spaCy tokenizer.")
         spacy_doc = self.nlp(text)
-        
+
         sentences = []
         for sent in spacy_doc.sents:
             tokens = []

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,81 @@
+"""
+Basic tests of the depparse processor boolean flags
+"""
+import pytest
+
+import stanza
+from stanza.models.common.doc import Document
+from stanza.pipeline.core import PipelineRequirementsException
+from stanza.pipeline.processor import Processor, ProcessorVariant, register_processor, register_processor_variant
+from stanza.utils.conll import CoNLL
+from tests import *
+
+pytestmark = pytest.mark.pipeline
+
+# data for testing
+EN_DOC = "This is a test sentence. This is another!"
+
+EN_DOC_LOWERCASE_TOKENS = '''<Token id=1;words=[<Word id=1;text=this>]>
+<Token id=2;words=[<Word id=2;text=is>]>
+<Token id=3;words=[<Word id=3;text=a>]>
+<Token id=4;words=[<Word id=4;text=test>]>
+<Token id=5;words=[<Word id=5;text=sentence>]>
+<Token id=6;words=[<Word id=6;text=.>]>
+
+<Token id=1;words=[<Word id=1;text=this>]>
+<Token id=2;words=[<Word id=2;text=is>]>
+<Token id=3;words=[<Word id=3;text=another>]>
+<Token id=4;words=[<Word id=4;text=!>]>'''
+
+EN_DOC_LOL_TOKENS = '''<Token id=1;words=[<Word id=1;text=LOL>]>
+<Token id=2;words=[<Word id=2;text=LOL>]>
+<Token id=3;words=[<Word id=3;text=LOL>]>
+<Token id=4;words=[<Word id=4;text=LOL>]>
+<Token id=5;words=[<Word id=5;text=LOL>]>
+<Token id=6;words=[<Word id=6;text=LOL>]>
+<Token id=7;words=[<Word id=7;text=LOL>]>
+<Token id=8;words=[<Word id=8;text=LOL>]>'''
+
+@register_processor("lowercase")
+class LowercaseProcessor(Processor):
+    ''' Processor that lowercases all text '''
+    _requires = set(['tokenize'])
+    _provides = set(['lowercase'])
+
+    def __init__(self, config, pipeline, use_gpu):
+        pass
+
+    def _set_up_model(self, *args):
+        pass
+
+    def process(self, doc):
+        doc.text = doc.text.lower()
+        for sent in doc.sentences:
+            for tok in sent.tokens:
+                tok.text = tok.text.lower()
+
+            for word in sent.words:
+                word.text = word.text.lower()
+
+        return doc
+
+def test_register_processor():
+    nlp = stanza.Pipeline(dir=TEST_MODELS_DIR, lang='en', processors='tokenize,lowercase')
+    doc = nlp(EN_DOC)
+    assert EN_DOC_LOWERCASE_TOKENS == '\n\n'.join(sent.tokens_string() for sent in doc.sentences)
+
+@register_processor_variant("tokenize", "lol")
+class LOLTokenizer(ProcessorVariant):
+    ''' An alternative tokenizer that splits text by space and replaces all tokens with LOL '''
+
+    def __init__(self, lang):
+        pass
+
+    def process(self, text):
+        sentence = [{'id': f'{i+1}', 'text': 'LOL'} for i, tok in enumerate(text.split())]
+        return Document([sentence], text)
+
+def test_register_processor_variant():
+    nlp = stanza.Pipeline(dir=TEST_MODELS_DIR, lang='en', processors={"tokenize": "lol"}, package=None)
+    doc = nlp(EN_DOC)
+    assert EN_DOC_LOL_TOKENS == '\n\n'.join(sent.tokens_string() for sent in doc.sentences)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -93,7 +93,7 @@ def test_register_processor_variant():
     assert EN_DOC_LOL_TOKENS == '\n\n'.join(sent.tokens_string() for sent in doc.sentences)
 
 @register_processor_variant("lemma", "cool")
-class LOLTokenizer(ProcessorVariant):
+class CoolLemmatizer(ProcessorVariant):
     ''' An alternative lemmatizer that lemmatizes every word to "cool". '''
 
     OVERRIDE = True
@@ -108,7 +108,7 @@ class LOLTokenizer(ProcessorVariant):
 
         return document
 
-def test_register_processor_variant_with_takeover():
+def test_register_processor_variant_with_override():
     nlp = stanza.Pipeline(dir=TEST_MODELS_DIR, lang='en', processors={"tokenize": "ewt", "pos": "ewt", "lemma": "cool"}, package=None)
     doc = nlp(EN_DOC)
     assert EN_DOC_COOL_LEMMAS == '\n\n'.join(sent.tokens_string() for sent in doc.sentences)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -96,7 +96,7 @@ def test_register_processor_variant():
 class LOLTokenizer(ProcessorVariant):
     ''' An alternative lemmatizer that lemmatizes every word to "cool". '''
 
-    TAKE_OVER = True
+    OVERRIDE = True
 
     def __init__(self, lang):
         pass

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -36,6 +36,18 @@ EN_DOC_LOL_TOKENS = '''<Token id=1;words=[<Word id=1;text=LOL>]>
 <Token id=7;words=[<Word id=7;text=LOL>]>
 <Token id=8;words=[<Word id=8;text=LOL>]>'''
 
+EN_DOC_COOL_LEMMAS = '''<Token id=1;words=[<Word id=1;text=This;lemma=cool;upos=PRON;xpos=DT;feats=Number=Sing|PronType=Dem>]>
+<Token id=2;words=[<Word id=2;text=is;lemma=cool;upos=AUX;xpos=VBZ;feats=Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin>]>
+<Token id=3;words=[<Word id=3;text=a;lemma=cool;upos=DET;xpos=DT;feats=Definite=Ind|PronType=Art>]>
+<Token id=4;words=[<Word id=4;text=test;lemma=cool;upos=NOUN;xpos=NN;feats=Number=Sing>]>
+<Token id=5;words=[<Word id=5;text=sentence;lemma=cool;upos=NOUN;xpos=NN;feats=Number=Sing>]>
+<Token id=6;words=[<Word id=6;text=.;lemma=cool;upos=PUNCT;xpos=.>]>
+
+<Token id=1;words=[<Word id=1;text=This;lemma=cool;upos=PRON;xpos=DT;feats=Number=Sing|PronType=Dem>]>
+<Token id=2;words=[<Word id=2;text=is;lemma=cool;upos=AUX;xpos=VBZ;feats=Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin>]>
+<Token id=3;words=[<Word id=3;text=another;lemma=cool;upos=DET;xpos=DT>]>
+<Token id=4;words=[<Word id=4;text=!;lemma=cool;upos=PUNCT;xpos=.>]>'''
+
 @register_processor("lowercase")
 class LowercaseProcessor(Processor):
     ''' Processor that lowercases all text '''
@@ -79,3 +91,24 @@ def test_register_processor_variant():
     nlp = stanza.Pipeline(dir=TEST_MODELS_DIR, lang='en', processors={"tokenize": "lol"}, package=None)
     doc = nlp(EN_DOC)
     assert EN_DOC_LOL_TOKENS == '\n\n'.join(sent.tokens_string() for sent in doc.sentences)
+
+@register_processor_variant("lemma", "cool")
+class LOLTokenizer(ProcessorVariant):
+    ''' An alternative lemmatizer that lemmatizes every word to "cool". '''
+
+    TAKE_OVER = True
+
+    def __init__(self, lang):
+        pass
+
+    def process(self, document):
+        for sentence in document.sentences:
+            for word in sentence.words:
+                word.lemma = "cool"
+
+        return document
+
+def test_register_processor_variant_with_takeover():
+    nlp = stanza.Pipeline(dir=TEST_MODELS_DIR, lang='en', processors={"tokenize": "ewt", "pos": "ewt", "lemma": "cool"}, package=None)
+    doc = nlp(EN_DOC)
+    assert EN_DOC_COOL_LEMMAS == '\n\n'.join(sent.tokens_string() for sent in doc.sentences)


### PR DESCRIPTION
## Desciption
This PR introduces two decorators, `register_processor` and `register_processor_variant` that allows users and developers to load their customized processors and processor variants (e.g., different tokenizer models).

## Fixes Issues
N/A

## Unit test coverage
Core functionality shouldn't change and is already covered by existing unittests; newly added decorators are tested in `test_decorators.py`.

## Known breaking changes/behaviors
N/A
