### PR TITLE
Compile re with r in front of strings

### DIFF
--- a/stanza/models/common/pretrain.py
+++ b/stanza/models/common/pretrain.py
@@ -97,7 +97,7 @@ class Pretrain:
         Open a vector file using the provided function and read from it.
         """
         # some vector files, such as Google News, use tabs
-        tab_space_pattern = re.compile("[ \t]+")
+        tab_space_pattern = re.compile(r"[ \t]+")
         first = True
         words = []
         failed = 0

--- a/stanza/models/tokenize/data.py
+++ b/stanza/models/tokenize/data.py
@@ -22,9 +22,9 @@ def filter_consecutive_whitespaces(para):
 
     return filtered
 
-NEWLINE_WHITESPACE_RE = re.compile('\n\s*\n')
-NUMERIC_RE = re.compile('^([\d]+[,\.]*)+$')
-WHITESPACE_RE = re.compile('\s')
+NEWLINE_WHITESPACE_RE = re.compile(r'\n\s*\n')
+NUMERIC_RE = re.compile(r'^([\d]+[,\.]*)+$')
+WHITESPACE_RE = re.compile(r'\s')
 
 
 class DataLoader:

--- a/stanza/models/tokenize/utils.py
+++ b/stanza/models/tokenize/utils.py
@@ -57,7 +57,7 @@ def process_sentence(sentence, mwt_dict=None):
     return sent
 
 SPACE_RE = re.compile(r'\s')
-SPACE_SPLIT_RE = re.compile('( *[^ ]+)')
+SPACE_SPLIT_RE = re.compile(r'( *[^ ]+)')
 
 def output_predictions(output_file, trainer, data_generator, vocab, mwt_dict, max_seqlen=1000, orig_text=None, no_ssplit=False):
     paragraphs = []

--- a/stanza/models/tokenize/vocab.py
+++ b/stanza/models/tokenize/vocab.py
@@ -4,7 +4,7 @@ import re
 from stanza.models.common.vocab import BaseVocab
 from stanza.models.common.vocab import UNK, PAD
 
-SPACE_RE = re.compile('\s')
+SPACE_RE = re.compile(r'\s')
 
 class Vocab(BaseVocab):
     def __init__(self):

--- a/stanza/pipeline/external/jieba.py
+++ b/stanza/pipeline/external/jieba.py
@@ -45,7 +45,7 @@ class JiebaTokenizer(ProcessorVariant):
         current_sentence = []
         offset = 0
         for token in tokens:
-            if re.match('\s+', token):
+            if re.match(r'\s+', token):
                 offset += len(token)
                 continue
 

--- a/stanza/utils/postprocess_vietnamese_tokenizer_data.py
+++ b/stanza/utils/postprocess_vietnamese_tokenizer_data.py
@@ -13,12 +13,12 @@ def para_to_chunks(text, char_level_pred):
         if re.match('^\w$', text[idx], flags=re.UNICODE):
             lastchunk += text[idx]
         else:
-            if len(lastchunk) > 0 and not re.match('^\W+$', lastchunk, flags=re.UNICODE):
+            if len(lastchunk) > 0 and not re.match(r'^\W+$', lastchunk, flags=re.UNICODE):
                 chunks += [lastchunk]
                 assert len(lastpred) > 0
                 preds += [int(lastpred)]
                 lastchunk = ''
-            if not re.match('^\s$', text[idx], flags=re.UNICODE):
+            if not re.match(r'^\s$', text[idx], flags=re.UNICODE):
                 # punctuation
                 chunks += [text[idx]]
                 preds += [int(char_level_pred[idx])]
@@ -34,7 +34,7 @@ def para_to_chunks(text, char_level_pred):
     return list(zip(chunks, preds))
 
 def paras_to_chunks(text, char_level_pred):
-    return [para_to_chunks(re.sub('\s', ' ', pt.rstrip()), pc) for pt, pc in zip(text.split('\n\n'), char_level_pred.split('\n\n'))]
+    return [para_to_chunks(re.sub(r'\s', ' ', pt.rstrip()), pc) for pt, pc in zip(text.split('\n\n'), char_level_pred.split('\n\n'))]
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/stanza/utils/prepare_tokenizer_data.py
+++ b/stanza/utils/prepare_tokenizer_data.py
@@ -14,7 +14,7 @@ a file of 0,1,2 indicating word break or sentence break on a character level for
   2: end of sentence
 """
 
-PARAGRAPH_BREAK = re.compile('\n\s*\n')
+PARAGRAPH_BREAK = re.compile(r'\n\s*\n')
 
 parser = argparse.ArgumentParser()
 


### PR DESCRIPTION
Gets rid of some random warnings I noticed in the PR test scripts