### PR TITLE
Integration of PyThaiNLP as external tokenizer

### DIFF
--- a/stanza/pipeline/external/pythainlp.py
+++ b/stanza/pipeline/external/pythainlp.py
@@ -1,0 +1,76 @@
+"""
+Processors related to PyThaiNLP in the pipeline.
+
+GitHub Home: https://github.com/PyThaiNLP/pythainlp
+"""
+
+from stanza.models.common import doc
+from stanza.pipeline._constants import TOKENIZE
+from stanza.pipeline.processor import ProcessorVariant, register_processor_variant
+
+def check_pythainlp():
+    """
+    Import necessary components from pythainlp to perform tokenization.
+    """
+    try:
+        import pythainlp
+    except ImportError:
+        raise ImportError(
+            "The pythainlp library is required. "
+            "Try to install it with `pip install pythainlp`. "
+            "Go to https://github.com/PyThaiNLP/pythainlp for more information."
+        )
+    return True
+
+@register_processor_variant(TOKENIZE, 'pythainlp')
+class PyThaiNLPTokenizer(ProcessorVariant):
+    def __init__(self, config):
+        """ Construct a PyThaiNLP-based tokenizer.
+
+        Note that we always uses the default tokenizer of PyThaiNLP for sentence and word segmentation.
+        Currently this is a CRF model for sentence segmentation and a dictionary-based model (newmm) for word segmentation.
+        """
+        if config['lang'] != 'th':
+            raise Exception("PyThaiNLP tokenizer is only allowed in Thai pipeline.")
+
+        check_pythainlp()
+        from pythainlp.tokenize import sent_tokenize as pythai_sent_tokenize
+        from pythainlp.tokenize import word_tokenize as pythai_word_tokenize
+
+        self.pythai_sent_tokenize = pythai_sent_tokenize
+        self.pythai_word_tokenize = pythai_word_tokenize
+    
+    def process(self, text):
+        """ Tokenize a document with the PyThaiNLP tokenizer and wrap the results into a Doc object.
+        """
+        if not isinstance(text, str):
+            raise Exception("Must supply a string to the PyThaiNLP tokenizer.")
+
+        sentences = []
+        current_sentence = []
+        offset = 0
+
+        for sent_str in self.pythai_sent_tokenize(text, engine='crfcut'):
+            for token_str in self.pythai_word_tokenize(sent_str, engine='newmm'):
+                # by default pythainlp will output whitespace as a token
+                # we need to skip these tokens to be consistent with other tokenizers
+                if token_str.isspace():
+                    offset += len(token_str)
+                    continue
+                
+                # create token entry
+                token_entry = {
+                    doc.TEXT: token_str,
+                    doc.MISC: f"{doc.START_CHAR}={offset}|{doc.END_CHAR}={offset+len(token_str)}"
+                }
+                current_sentence.append(token_entry)
+                offset += len(token_str)
+            
+            # finish sentence
+            sentences.append(current_sentence)
+            current_sentence = []
+
+        if len(current_sentence) > 0:
+            sentences.append(current_sentence)
+
+        return doc.Document(sentences, text)

--- a/stanza/pipeline/external/pythainlp.py
+++ b/stanza/pipeline/external/pythainlp.py
@@ -39,6 +39,7 @@ class PyThaiNLPTokenizer(ProcessorVariant):
 
         self.pythai_sent_tokenize = pythai_sent_tokenize
         self.pythai_word_tokenize = pythai_word_tokenize
+        self.no_ssplit = config.get('no_ssplit', False)
     
     def process(self, text):
         """ Tokenize a document with the PyThaiNLP tokenizer and wrap the results into a Doc object.
@@ -50,7 +51,12 @@ class PyThaiNLPTokenizer(ProcessorVariant):
         current_sentence = []
         offset = 0
 
-        for sent_str in self.pythai_sent_tokenize(text, engine='crfcut'):
+        if self.no_ssplit:
+            # skip sentence segmentation
+            sent_strs = [text]
+        else:
+            sent_strs = self.pythai_sent_tokenize(text, engine='crfcut')
+        for sent_str in sent_strs:
             for token_str in self.pythai_word_tokenize(sent_str, engine='newmm'):
                 # by default pythainlp will output whitespace as a token
                 # we need to skip these tokens to be consistent with other tokenizers

--- a/stanza/pipeline/external/sudachipy.py
+++ b/stanza/pipeline/external/sudachipy.py
@@ -78,7 +78,3 @@ class SudachiPyTokenizer(ProcessorVariant):
             sentences.append(current_sentence)
 
         return doc.Document(sentences, text)
-
-
-
-

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -16,6 +16,7 @@ from stanza.models.common import doc
 from stanza.pipeline.external.jieba import JiebaTokenizer
 from stanza.pipeline.external.spacy import SpacyTokenizer
 from stanza.pipeline.external.sudachipy import SudachiPyTokenizer
+from stanza.pipeline.external.pythainlp import PyThaiNLPTokenizer
 
 logger = logging.getLogger('stanza')
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -199,6 +199,23 @@ TH_DOC_GOLD_TOKENS = """
 <Token id=9;words=[<Word id=9;text=ภูมิภาค>]>
 """.strip()
 
+TH_DOC_GOLD_NOSSPLIT_TOKENS = """
+<Token id=1;words=[<Word id=1;text=ข้าราชการ>]>
+<Token id=2;words=[<Word id=2;text=ได้รับ>]>
+<Token id=3;words=[<Word id=3;text=การ>]>
+<Token id=4;words=[<Word id=4;text=หมุนเวียน>]>
+<Token id=5;words=[<Word id=5;text=เป็นระยะ>]>
+<Token id=6;words=[<Word id=6;text=และ>]>
+<Token id=7;words=[<Word id=7;text=เขา>]>
+<Token id=8;words=[<Word id=8;text=ได้>]>
+<Token id=9;words=[<Word id=9;text=รับมอบหมาย>]>
+<Token id=10;words=[<Word id=10;text=ให้>]>
+<Token id=11;words=[<Word id=11;text=ประจำ>]>
+<Token id=12;words=[<Word id=12;text=ใน>]>
+<Token id=13;words=[<Word id=13;text=ระดับ>]>
+<Token id=14;words=[<Word id=14;text=ภูมิภาค>]>
+""".strip()
+
 def test_tokenize():
     nlp = stanza.Pipeline(processors='tokenize', dir=TEST_MODELS_DIR, lang='en')
     doc = nlp(EN_DOC)
@@ -284,4 +301,11 @@ def test_pythainlp():
     doc = nlp(TH_DOC)
     assert "PyThaiNLPTokenizer" == nlp.processors['tokenize']._variant.__class__.__name__
     assert TH_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
+    assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
+
+def test_pythainlp_no_ssplit():
+    nlp = stanza.Pipeline(lang='th', dir=TEST_MODELS_DIR, processors={'tokenize': 'pythainlp'}, tokenize_no_ssplit=True, package=None)
+    doc = nlp(TH_DOC)
+    assert "PyThaiNLPTokenizer" == nlp.processors['tokenize']._variant.__class__.__name__
+    assert TH_DOC_GOLD_NOSSPLIT_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -180,6 +180,25 @@ ZH_DOC_GOLD_NOSSPLIT_TOKENS = """
 <Token id=16;words=[<Word id=16;text=。>]>
 """.strip()
 
+TH_DOC = "ข้าราชการได้รับการหมุนเวียนเป็นระยะ และเขาได้รับมอบหมายให้ประจำในระดับภูมิภาค"
+TH_DOC_GOLD_TOKENS = """
+<Token id=1;words=[<Word id=1;text=ข้าราชการ>]>
+<Token id=2;words=[<Word id=2;text=ได้รับ>]>
+<Token id=3;words=[<Word id=3;text=การ>]>
+<Token id=4;words=[<Word id=4;text=หมุนเวียน>]>
+<Token id=5;words=[<Word id=5;text=เป็นระยะ>]>
+
+<Token id=1;words=[<Word id=1;text=และ>]>
+<Token id=2;words=[<Word id=2;text=เขา>]>
+<Token id=3;words=[<Word id=3;text=ได้>]>
+<Token id=4;words=[<Word id=4;text=รับมอบหมาย>]>
+<Token id=5;words=[<Word id=5;text=ให้>]>
+<Token id=6;words=[<Word id=6;text=ประจำ>]>
+<Token id=7;words=[<Word id=7;text=ใน>]>
+<Token id=8;words=[<Word id=8;text=ระดับ>]>
+<Token id=9;words=[<Word id=9;text=ภูมิภาค>]>
+""".strip()
+
 def test_tokenize():
     nlp = stanza.Pipeline(processors='tokenize', dir=TEST_MODELS_DIR, lang='en')
     doc = nlp(EN_DOC)
@@ -258,4 +277,11 @@ def test_jieba_no_ssplit():
 
     assert "JiebaTokenizer" == nlp.processors['tokenize']._variant.__class__.__name__
     assert ZH_DOC_GOLD_NOSSPLIT_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
+    assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
+
+def test_pythainlp():
+    nlp = stanza.Pipeline(lang='th', dir=TEST_MODELS_DIR, processors={'tokenize': 'pythainlp'}, package=None)
+    doc = nlp(TH_DOC)
+    assert "PyThaiNLPTokenizer" == nlp.processors['tokenize']._variant.__class__.__name__
+    assert TH_DOC_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])


### PR DESCRIPTION
## Description
This PR integrats PyThaiNLP as an external tokenizer for the Stanza Thai pipeline. This integration can be used as:
```python
text = "ข้าราชการได้รับการหมุนเวียนเป็นระยะ และเขาได้รับมอบหมายให้ประจำในระดับภูมิภาค"
nlp = stanza.Pipeline(lang='th', processors={'tokenize': 'pythainlp'}, package=None)
doc = nlp(text)
```

Note:
- I only integrated the default sentence and word segmentation models in PyThaiNLP. For sentence segmentation it is a CRF-based model; for word segmentation it is a dictionary-based model (newmm). 
- To make it consistent with other tokenizers, I am currently throwing out all whitespace tokens output by PyThaiNLP. Not sure if this is the best decision for Thai.

## Unit test coverage
Unit test covers basic sentence segmentation and word segmentation.

## Known breaking changes/behaviors
None.
