### PR TITLE
Add SudachiPy as external tokenizer for Japanese pipeline

### DIFF
--- a/stanza/pipeline/_constants.py
+++ b/stanza/pipeline/_constants.py
@@ -8,6 +8,3 @@ LEMMA = 'lemma'
 DEPPARSE = 'depparse'
 NER = 'ner'
 SENTIMENT = 'sentiment'
-
-# supported external packages
-SUPPORTED_TOKENIZERS = ['spacy', 'jieba', 'sudachipy']

--- a/stanza/pipeline/_constants.py
+++ b/stanza/pipeline/_constants.py
@@ -10,4 +10,4 @@ NER = 'ner'
 SENTIMENT = 'sentiment'
 
 # supported external packages
-SUPPORTED_TOKENIZERS = ['spacy', 'jieba']
+SUPPORTED_TOKENIZERS = ['spacy', 'jieba', 'sudachipy']

--- a/stanza/pipeline/external/sudachipy.py
+++ b/stanza/pipeline/external/sudachipy.py
@@ -1,0 +1,79 @@
+"""
+Processors related to SudachiPy in the pipeline.
+
+GitHub Home: https://github.com/WorksApplications/SudachiPy
+"""
+
+import re
+
+from stanza.models.common import doc
+from stanza.pipeline._constants import TOKENIZE
+from stanza.pipeline.processor import ProcessorVariant, register_processor_variant
+
+def check_sudachipy():
+    """
+    Import necessary components from SudachiPy to perform tokenization.
+    """
+    try:
+        import sudachipy
+        import sudachidict_core
+    except ImportError:
+        raise ImportError(
+            "Both sudachipy and sudachidict_core libraries are required. "
+            "Try install them with `pip install sudachipy sudachidict_core`. "
+            "Go to https://github.com/WorksApplications/SudachiPy for more information."
+        )
+    return True
+
+@register_processor_variant(TOKENIZE, 'sudachipy')
+class SudachiPyTokenizer(ProcessorVariant):
+    def __init__(self, config):
+        """ Construct a SudachiPy-based tokenizer.
+
+        Note that this tokenizer uses regex for sentence segmentation.
+        """
+        if config['lang'] != 'ja':
+            raise Exception("SudachiPy tokenizer is only allowed in Japanese pipelines.")
+
+        check_sudachipy()
+        from sudachipy import tokenizer
+        from sudachipy import dictionary
+
+        self.tokenizer = dictionary.Dictionary().create()
+
+    def process(self, text):
+        """ Tokenize a document with the SudachiPy tokenizer and wrap the results into a Doc object.
+        """
+        if not isinstance(text, str):
+            raise Exception("Must supply a string to the SudachiPy tokenizer.")
+
+        # we use the default sudachipy tokenization mode (i.e., mode C)
+        # more config needs to be added to support other modes
+
+        tokens = self.tokenizer.tokenize(text)
+
+        sentences = []
+        current_sentence = []
+        for token in tokens:
+            start = token.begin()
+            end = token.end()
+            token_text = token.surface()
+
+            token_entry = {
+                doc.TEXT: token_text,
+                doc.MISC: f"{doc.START_CHAR}={start}|{doc.END_CHAR}={end}"
+            }
+            current_sentence.append(token_entry)
+
+            if token_text in ['。', '！', '？', '!', '?']:
+                sentences.append(current_sentence)
+                current_sentence = []
+
+        if len(current_sentence) > 0:
+            sentences.append(current_sentence)
+
+        return doc.Document(sentences, text)
+
+
+
+

--- a/stanza/pipeline/external/sudachipy.py
+++ b/stanza/pipeline/external/sudachipy.py
@@ -55,9 +55,13 @@ class SudachiPyTokenizer(ProcessorVariant):
         sentences = []
         current_sentence = []
         for token in tokens:
+            token_text = token.surface()
+            # by default sudachipy will output whitespace as a token
+            # we need to skip these tokens to be consistent with other tokenizers
+            if token_text.isspace():
+                continue
             start = token.begin()
             end = token.end()
-            token_text = token.surface()
 
             token_entry = {
                 doc.TEXT: token_text,

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -15,6 +15,7 @@ from stanza.utils.postprocess_vietnamese_tokenizer_data import paras_to_chunks
 from stanza.models.common import doc
 from stanza.pipeline.external.jieba import JiebaTokenizer
 from stanza.pipeline.external.spacy import SpacyTokenizer
+from stanza.pipeline.external.sudachipy import SudachiPyTokenizer
 
 logger = logging.getLogger('stanza')
 

--- a/stanza/resources/common.py
+++ b/stanza/resources/common.py
@@ -14,7 +14,7 @@ import logging
 
 from stanza.utils.helper_func import make_table
 from stanza.pipeline._constants import TOKENIZE, MWT, POS, LEMMA, DEPPARSE, \
-    NER, SENTIMENT, SUPPORTED_TOKENIZERS
+    NER, SENTIMENT
 from stanza.pipeline.registry import PIPELINE_NAMES, PROCESSOR_VARIANTS
 from stanza._version import __resources_version__
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -147,17 +147,24 @@ def test_no_ssplit():
 def test_spacy():
     nlp = stanza.Pipeline(processors='tokenize', dir=TEST_MODELS_DIR, lang='en', tokenize_with_spacy=True)
     doc = nlp(EN_DOC)
+    
+    # make sure the loaded tokenizer is actually spacy
+    assert "SpacyTokenizer" == nlp.processors['tokenize']._variant.__class__.__name__
     assert EN_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
 
 def test_sudachipy():
     nlp = stanza.Pipeline(lang='ja', dir=TEST_MODELS_DIR, processors={'tokenize': 'sudachipy'}, package=None)
     doc = nlp(JA_DOC)
+    
+    assert "SudachiPyTokenizer" == nlp.processors['tokenize']._variant.__class__.__name__
     assert JA_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
 
 def test_jieba():
     nlp = stanza.Pipeline(lang='zh', dir=TEST_MODELS_DIR, processors={'tokenize': 'jieba'}, package=None)
     doc = nlp(ZH_DOC)
+
+    assert "JiebaTokenizer" == nlp.processors['tokenize']._variant.__class__.__name__
     assert ZH_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -10,7 +10,6 @@ from tests import *
 pytestmark = pytest.mark.pipeline
 
 EN_DOC = "Joe Smith lives in California. Joe's favorite food is pizza. He enjoys going to the beach."
-
 EN_DOC_GOLD_TOKENS = """
 <Token id=1;words=[<Word id=1;text=Joe>]>
 <Token id=2;words=[<Word id=2;text=Smith>]>
@@ -36,10 +35,8 @@ EN_DOC_GOLD_TOKENS = """
 <Token id=7;words=[<Word id=7;text=.>]>
 """.strip()
 
-
 EN_DOC_PRETOKENIZED = \
     "Joe Smith lives in California .\nJoe's favorite  food is  pizza .\n\nHe enjoys going to the beach.\n"
-
 EN_DOC_PRETOKENIZED_GOLD_TOKENS = """
 <Token id=1;words=[<Word id=1;text=Joe>]>
 <Token id=2;words=[<Word id=2;text=Smith>]>
@@ -63,9 +60,7 @@ EN_DOC_PRETOKENIZED_GOLD_TOKENS = """
 <Token id=6;words=[<Word id=6;text=beach.>]>
 """.strip()
 
-
 EN_DOC_PRETOKENIZED_LIST = [['Joe', 'Smith', 'lives', 'in', 'California', '.'], ['He', 'loves', 'pizza', '.']]
-
 EN_DOC_PRETOKENIZED_LIST_GOLD_TOKENS = """
 <Token id=1;words=[<Word id=1;text=Joe>]>
 <Token id=2;words=[<Word id=2;text=Smith>]>
@@ -81,9 +76,7 @@ EN_DOC_PRETOKENIZED_LIST_GOLD_TOKENS = """
 """.strip()
 
 EN_DOC_NO_SSPLIT = ["This is a sentence. This is another.", "This is a third."]
-
 EN_DOC_NO_SSPLIT_SENTENCES = [['This', 'is', 'a', 'sentence', '.', 'This', 'is', 'another', '.'], ['This', 'is', 'a', 'third', '.']]
-
 
 JA_DOC = "北京は中国の首都です。 北京の人口は2152万人です。\n" # add some random whitespaces that need to be skipped
 JA_DOC_GOLD_TOKENS = """
@@ -103,6 +96,27 @@ JA_DOC_GOLD_TOKENS = """
 <Token id=6;words=[<Word id=6;text=人>]>
 <Token id=7;words=[<Word id=7;text=です>]>
 <Token id=8;words=[<Word id=8;text=。>]>
+""".strip()
+
+ZH_DOC = "北京是中国的首都。 北京有2100万人口，是一个直辖市。\n"
+ZH_DOC_GOLD_TOKENS = """
+<Token id=1;words=[<Word id=1;text=北京>]>
+<Token id=2;words=[<Word id=2;text=是>]>
+<Token id=3;words=[<Word id=3;text=中国>]>
+<Token id=4;words=[<Word id=4;text=的>]>
+<Token id=5;words=[<Word id=5;text=首都>]>
+<Token id=6;words=[<Word id=6;text=。>]>
+
+<Token id=1;words=[<Word id=1;text=北京>]>
+<Token id=2;words=[<Word id=2;text=有>]>
+<Token id=3;words=[<Word id=3;text=2100>]>
+<Token id=4;words=[<Word id=4;text=万>]>
+<Token id=5;words=[<Word id=5;text=人口>]>
+<Token id=6;words=[<Word id=6;text=，>]>
+<Token id=7;words=[<Word id=7;text=是>]>
+<Token id=8;words=[<Word id=8;text=一个>]>
+<Token id=9;words=[<Word id=9;text=直辖市>]>
+<Token id=10;words=[<Word id=10;text=。>]>
 """.strip()
 
 def test_tokenize():
@@ -140,4 +154,10 @@ def test_sudachipy():
     nlp = stanza.Pipeline(lang='ja', dir=TEST_MODELS_DIR, processors={'tokenize': 'sudachipy'}, package=None)
     doc = nlp(JA_DOC)
     assert JA_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
+    assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
+
+def test_jieba():
+    nlp = stanza.Pipeline(lang='zh', dir=TEST_MODELS_DIR, processors={'tokenize': 'jieba'}, package=None)
+    doc = nlp(ZH_DOC)
+    assert ZH_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -146,8 +146,6 @@ def test_no_ssplit():
 
 def test_spacy():
     nlp = stanza.Pipeline(processors='tokenize', dir=TEST_MODELS_DIR, lang='en', tokenize_with_spacy=True)
-    assert nlp.processors['tokenize']._variant is not None
-    assert nlp.processors['tokenize']._trainer is None
     doc = nlp(EN_DOC)
     
     # make sure the loaded tokenizer is actually spacy

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -85,6 +85,26 @@ EN_DOC_NO_SSPLIT = ["This is a sentence. This is another.", "This is a third."]
 EN_DOC_NO_SSPLIT_SENTENCES = [['This', 'is', 'a', 'sentence', '.', 'This', 'is', 'another', '.'], ['This', 'is', 'a', 'third', '.']]
 
 
+JA_DOC = "北京は中国の首都です。 北京の人口は2152万人です。\n" # add some random whitespaces that need to be skipped
+JA_DOC_GOLD_TOKENS = """
+<Token id=1;words=[<Word id=1;text=北京>]>
+<Token id=2;words=[<Word id=2;text=は>]>
+<Token id=3;words=[<Word id=3;text=中国>]>
+<Token id=4;words=[<Word id=4;text=の>]>
+<Token id=5;words=[<Word id=5;text=首都>]>
+<Token id=6;words=[<Word id=6;text=です>]>
+<Token id=7;words=[<Word id=7;text=。>]>
+
+<Token id=1;words=[<Word id=1;text=北京>]>
+<Token id=2;words=[<Word id=2;text=の>]>
+<Token id=3;words=[<Word id=3;text=人口>]>
+<Token id=4;words=[<Word id=4;text=は>]>
+<Token id=5;words=[<Word id=5;text=2152万>]>
+<Token id=6;words=[<Word id=6;text=人>]>
+<Token id=7;words=[<Word id=7;text=です>]>
+<Token id=8;words=[<Word id=8;text=。>]>
+""".strip()
+
 def test_tokenize():
     nlp = stanza.Pipeline(processors='tokenize', dir=TEST_MODELS_DIR, lang='en')
     doc = nlp(EN_DOC)
@@ -114,4 +134,10 @@ def test_spacy():
     nlp = stanza.Pipeline(processors='tokenize', dir=TEST_MODELS_DIR, lang='en', tokenize_with_spacy=True)
     doc = nlp(EN_DOC)
     assert EN_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
+    assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
+
+def test_sudachipy():
+    nlp = stanza.Pipeline(lang='ja', dir=TEST_MODELS_DIR, processors={'tokenize': 'sudachipy'}, package=None)
+    doc = nlp(JA_DOC)
+    assert JA_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])


### PR DESCRIPTION
## Desciption
This PR adds [SudachiPy](https://github.com/WorksApplications/SudachiPy) as an external tokenizer variant for the Japanese pipeline. Use it with `stanza.Pipeline('ja', processors={'tokenize': 'sudachipy'})`.

## Known breaking changes/behaviors
No. Although using this external tokenizer requires installing Python packages `sudachipy` and `sudachidict_core`.
