### PR TITLE
server refinements

### DIFF
--- a/stanza/server/client.py
+++ b/stanza/server/client.py
@@ -481,7 +481,7 @@ class CoreNLPClient(RobustService):
         # if annotators list is specified, override with that
         # also can use the annotators field the object was created with
         if annotators is not None and (type(annotators) == str or type(annotators) == list):
-            request_properties['annotators'] = annotators if type(self.annotators) == str else ",".join(annotators)
+            request_properties['annotators'] = annotators if type(annotators) == str else ",".join(annotators)
 
         # if output format is specified, override with that
         if output_format is not None and type(output_format) == str:

--- a/stanza/server/client.py
+++ b/stanza/server/client.py
@@ -240,7 +240,7 @@ class CoreNLPClient(RobustService):
                  stdout=sys.stdout,
                  stderr=sys.stderr,
                  memory=DEFAULT_MEMORY,
-                 be_quiet=True,
+                 be_quiet=False,
                  max_char_length=DEFAULT_MAX_CHAR_LENGTH,
                  preload=True,
                  classpath=None,

--- a/tests/test_server_misc.py
+++ b/tests/test_server_misc.py
@@ -16,25 +16,26 @@ Sentence #1 (6 tokens):
 Joe Smith lives in California.
 
 Tokens:
-[Text=Joe CharacterOffsetBegin=0 CharacterOffsetEnd=3 PartOfSpeech=NNP Lemma=Joe NamedEntityTag=PERSON]
-[Text=Smith CharacterOffsetBegin=4 CharacterOffsetEnd=9 PartOfSpeech=NNP Lemma=Smith NamedEntityTag=PERSON]
-[Text=lives CharacterOffsetBegin=10 CharacterOffsetEnd=15 PartOfSpeech=VBZ Lemma=live NamedEntityTag=O]
-[Text=in CharacterOffsetBegin=16 CharacterOffsetEnd=18 PartOfSpeech=IN Lemma=in NamedEntityTag=O]
-[Text=California CharacterOffsetBegin=19 CharacterOffsetEnd=29 PartOfSpeech=NNP Lemma=California NamedEntityTag=STATE_OR_PROVINCE]
-[Text=. CharacterOffsetBegin=29 CharacterOffsetEnd=30 PartOfSpeech=. Lemma=. NamedEntityTag=O]
+[Text=Joe CharacterOffsetBegin=0 CharacterOffsetEnd=3 PartOfSpeech=PROPN Lemma=joe NamedEntityTag=PERSON]
+[Text=Smith CharacterOffsetBegin=4 CharacterOffsetEnd=9 PartOfSpeech=PROPN Lemma=smith NamedEntityTag=PERSON]
+[Text=lives CharacterOffsetBegin=10 CharacterOffsetEnd=15 PartOfSpeech=ADJ Lemma=lives NamedEntityTag=O]
+[Text=in CharacterOffsetBegin=16 CharacterOffsetEnd=18 PartOfSpeech=ADP Lemma=in NamedEntityTag=O]
+[Text=California CharacterOffsetBegin=19 CharacterOffsetEnd=29 PartOfSpeech=PROPN Lemma=california NamedEntityTag=STATE_OR_PROVINCE]
+[Text=. CharacterOffsetBegin=29 CharacterOffsetEnd=30 PartOfSpeech=PUNCT Lemma=. NamedEntityTag=O]
 
 Dependency Parse (enhanced plus plus dependencies):
-root(ROOT-0, lives-3)
-compound(Smith-2, Joe-1)
-nsubj(lives-3, Smith-2)
+root(ROOT-0, Joe-1)
+flat(Joe-1, Smith-2)
+amod(Joe-1, lives-3)
 case(California-5, in-4)
-obl(lives-3, California-5)
-punct(lives-3, .-6)
+nmod(lives-3, California-5)
+punct(Joe-1, .-6)
 
 Extracted the following NER entity mentions:
-Joe Smith       PERSON              PERSON:0.9972202681743931
-California      STATE_OR_PROVINCE   LOCATION:0.9990868267559281
+Joe Smith       PERSON  PERSON:0.9989563558707318
+California      STATE_OR_PROVINCE       LOCATION:0.9911262738614187
 """
+
 
 EN_DOC_POS_ONLY_GOLD = """
 Sentence #1 (6 tokens):
@@ -52,16 +53,9 @@ Tokens:
 def test_english_request():
     """ Test case of starting server with Spanish defaults, and then requesting default English properties """
     with corenlp.CoreNLPClient(properties='spanish', server_id='test_english_request') as client:
-        ann = client.annotate(EN_DOC, properties_key='english', output_format='text')
+        ann = client.annotate(EN_DOC, properties='english', output_format='text')
         compare_ignoring_whitespace(ann, EN_DOC_GOLD)
 
-
-
-def test_unknown_properties():
-    """ Test case of starting server with Spanish defaults, and then requesting UNBAN_MOX_OPAL properties """
-    with corenlp.CoreNLPClient(properties='spanish', server_id='test_unknown_properties') as client:
-        with pytest.raises(ValueError):
-            ann = client.annotate(EN_DOC, properties_key='UNBAN_MOX_OPAL', output_format='text')
 
 def test_default_annotators():
     """

--- a/tests/test_server_request.py
+++ b/tests/test_server_request.py
@@ -190,7 +190,6 @@ punct(presidente-7, .-10)
 def corenlp_client():
     """ Client to run tests on """
     client = corenlp.CoreNLPClient(annotators='tokenize,ssplit,pos', server_id='stanza_request_tests_server')
-    client.register_properties_key('fr-custom', FRENCH_CUSTOM_PROPS)
     yield client
     client.stop()
 
@@ -207,33 +206,13 @@ def test_python_dict(corenlp_client):
     """ Test using a Python dictionary to specify all request properties """
     ann = corenlp_client.annotate(ES_DOC, properties=ES_PROPS, output_format="text")
     assert ann.strip() == ES_PROPS_GOLD.strip()
-
-
-def test_properties_key_and_python_dict(corenlp_client):
-    """ Test using a properties key and additional properties """
-    ann = corenlp_client.annotate(FRENCH_DOC, properties_key='fr-custom', properties=FRENCH_EXTRA_PROPS)
-    assert ann.strip() == FRENCH_EXTRA_GOLD.strip()
-
-
-def test_properties_key(corenlp_client):
-    """ Test using the properties_key which was registered with the properties cache """
-    ann = corenlp_client.annotate(FRENCH_DOC, properties_key='fr-custom')
-    assert ann.strip() == FRENCH_CUSTOM_GOLD.strip()
-
-
-def test_switching_back_and_forth(corenlp_client):
-    """ Test using a properties key, then properties key with python dict, then back to just properties key """
-    ann = corenlp_client.annotate(FRENCH_DOC, properties_key='fr-custom')
-    assert ann.strip() == FRENCH_CUSTOM_GOLD.strip()
-    ann = corenlp_client.annotate(FRENCH_DOC, properties_key='fr-custom', properties=FRENCH_EXTRA_PROPS)
-    assert ann.strip() == FRENCH_EXTRA_GOLD.strip()
-    ann = corenlp_client.annotate(FRENCH_DOC, properties_key='fr-custom')
+    ann = corenlp_client.annotate(FRENCH_DOC, properties=FRENCH_CUSTOM_PROPS)
     assert ann.strip() == FRENCH_CUSTOM_GOLD.strip()
 
 
 def test_lang_setting(corenlp_client):
     """ Test using a Stanford CoreNLP supported languages as a properties key """
-    ann = corenlp_client.annotate(GERMAN_DOC, properties_key="german", output_format="text")
+    ann = corenlp_client.annotate(GERMAN_DOC, properties="german", output_format="text")
     compare_ignoring_whitespace(ann, GERMAN_DOC_GOLD)
 
 


### PR DESCRIPTION
## Description
High level, the client interface had too many options and confusing logic about how properties are set. This pull request is an attempt to simplify things without losing much functionality. Also some misc. issues have been addressed, and new features in CoreNLP 4.1.0 can be used.

## Fixes Issues
- remove references to CoreNLP defaults on the client side, these
are mainly stored with CoreNLP (some exceptions include
what are valid CoreNLP languages and output formats)

- now both the client constructor and annotate() method use a
similar interface for determing properties…annotators and
output_format can override specified properties, get rid of
the properties_key arg

- related to that last point, the properties_cache has been removed,
it didn’t seem that useful

- added some basic validation (check that output format is valid)

- preload=True will tell CoreNLP to preload the default annotators,
4.1.0 can accomplish this with just the preload flag

- CoreNLP server can directly take a list of annotators (like the cl interface),
so some logic in the server for needlessly making temp files has
been removed

- non-English languages are built on top of CoreNLP English defaults...so the
German properties should lie on top of English defaults…if you start a French
server and then send a request with German properties, the German props
would lie on top of French defaults, which could cause some odd behavior…
that is German on top of French != German on top of English…the new
resetDefault option for the server allows to totally ignore server defaults,
so one can alternate between French and German requests (this wouldn’t
be an issue if one launches a default English server)

## Unit test coverage
Need to check server 

## Known breaking changes/behaviors
removes properties_cache, removes properties_key arg from annotate() method, requires CoreNLP 4.1.0
