### PR TITLE
Cross-document batching for the pipeline for improved multi-doc processing speed

### DIFF
--- a/stanza/pipeline/external/jieba.py
+++ b/stanza/pipeline/external/jieba.py
@@ -43,7 +43,7 @@ class JiebaTokenizer(ProcessorVariant):
         else:
             text = document
         if not isinstance(text, str):
-            raise Exception("Must supply a string to the Jieba tokenizer.")
+            raise Exception("Must supply a string or Stanza Document object to the Jieba tokenizer.")
         tokens = self.nlp.cut(text, cut_all=False)
 
         sentences = []

--- a/stanza/pipeline/external/jieba.py
+++ b/stanza/pipeline/external/jieba.py
@@ -35,9 +35,13 @@ class JiebaTokenizer(ProcessorVariant):
         self.nlp = jieba
         self.no_ssplit = config.get('no_ssplit', False)
 
-    def process(self, text):
+    def process(self, document):
         """ Tokenize a document with the Jieba tokenizer and wrap the results into a Doc object.
         """
+        if isinstance(document, doc.Document):
+            text = document.text
+        else:
+            text = document
         if not isinstance(text, str):
             raise Exception("Must supply a string to the Jieba tokenizer.")
         tokens = self.nlp.cut(text, cut_all=False)

--- a/stanza/pipeline/external/pythainlp.py
+++ b/stanza/pipeline/external/pythainlp.py
@@ -41,11 +41,15 @@ class PyThaiNLPTokenizer(ProcessorVariant):
         self.pythai_word_tokenize = pythai_word_tokenize
         self.no_ssplit = config.get('no_ssplit', False)
     
-    def process(self, text):
+    def process(self, document):
         """ Tokenize a document with the PyThaiNLP tokenizer and wrap the results into a Doc object.
         """
+        if isinstance(document, doc.Document):
+            text = document.text
+        else:
+            text = document
         if not isinstance(text, str):
-            raise Exception("Must supply a string to the PyThaiNLP tokenizer.")
+            raise Exception("Must supply a string or stanza Document object to the PyThaiNLP tokenizer.")
 
         sentences = []
         current_sentence = []

--- a/stanza/pipeline/external/pythainlp.py
+++ b/stanza/pipeline/external/pythainlp.py
@@ -49,7 +49,7 @@ class PyThaiNLPTokenizer(ProcessorVariant):
         else:
             text = document
         if not isinstance(text, str):
-            raise Exception("Must supply a string or stanza Document object to the PyThaiNLP tokenizer.")
+            raise Exception("Must supply a string or Stanza Document object to the PyThaiNLP tokenizer.")
 
         sentences = []
         current_sentence = []

--- a/stanza/pipeline/external/spacy.py
+++ b/stanza/pipeline/external/spacy.py
@@ -53,7 +53,7 @@ class SpacyTokenizer(ProcessorVariant):
         else:
             text = document
         if not isinstance(text, str):
-            raise Exception("Must supply a string or Document to the spaCy tokenizer.")
+            raise Exception("Must supply a string or Stanza Document object to the spaCy tokenizer.")
         spacy_doc = self.nlp(text)
 
         sentences = []

--- a/stanza/pipeline/external/spacy.py
+++ b/stanza/pipeline/external/spacy.py
@@ -45,11 +45,15 @@ class SpacyTokenizer(ProcessorVariant):
             self.nlp.add_pipe("sentencizer")
         self.no_ssplit = config.get('no_ssplit', False)
 
-    def process(self, text):
+    def process(self, document):
         """ Tokenize a document with the spaCy tokenizer and wrap the results into a Doc object.
         """
+        if isinstance(document, doc.Document):
+            text = document.text
+        else:
+            text = document
         if not isinstance(text, str):
-            raise Exception("Must supply a string to the spaCy tokenizer.")
+            raise Exception("Must supply a string or Document to the spaCy tokenizer.")
         spacy_doc = self.nlp(text)
 
         sentences = []

--- a/stanza/pipeline/external/sudachipy.py
+++ b/stanza/pipeline/external/sudachipy.py
@@ -42,11 +42,15 @@ class SudachiPyTokenizer(ProcessorVariant):
         self.tokenizer = dictionary.Dictionary().create()
         self.no_ssplit = config.get('no_ssplit', False)
 
-    def process(self, text):
+    def process(self, document):
         """ Tokenize a document with the SudachiPy tokenizer and wrap the results into a Doc object.
         """
+        if isinstance(document, doc.Document):
+            text = document.text
+        else:
+            text = document
         if not isinstance(text, str):
-            raise Exception("Must supply a string to the SudachiPy tokenizer.")
+            raise Exception("Must supply a string or Stanza Document object to the SudachiPy tokenizer.")
 
         # we use the default sudachipy tokenization mode (i.e., mode C)
         # more config needs to be added to support other modes

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -113,12 +113,13 @@ class TokenizeProcessor(UDProcessor):
             thisdoc.sentences = sentences
             for sent in sentences:
                 # fix doc back pointers for sentences
-                sent.doc = thisdoc
+                sent._doc = thisdoc
 
-                # fix char offsets for tokens
+                # fix char offsets for tokens and words
                 for token in sent.tokens:
-                    token.misc = token.misc.replace(f"{doc.START_CHAR}={token.start_char}", f"{doc.START_CHAR}={token.start_char - charoffset}")
-                    token.misc = token.misc.replace(f"{doc.END_CHAR}={token.end_char}", f"{doc.END_CHAR}={token.end_char - charoffset}")
+                    token._misc = token._misc.replace(f"{doc.START_CHAR}={token.start_char}", f"{doc.START_CHAR}={token.start_char - charoffset}")
+                    token._misc = token._misc.replace(f"{doc.END_CHAR}={token.end_char}", f"{doc.END_CHAR}={token.end_char - charoffset}")
+                    token.words[0]._misc = token._misc
                     token._start_char -= charoffset
                     token._end_char -= charoffset
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -115,7 +115,7 @@ class CoolLemmatizer(ProcessorVariant):
         return document
 
 def test_register_processor_variant_with_override():
-    nlp = stanza.Pipeline(dir=TEST_MODELS_DIR, lang='en', processors={"tokenize": "ewt", "pos": "ewt", "lemma": "cool"}, package=None)
+    nlp = stanza.Pipeline(dir=TEST_MODELS_DIR, lang='en', processors={"tokenize": "combined", "pos": "combined", "lemma": "cool"}, package=None)
     doc = nlp(EN_DOC)
     assert EN_DOC_COOL_LEMMAS == '\n\n'.join(sent.tokens_string() for sent in doc.sentences)
 

--- a/tests/test_english_pipeline.py
+++ b/tests/test_english_pipeline.py
@@ -109,6 +109,30 @@ EN_DOC_CONLLU_GOLD = """
 
 """.lstrip()
 
+EN_DOC_CONLLU_GOLD_MULTIDOC = """
+1	Barack	Barack	PROPN	NNP	Number=Sing	4	nsubj:pass	_	start_char=0|end_char=6
+2	Obama	Obama	PROPN	NNP	Number=Sing	1	flat	_	start_char=7|end_char=12
+3	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux:pass	_	start_char=13|end_char=16
+4	born	bear	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	start_char=17|end_char=21
+5	in	in	ADP	IN	_	6	case	_	start_char=22|end_char=24
+6	Hawaii	Hawaii	PROPN	NNP	Number=Sing	4	obl	_	start_char=25|end_char=31
+7	.	.	PUNCT	.	_	4	punct	_	start_char=31|end_char=32
+
+1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj:pass	_	start_char=0|end_char=2
+2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	start_char=3|end_char=6
+3	elected	elect	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	start_char=7|end_char=14
+4	president	president	NOUN	NN	Number=Sing	3	xcomp	_	start_char=15|end_char=24
+5	in	in	ADP	IN	_	6	case	_	start_char=25|end_char=27
+6	2008	2008	NUM	CD	NumType=Card	3	obl	_	start_char=28|end_char=32
+7	.	.	PUNCT	.	_	3	punct	_	start_char=32|end_char=33
+
+1	Obama	Obama	PROPN	NNP	Number=Sing	2	nsubj	_	start_char=0|end_char=5
+2	attended	attend	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	start_char=6|end_char=14
+3	Harvard	Harvard	PROPN	NNP	Number=Sing	2	obj	_	start_char=15|end_char=22
+4	.	.	PUNCT	.	_	2	punct	_	start_char=22|end_char=23
+
+""".lstrip()
+
 
 @pytest.fixture(scope="module")
 def processed_doc():
@@ -145,6 +169,9 @@ def processed_multidoc():
     nlp = stanza.Pipeline(dir=TEST_MODELS_DIR)
     return nlp(docs)
 
+
+def test_conllu_multidoc(processed_multidoc):
+    assert "".join([CoNLL.conll_as_string(CoNLL.convert_dict(doc.to_dict())) for doc in processed_multidoc]) == EN_DOC_CONLLU_GOLD_MULTIDOC
 
 def test_tokens_multidoc(processed_multidoc):
     assert "\n\n".join([sent.tokens_string() for processed_doc in processed_multidoc for sent in processed_doc.sentences]) == EN_DOC_TOKENS_GOLD

--- a/tests/test_english_pipeline.py
+++ b/tests/test_english_pipeline.py
@@ -157,3 +157,15 @@ def test_words_multidoc(processed_multidoc):
 def test_dependency_parse_multidoc(processed_multidoc):
     assert "\n\n".join([sent.dependencies_string() for processed_doc in processed_multidoc for sent in processed_doc.sentences]) == \
            EN_DOC_DEPENDENCY_PARSES_GOLD
+
+
+@pytest.fixture(scope="module")
+def processed_multidoc_variant():
+    """ Document created by running full English pipeline on a few sentences """
+    docs = [Document([], text=t) for t in EN_DOCS]
+    nlp = stanza.Pipeline(dir=TEST_MODELS_DIR, processors={'tokenize': 'spacy'})
+    return nlp(docs)
+
+def test_dependency_parse_multidoc_variant(processed_multidoc_variant):
+    assert "\n\n".join([sent.dependencies_string() for processed_doc in processed_multidoc_variant for sent in processed_doc.sentences]) == \
+           EN_DOC_DEPENDENCY_PARSES_GOLD

--- a/tests/test_english_pipeline.py
+++ b/tests/test_english_pipeline.py
@@ -9,7 +9,7 @@ from stanza.models.common.doc import Document
 
 from tests import *
 
-pytestmark = pytest.mark.pipeline
+pytestmark = [pytest.mark.pipeline, pytest.mark.travis]
 
 # data for testing
 EN_DOC = "Barack Obama was born in Hawaii.  He was elected president in 2008.  Obama attended Harvard."

--- a/tests/test_english_pipeline.py
+++ b/tests/test_english_pipeline.py
@@ -27,8 +27,8 @@ EN_DOC_TOKENS_GOLD = """
 
 <Token id=1;words=[<Word id=1;text=He;lemma=he;upos=PRON;xpos=PRP;feats=Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs;head=3;deprel=nsubj:pass>]>
 <Token id=2;words=[<Word id=2;text=was;lemma=be;upos=AUX;xpos=VBD;feats=Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin;head=3;deprel=aux:pass>]>
-<Token id=3;words=[<Word id=3;text=elected;lemma=elect;upos=VERB;xpos=VBN;feats=Tense=Past|VerbForm=Part|Voice=Pass;head=0;deprel=root>]>
-<Token id=4;words=[<Word id=4;text=president;lemma=president;upos=PROPN;xpos=NNP;feats=Number=Sing;head=3;deprel=xcomp>]>
+<Token id=3;words=[<Word id=3;text=elected;lemma=elect;upos=VERB;xpos=VBN;feats=Tense=Past|VerbForm=Part;head=0;deprel=root>]>
+<Token id=4;words=[<Word id=4;text=president;lemma=president;upos=NOUN;xpos=NN;feats=Number=Sing;head=3;deprel=xcomp>]>
 <Token id=5;words=[<Word id=5;text=in;lemma=in;upos=ADP;xpos=IN;head=6;deprel=case>]>
 <Token id=6;words=[<Word id=6;text=2008;lemma=2008;upos=NUM;xpos=CD;feats=NumType=Card;head=3;deprel=obl>]>
 <Token id=7;words=[<Word id=7;text=.;lemma=.;upos=PUNCT;xpos=.;head=3;deprel=punct>]>
@@ -50,8 +50,8 @@ EN_DOC_WORDS_GOLD = """
 
 <Word id=1;text=He;lemma=he;upos=PRON;xpos=PRP;feats=Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs;head=3;deprel=nsubj:pass>
 <Word id=2;text=was;lemma=be;upos=AUX;xpos=VBD;feats=Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin;head=3;deprel=aux:pass>
-<Word id=3;text=elected;lemma=elect;upos=VERB;xpos=VBN;feats=Tense=Past|VerbForm=Part|Voice=Pass;head=0;deprel=root>
-<Word id=4;text=president;lemma=president;upos=PROPN;xpos=NNP;feats=Number=Sing;head=3;deprel=xcomp>
+<Word id=3;text=elected;lemma=elect;upos=VERB;xpos=VBN;feats=Tense=Past|VerbForm=Part;head=0;deprel=root>
+<Word id=4;text=president;lemma=president;upos=NOUN;xpos=NN;feats=Number=Sing;head=3;deprel=xcomp>
 <Word id=5;text=in;lemma=in;upos=ADP;xpos=IN;head=6;deprel=case>
 <Word id=6;text=2008;lemma=2008;upos=NUM;xpos=CD;feats=NumType=Card;head=3;deprel=obl>
 <Word id=7;text=.;lemma=.;upos=PUNCT;xpos=.;head=3;deprel=punct>
@@ -96,8 +96,8 @@ EN_DOC_CONLLU_GOLD = """
 
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj:pass	_	start_char=34|end_char=36
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	start_char=37|end_char=40
-3	elected	elect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	start_char=41|end_char=48
-4	president	president	PROPN	NNP	Number=Sing	3	xcomp	_	start_char=49|end_char=58
+3	elected	elect	VERB	VBN	Tense=Past|VerbForm=Part	0	root	_	start_char=41|end_char=48
+4	president	president	NOUN	NN	Number=Sing	3	xcomp	_	start_char=49|end_char=58
 5	in	in	ADP	IN	_	6	case	_	start_char=59|end_char=61
 6	2008	2008	NUM	CD	NumType=Card	3	obl	_	start_char=62|end_char=66
 7	.	.	PUNCT	.	_	3	punct	_	start_char=66|end_char=67

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -238,6 +238,16 @@ def test_pretokenized():
     assert EN_DOC_PRETOKENIZED_LIST_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
 
+def test_pretokenized_multidoc():
+    nlp = stanza.Pipeline(**{'processors': 'tokenize', 'dir': TEST_MODELS_DIR, 'lang': 'en',
+                                  'tokenize_pretokenized': True})
+    doc = nlp(EN_DOC_PRETOKENIZED)
+    assert EN_DOC_PRETOKENIZED_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
+    assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
+    doc = nlp([stanza.Document([], text=EN_DOC_PRETOKENIZED_LIST)])[0]
+    assert EN_DOC_PRETOKENIZED_LIST_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
+    assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
+
 def test_no_ssplit():
     nlp = stanza.Pipeline(**{'processors': 'tokenize', 'dir': TEST_MODELS_DIR, 'lang': 'en',
                                   'tokenize_no_ssplit': True})


### PR DESCRIPTION
## Description
This PR aims at providing a transparent `bulk_process` interface for processors that operate on the sentence-level to batch across documents for optimized speed, and implements cross-document batching for the tokenizer, which doesn't operate on the sentence level.

## Fixes Issues
Could help significantly with #550, especially in cases where the user wishes to process a large collection of short documents.

## Unit test coverage
Covered by existing tests, also added new tests in `tests/test_english_pipeline.py` for character offsets in multi-document mode (`test_conllu_multidoc`) and processor variants in multi-document mode (`test_dependency_parse_multidoc_variant`).

## Known breaking changes/behaviors
N/A
