### PR TITLE
Patch for tokenizer to handle consecutive whitespaces

### DIFF
--- a/stanza/models/tokenize/data.py
+++ b/stanza/models/tokenize/data.py
@@ -11,6 +11,17 @@ from .vocab import Vocab
 
 logger = logging.getLogger('stanza')
 
+def filter_consecutive_whitespaces(para):
+    filtered = []
+    for i, (char, label) in enumerate(para):
+        if i > 0:
+            if char == ' ' and para[i-1][0] == ' ':
+                continue
+
+        filtered.append((char, label))
+
+    return filtered
+
 class DataLoader:
     def __init__(self, args, input_files={'json': None, 'txt': None, 'label': None}, input_text=None, input_data=None, vocab=None, evaluation=False):
         self.args = args
@@ -45,6 +56,9 @@ class DataLoader:
             self.data = [[(re.sub('\s', ' ', char), int(label)) # substitute special whitespaces
                     for char, label in zip(pt.rstrip(), pc) if not (args.get('skip_newline', False) and char == '\n')] # check if newline needs to be eaten
                     for pt, pc in zip(re.split('\n\s*\n', text), re.split('\n\s*\n', labels)) if len(pt.rstrip()) > 0]
+
+        # remove consecutive whitespaces
+        self.data = [filter_consecutive_whitespaces(x) for x in self.data]
 
         self.vocab = vocab if vocab is not None else self.init_vocab()
 
@@ -85,7 +99,7 @@ class DataLoader:
                 raise Exception('Feature function "{}" is undefined.'.format(feat_func))
 
             funcs.append(func)
-        
+
         # stacking all featurize functions
         composite_func = lambda x: list(map(lambda f: f(x), funcs))
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -10,6 +10,7 @@ from tests import *
 pytestmark = pytest.mark.pipeline
 
 EN_DOC = "Joe Smith lives in California. Joe's favorite food is pizza. He enjoys going to the beach."
+EN_DOC_WITH_EXTRA_WHITESPACE = "Joe   Smith \n lives in\n California.   Joe's    favorite food \tis pizza. \t\t\tHe enjoys \t\tgoing to the beach."
 EN_DOC_GOLD_TOKENS = """
 <Token id=1;words=[<Word id=1;text=Joe>]>
 <Token id=2;words=[<Word id=2;text=Smith>]>
@@ -125,6 +126,11 @@ def test_tokenize():
     assert EN_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
 
+def test_tokenize_ssplit_robustness():
+    nlp = stanza.Pipeline(processors='tokenize', dir=TEST_MODELS_DIR, lang='en')
+    doc = nlp(EN_DOC_WITH_EXTRA_WHITESPACE)
+    assert EN_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
+    assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
 
 def test_pretokenized():
     nlp = stanza.Pipeline(**{'processors': 'tokenize', 'dir': TEST_MODELS_DIR, 'lang': 'en',
@@ -147,7 +153,7 @@ def test_no_ssplit():
 def test_spacy():
     nlp = stanza.Pipeline(processors='tokenize', dir=TEST_MODELS_DIR, lang='en', tokenize_with_spacy=True)
     doc = nlp(EN_DOC)
-    
+
     # make sure the loaded tokenizer is actually spacy
     assert "SpacyTokenizer" == nlp.processors['tokenize']._variant.__class__.__name__
     assert EN_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
@@ -156,7 +162,7 @@ def test_spacy():
 def test_sudachipy():
     nlp = stanza.Pipeline(lang='ja', dir=TEST_MODELS_DIR, processors={'tokenize': 'sudachipy'}, package=None)
     doc = nlp(JA_DOC)
-    
+
     assert "SudachiPyTokenizer" == nlp.processors['tokenize']._variant.__class__.__name__
     assert JA_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])


### PR DESCRIPTION
## Desciption
This PR improves the robustness of the tokenizer in noisy real-world data that often contain multiple consecutive whitespaces.

## Fixes Issues
N/A

## Unit test coverage
New unittest added in test_tokenizer

## Known breaking changes/behaviors
Not that I'm aware of
