### PR TITLE
Server improvements

### DIFF
--- a/stanza/server/client.py
+++ b/stanza/server/client.py
@@ -231,13 +231,12 @@ class CoreNLPClient(RobustService):
         # validate properties
         validate_corenlp_props(properties=properties, annotators=annotators, output_format=output_format)
         # set up client defaults
+        self.properties = properties
         self.annotators = annotators
         self.output_format = output_format
         self._setup_client_defaults()
         # start the server
         if start_server:
-            # set up default properties for server
-            self.properties = properties
             # record info for server start
             self.server_props_path = None
             self.server_start_time = datetime.now()
@@ -453,10 +452,11 @@ class CoreNLPClient(RobustService):
 
         # add values from properties arg
         # handle str case
-        if type(properties) == str and is_corenlp_lang(properties):
-            properties = {'pipelineLanguage': properties.lower()}
-        else:
-            raise ValueError(f"Unrecognized properties keyword {properties}")
+        if type(properties) == str:
+            if is_corenlp_lang(properties):
+                properties = {'pipelineLanguage': properties.lower()}
+            else:
+                raise ValueError(f"Unrecognized properties keyword {properties}")
 
         if properties and type(properties) == dict:
             request_properties.update(properties)

--- a/stanza/server/client.py
+++ b/stanza/server/client.py
@@ -228,6 +228,8 @@ class CoreNLPClient(RobustService):
 
         # whether or not server should be started by client
         self.start_server = start_server
+        self.server_props_path = None
+        self.server_start_time = None
         # validate properties
         validate_corenlp_props(properties=properties, annotators=annotators, output_format=output_format)
         # set up client defaults
@@ -238,7 +240,6 @@ class CoreNLPClient(RobustService):
         # start the server
         if start_server:
             # record info for server start
-            self.server_props_path = None
             self.server_start_time = datetime.now()
             self._setup_server_defaults()
             host, port = urlparse(endpoint).netloc.split(":")

--- a/stanza/server/client.py
+++ b/stanza/server/client.py
@@ -492,7 +492,7 @@ class CoreNLPClient(RobustService):
                 'serializer': 'edu.stanford.nlp.pipeline.ProtobufAnnotationSerializer'
             })
         if annotators:
-            properties['annotators'] = ",".join(annotators) if isinstance(annotators, list) else annotators
+            properties['annotators'] = annotators if type(annotators) == str else ",".join(annotators)
         with io.BytesIO() as stream:
             writeToDelimitedString(doc, stream)
             msg = stream.getvalue()

--- a/stanza/server/client.py
+++ b/stanza/server/client.py
@@ -446,7 +446,6 @@ class CoreNLPClient(RobustService):
             else:
                 request_properties.update(dict(self.properties_cache[properties_key]))
 
-        # add on custom properties for this request
         # add values from properties arg
         if type(properties) == str:
             if properties.lower() in CoreNLPClient.PIPELINE_LANGUAGES:
@@ -462,7 +461,7 @@ class CoreNLPClient(RobustService):
             request_properties['annotators'] = ",".join(annotators) if isinstance(annotators, list) else annotators
 
         # if output format is specified, override with that
-        if output_format is not None:
+        if output_format is not None and type(output_format) == str:
             request_properties['outputFormat'] = output_format
 
         # make the request

--- a/tests/test_server_misc.py
+++ b/tests/test_server_misc.py
@@ -16,24 +16,24 @@ Sentence #1 (6 tokens):
 Joe Smith lives in California.
 
 Tokens:
-[Text=Joe CharacterOffsetBegin=0 CharacterOffsetEnd=3 PartOfSpeech=NNP Lemma=Joe NamedEntityTag=PERSON]
-[Text=Smith CharacterOffsetBegin=4 CharacterOffsetEnd=9 PartOfSpeech=NNP Lemma=Smith NamedEntityTag=PERSON]
-[Text=lives CharacterOffsetBegin=10 CharacterOffsetEnd=15 PartOfSpeech=VBZ Lemma=live NamedEntityTag=O]
-[Text=in CharacterOffsetBegin=16 CharacterOffsetEnd=18 PartOfSpeech=IN Lemma=in NamedEntityTag=O]
-[Text=California CharacterOffsetBegin=19 CharacterOffsetEnd=29 PartOfSpeech=NNP Lemma=California NamedEntityTag=STATE_OR_PROVINCE]
-[Text=. CharacterOffsetBegin=29 CharacterOffsetEnd=30 PartOfSpeech=. Lemma=. NamedEntityTag=O]
+[Text=Joe CharacterOffsetBegin=0 CharacterOffsetEnd=3 PartOfSpeech=PROPN Lemma=joe NamedEntityTag=PERSON]
+[Text=Smith CharacterOffsetBegin=4 CharacterOffsetEnd=9 PartOfSpeech=PROPN Lemma=smith NamedEntityTag=PERSON]
+[Text=lives CharacterOffsetBegin=10 CharacterOffsetEnd=15 PartOfSpeech=ADJ Lemma=lives NamedEntityTag=O]
+[Text=in CharacterOffsetBegin=16 CharacterOffsetEnd=18 PartOfSpeech=ADP Lemma=in NamedEntityTag=O]
+[Text=California CharacterOffsetBegin=19 CharacterOffsetEnd=29 PartOfSpeech=PROPN Lemma=california NamedEntityTag=STATE_OR_PROVINCE]
+[Text=. CharacterOffsetBegin=29 CharacterOffsetEnd=30 PartOfSpeech=PUNCT Lemma=. NamedEntityTag=O]
 
 Dependency Parse (enhanced plus plus dependencies):
-root(ROOT-0, lives-3)
-compound(Smith-2, Joe-1)
-nsubj(lives-3, Smith-2)
+root(ROOT-0, Joe-1)
+flat(Joe-1, Smith-2)
+amod(Joe-1, lives-3)
 case(California-5, in-4)
-obl(lives-3, California-5)
-punct(lives-3, .-6)
+nmod(lives-3, California-5)
+punct(Joe-1, .-6)
 
 Extracted the following NER entity mentions:
-Joe Smith       PERSON  PERSON:0.9972202689478088
-California      STATE_OR_PROVINCE       LOCATION:0.9990868267002156
+Joe Smith	PERSON	PERSON:0.9989563558707318
+California	STATE_OR_PROVINCE	LOCATION:0.9911262738614187
 """
 
 EN_DOC_POS_ONLY_GOLD = """
@@ -49,19 +49,14 @@ Tokens:
 [Text=. CharacterOffsetBegin=29 CharacterOffsetEnd=30 PartOfSpeech=.]
 """
 
+
 def test_english_request():
     """ Test case of starting server with Spanish defaults, and then requesting default English properties """
     with corenlp.CoreNLPClient(properties='spanish', server_id='test_english_request') as client:
-        ann = client.annotate(EN_DOC, properties_key='english', output_format='text')
+        ann = client.annotate(EN_DOC, properties='english', output_format='text')
+        print(ann)
         compare_ignoring_whitespace(ann, EN_DOC_GOLD)
 
-
-
-def test_unknown_properties():
-    """ Test case of starting server with Spanish defaults, and then requesting UNBAN_MOX_OPAL properties """
-    with corenlp.CoreNLPClient(properties='spanish', server_id='test_unknown_properties') as client:
-        with pytest.raises(ValueError):
-            ann = client.annotate(EN_DOC, properties_key='UNBAN_MOX_OPAL', output_format='text')
 
 def test_default_annotators():
     """
@@ -70,20 +65,22 @@ def test_default_annotators():
     """
     with corenlp.CoreNLPClient(server_id='test_default_annotators',
                                output_format='text',
-                               annotators=['tokenize','ssplit','pos','lemma','ner','depparse']) as client:
+                               annotators=['tokenize', 'ssplit', 'pos', 'lemma', 'ner', 'depparse']) as client:
         with corenlp.CoreNLPClient(start_server=False,
                                    output_format='text',
-                                   annotators=['tokenize','ssplit','pos']) as client2:
+                                   annotators=['tokenize', 'ssplit', 'pos']) as client2:
             ann = client2.annotate(EN_DOC)
             print(ann)
+
 
 expected_codepoints = ((0, 1), (2, 4), (5, 8), (9, 15), (16, 20))
 expected_characters = ((0, 1), (2, 4), (5, 10), (11, 17), (18, 22))
 codepoint_doc = "I am 𝒚̂𝒊 random text"
 
+
 def test_codepoints():
     """ Test case of asking for codepoints from the English tokenizer """
-    with corenlp.CoreNLPClient(annotators=['tokenize','ssplit'], # 'depparse','coref'],
+    with corenlp.CoreNLPClient(annotators=['tokenize', 'ssplit'], # 'depparse','coref'],
                                properties={'tokenize.codepoint': 'true'}) as client:
         ann = client.annotate(codepoint_doc)
         for i, (codepoints, characters) in enumerate(zip(expected_codepoints, expected_characters)):

--- a/tests/test_server_request.py
+++ b/tests/test_server_request.py
@@ -104,28 +104,6 @@ Constituency parse:
     (NP (DET quelques) (NOUN jours))
     (AdP (ADV plus) (ADV tôt))
     (PUNCT .)))
-
-
-Binary Constituency parse: 
-(ROOT
-  (SENT
-    (NP (DET Cette)
-      (MWN (NOUN enquête) (ADJ préliminaire)))
-    (@SENT
-      (@SENT
-        (@SENT
-          (@SENT
-            (VN
-              (MWV (VERB fait) (NOUN suite)))
-            (PP (ADP à)
-              (NP
-                (@NP (DET les) (NOUN révélations))
-                (PP (ADP de)
-                  (NP (NOUN l’)
-                    (AP (ADJ hebdomadaire)))))))
-          (NP (DET quelques) (NOUN jours)))
-        (AdP (ADV plus) (ADV tôt)))
-      (PUNCT .))))
 """
 
 FRENCH_EXTRA_GOLD = """
@@ -212,7 +190,6 @@ punct(presidente-7, .-10)
 def corenlp_client():
     """ Client to run tests on """
     client = corenlp.CoreNLPClient(annotators='tokenize,ssplit,pos', server_id='stanza_request_tests_server')
-    client.register_properties_key('fr-custom', FRENCH_CUSTOM_PROPS)
     yield client
     client.stop()
 
@@ -229,33 +206,13 @@ def test_python_dict(corenlp_client):
     """ Test using a Python dictionary to specify all request properties """
     ann = corenlp_client.annotate(ES_DOC, properties=ES_PROPS, output_format="text")
     assert ann.strip() == ES_PROPS_GOLD.strip()
-
-
-def test_properties_key_and_python_dict(corenlp_client):
-    """ Test using a properties key and additional properties """
-    ann = corenlp_client.annotate(FRENCH_DOC, properties_key='fr-custom', properties=FRENCH_EXTRA_PROPS)
-    assert ann.strip() == FRENCH_EXTRA_GOLD.strip()
-
-
-def test_properties_key(corenlp_client):
-    """ Test using the properties_key which was registered with the properties cache """
-    ann = corenlp_client.annotate(FRENCH_DOC, properties_key='fr-custom')
-    assert ann.strip() == FRENCH_CUSTOM_GOLD.strip()
-
-
-def test_switching_back_and_forth(corenlp_client):
-    """ Test using a properties key, then properties key with python dict, then back to just properties key """
-    ann = corenlp_client.annotate(FRENCH_DOC, properties_key='fr-custom')
-    assert ann.strip() == FRENCH_CUSTOM_GOLD.strip()
-    ann = corenlp_client.annotate(FRENCH_DOC, properties_key='fr-custom', properties=FRENCH_EXTRA_PROPS)
-    assert ann.strip() == FRENCH_EXTRA_GOLD.strip()
-    ann = corenlp_client.annotate(FRENCH_DOC, properties_key='fr-custom')
+    ann = corenlp_client.annotate(FRENCH_DOC, properties=FRENCH_CUSTOM_PROPS)
     assert ann.strip() == FRENCH_CUSTOM_GOLD.strip()
 
 
 def test_lang_setting(corenlp_client):
     """ Test using a Stanford CoreNLP supported languages as a properties key """
-    ann = corenlp_client.annotate(GERMAN_DOC, properties_key="german", output_format="text")
+    ann = corenlp_client.annotate(GERMAN_DOC, properties="german", output_format="text")
     compare_ignoring_whitespace(ann, GERMAN_DOC_GOLD)
 
 

--- a/tests/test_server_start.py
+++ b/tests/test_server_start.py
@@ -35,8 +35,8 @@ obl:in(lives-3, California-5)
 punct(lives-3, .-6)
 
 Extracted the following NER entity mentions:
-Joe Smith	PERSON  PERSON:0.9972202689478088
-California	STATE_OR_PROVINCE       LOCATION:0.9990868267002156
+Joe Smith	PERSON	PERSON:0.9972202681743931
+California	STATE_OR_PROVINCE	LOCATION:0.9990868267559281
 """
 
 # results with an example properties file
@@ -85,8 +85,8 @@ appos(Bundesrepublik-8, Deutschland-9)
 punct(Bundeskanzlerin-6, .-10)
 
 Extracted the following NER entity mentions:
-Angela Merkel   PERSON  PERSON:0.9999981583355767
-Bundesrepublik Deutschland      LOCATION        LOCATION:0.968290232887181
+Angela Merkel	PERSON	PERSON:0.9999981583351504
+Bundesrepublik Deutschland	LOCATION	LOCATION:0.9682902289749544
 """
 
 


### PR DESCRIPTION
## Description
High level, the client interface had too many options and confusing logic about how properties are set. This pull request is an attempt to simplify things without losing much functionality. Also some misc. issues have been addressed, and new features in CoreNLP 4.1.0 can be used.

## Fixes Issues
- remove references to CoreNLP defaults on the client side, these
  are mainly stored with CoreNLP (some exceptions include
  what are valid CoreNLP languages and output formats)

- now both the client constructor and annotate() method use a
  similar interface for determing properties…annotators and
  output_format can override specified properties, get rid of
  the properties_key arg

- related to that last point, the properties_cache has been removed,
  it didn’t seem that useful

- added some basic validation (check that output format is valid)

- preload=True will tell CoreNLP to preload the default annotators,
  4.1.0 can accomplish this with just the preload flag

- CoreNLP server can directly take a list of annotators (like the cl interface),
  so some logic in the server for needlessly making temp files has
  been removed

- non-English languages are built on top of CoreNLP English defaults...so the
  German properties should lie on top of English defaults…if you start a French
  server and then send a request with German properties, the German props
  would lie on top of French defaults, which could cause some odd behavior…
  that is German on top of French != German on top of English…the new
  resetDefault option for the server allows to totally ignore server defaults,
  so one can alternate between French and German requests (this wouldn’t
  be an issue if one launches a default English server)

## Unit test coverage
The server tests should be passing with this new code.

## Known breaking changes/behaviors
The properties_cache has been eliminated and the properties_key arg to annotate() removed.
