### PR TITLE
Add sentence back pointers for data objects

### DIFF
--- a/tests/setup_test.sh
+++ b/tests/setup_test.sh
@@ -20,8 +20,8 @@ cp tests/data/tiny_emb.* $test_dir/in
 
 models_dir=$test_dir/models
 mkdir -p $models_dir
-$PYTHON -c "import stanza; stanza.download(lang='en', dir='${models_dir}', logging_level='info')" || echo "failed to download english model"
-$PYTHON -c "import stanza; stanza.download(lang='fr', dir='${models_dir}', logging_level='info')" || echo "failed to download french model"
+$PYTHON -c "import stanza; stanza.download(lang='en', model_dir='${models_dir}', logging_level='info')" || echo "failed to download english model"
+$PYTHON -c "import stanza; stanza.download(lang='fr', model_dir='${models_dir}', logging_level='info')" || echo "failed to download french model"
 echo "Models downloaded to ${models_dir}."
 
 export STANZA_TEST_HOME=$test_dir

--- a/tests/test_data_objects.py
+++ b/tests/test_data_objects.py
@@ -14,6 +14,7 @@ EN_DOC = "This is a test document. Pretty cool!"
 
 EN_DOC_UPOS_XPOS = (('PRON_DT', 'AUX_VBZ', 'DET_DT', 'NOUN_NN', 'NOUN_NN', 'PUNCT_.'), ('ADV_RB', 'ADJ_JJ', 'PUNCT_.'))
 
+EN_DOC2 = "Chris wrote a sentence. Then another."
 
 def test_readonly():
     Document.add_property('some_property', 123)
@@ -48,3 +49,11 @@ def test_setter_getter():
     # don't try this at home
     sentence._classname = 2
     assert sentence.classname == 'bad'
+
+def test_backpointer():
+    nlp = stanza.Pipeline(dir=TEST_MODELS_DIR, lang='en')
+    doc = nlp(EN_DOC2)
+    ent = doc.ents[0]
+    assert ent.sent is doc.sentences[0]
+    assert list(doc.iter_words())[0].sent is doc.sentences[0]
+    assert list(doc.iter_tokens())[-1].sent is doc.sentences[-1]


### PR DESCRIPTION
## Desciption
This PR adds `sent` backpointers from the `Token`, `Word`, and `Span` data objects to the sentence they are from.

## Fixes Issues
N/A

## Unit test coverage
Added new tests in `test_data_objects.py`.

## Known breaking changes/behaviors
N/A
