### PR TITLE
Support passing a list of Document objects into the Stanza Pipeline

### DIFF
--- a/stanza/pipeline/core.py
+++ b/stanza/pipeline/core.py
@@ -175,16 +175,17 @@ class Pipeline:
         """
         return [self.processors[processor_name] for processor_name in PIPELINE_NAMES if self.processors.get(processor_name)]
 
-    def process(self, doc):
+    def process(self, doc, bulk=False):
         # run the pipeline
         for processor_name in PIPELINE_NAMES:
             if self.processors.get(processor_name):
-                doc = self.processors[processor_name].process(doc)
+                process = self.processors[processor_name].bulk_process if bulk else self.processors[processor_name].process
+                doc = process(doc)
         return doc
 
     def __call__(self, doc):
         assert any([isinstance(doc, str), isinstance(doc, list),
                     isinstance(doc, Document)]), 'input should be either str, list or Document'
-        doc = self.process(doc)
+        doc = self.process(doc, bulk=(isinstance(doc, list) and len(doc) > 0 and isinstance(doc[0], Document)))
         return doc
 

--- a/stanza/pipeline/core.py
+++ b/stanza/pipeline/core.py
@@ -175,8 +175,11 @@ class Pipeline:
         """
         return [self.processors[processor_name] for processor_name in PIPELINE_NAMES if self.processors.get(processor_name)]
 
-    def process(self, doc, bulk=False):
+    def process(self, doc):
         # run the pipeline
+
+        # determine whether we are in bulk processing mode for multiple documents
+        bulk=(isinstance(doc, list) and len(doc) > 0 and isinstance(doc[0], Document))
         for processor_name in PIPELINE_NAMES:
             if self.processors.get(processor_name):
                 process = self.processors[processor_name].bulk_process if bulk else self.processors[processor_name].process
@@ -186,6 +189,6 @@ class Pipeline:
     def __call__(self, doc):
         assert any([isinstance(doc, str), isinstance(doc, list),
                     isinstance(doc, Document)]), 'input should be either str, list or Document'
-        doc = self.process(doc, bulk=(isinstance(doc, list) and len(doc) > 0 and isinstance(doc[0], Document)))
+        doc = self.process(doc)
         return doc
 

--- a/stanza/pipeline/processor.py
+++ b/stanza/pipeline/processor.py
@@ -73,6 +73,11 @@ class Processor(ABC):
         """ Process a Document.  This is the main method of a processor. """
         pass
 
+    def bulk_process(self, docs):
+        """ Process a list of Documents. This should be replaced with a more efficient implementation if possible. """
+
+        return [self.process(doc) for doc in docs]
+
     def _set_up_provides(self):
         """ Set up what processor requirements this processor fulfills.  Default is to use a class defined list. """
         self._provides = self.__class__.PROVIDES_DEFAULT
@@ -131,6 +136,10 @@ class ProcessorVariant(ABC):
         """
         pass
 
+    @abstractmethod
+    def bulk_process(self, docs):
+        """ Process a list of Documents that are potentially preprocessed by the processor. """
+        pass
 
 class UDProcessor(Processor):
     """ Base class for the neural UD Processors (tokenize,mwt,pos,lemma,depparse,sentiment) """

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -64,8 +64,11 @@ class TokenizeProcessor(UDProcessor):
         return raw_text, document
 
     def process(self, document):
-        assert isinstance(document, str) or (self.config.get('pretokenized') or self.config.get('no_ssplit', False)), \
-            "If neither 'pretokenized' or 'no_ssplit' option is enabled, the input to the TokenizerProcessor must be a string."
+        assert isinstance(document, str) or isinstance(document, doc.Document) or (self.config.get('pretokenized') or self.config.get('no_ssplit', False)), \
+            "If neither 'pretokenized' or 'no_ssplit' option is enabled, the input to the TokenizerProcessor must be a string or a Document object."
+
+        if isinstance(document, doc.Document):
+            document = document.text
 
         if self.config.get('pretokenized'):
             raw_text, document = self.process_pre_tokenized_text(document)

--- a/tests/test_english_pipeline.py
+++ b/tests/test_english_pipeline.py
@@ -5,6 +5,7 @@ Basic testing of the English pipeline
 import pytest
 import stanza
 from stanza.utils.conll import CoNLL
+from stanza.models.common.doc import Document
 
 from tests import *
 
@@ -12,6 +13,8 @@ pytestmark = pytest.mark.pipeline
 
 # data for testing
 EN_DOC = "Barack Obama was born in Hawaii.  He was elected president in 2008.  Obama attended Harvard."
+
+EN_DOCS = ["Barack Obama was born in Hawaii.", "He was elected president in 2008.", "Obama attended Harvard."]
 
 EN_DOC_TOKENS_GOLD = """
 <Token id=1;words=[<Word id=1;text=Barack;lemma=Barack;upos=PROPN;xpos=NNP;feats=Number=Sing;head=4;deprel=nsubj:pass>]>
@@ -132,4 +135,25 @@ def test_words(processed_doc):
 
 def test_dependency_parse(processed_doc):
     assert "\n\n".join([sent.dependencies_string() for sent in processed_doc.sentences]) == \
+           EN_DOC_DEPENDENCY_PARSES_GOLD
+
+
+@pytest.fixture(scope="module")
+def processed_multidoc():
+    """ Document created by running full English pipeline on a few sentences """
+    docs = [Document([], text=t) for t in EN_DOCS]
+    nlp = stanza.Pipeline(dir=TEST_MODELS_DIR)
+    return nlp(docs)
+
+
+def test_tokens_multidoc(processed_multidoc):
+    assert "\n\n".join([sent.tokens_string() for processed_doc in processed_multidoc for sent in processed_doc.sentences]) == EN_DOC_TOKENS_GOLD
+
+
+def test_words_multidoc(processed_multidoc):
+    assert "\n\n".join([sent.words_string() for processed_doc in processed_multidoc for sent in processed_doc.sentences]) == EN_DOC_WORDS_GOLD
+
+
+def test_dependency_parse_multidoc(processed_multidoc):
+    assert "\n\n".join([sent.dependencies_string() for processed_doc in processed_multidoc for sent in processed_doc.sentences]) == \
            EN_DOC_DEPENDENCY_PARSES_GOLD


### PR DESCRIPTION
## Desciption
This PR adds a basic support for passing a list of stanza `Document` objects into the neural pipeline and getting a list of `Document`s on the other end (although it could potentially be sped up in a later iteration to improve CPU/GPU utility via cross-document batching).

## Fixes Issues
Feature request from email.

## Unit test coverage
Covered by added tests in [test_english_pipeline.py](https://github.com/stanfordnlp/stanza/blob/pipeline-multidoc/tests/test_english_pipeline.py#L141-L159).

## Known breaking changes/behaviors
N/A
