### PR TITLE
Add spaCy v3 compatibility alongside v2

### DIFF
--- a/stanza/pipeline/external/spacy.py
+++ b/stanza/pipeline/external/spacy.py
@@ -39,8 +39,10 @@ class SpacyTokenizer(ProcessorVariant):
         self.nlp = English()
         # by default spacy uses dependency parser to do ssplit
         # we need to add a sentencizer for fast rule-based ssplit
-        sentencizer = self.nlp.create_pipe('sentencizer')
-        self.nlp.add_pipe(sentencizer)
+        if spacy.__version__.startswith("2."):
+            self.nlp.add_pipe(self.nlp.create_pipe("sentencizer"))
+        else:
+            self.nlp.add_pipe("sentencizer")
 
     def process(self, text):
         """ Tokenize a document with the spaCy tokenizer and wrap the results into a Doc object.


### PR DESCRIPTION
## Description

Extend `SpacyTokenizer` so that it supports both spaCy v2 and spaCy v3 when adding the sentencizer to the pipeline.

## Unit test coverage

In the existing test `test_spacy`.

## Known breaking changes/behaviors

None.