### PR TITLE
Pytorch dataloader

### DIFF
--- a/stanza/models/tokenization/torch_data.py
+++ b/stanza/models/tokenization/torch_data.py
@@ -1,0 +1,37 @@
+from torch.utils.data import Dataset
+from stanza.models.tokenization.data import DataLoader
+import torch
+
+
+class DocsDataset(Dataset):
+    def __init__(self, docs, transform):
+        self.docs = docs
+        self.transformtion = transform
+
+    def __len__(self):
+        return len(self.docs)
+
+    def __getitem__(self, index):
+
+        text = self.docs[index].text
+        units, features = self.transformtion(text)
+
+        units = torch.LongTensor(units)
+        features = torch.LongTensor(features)
+
+        return units, features
+
+
+class transform():
+    """Implements function next from data.py (guess its preparing batches)"""
+    def __init__(self, config, vocab):
+        self.config = config
+        self.vocab = vocab
+
+    def __call__(self, text):
+        d = DataLoader(self.config, input_text=text, vocab=self.vocab, evaluation=True)
+        units, _, features, _ = d.next()
+        units = units[0].numpy()
+        features = features[0].numpy()
+
+        return units, features

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -121,7 +121,7 @@ class TokenizeProcessor(UDProcessor):
 
             _, predictions = torch.max(self.trainer.model(units_tensors, features_tensors), 1)
             predictions = predictions.cpu().tolist()
-            # print(predictions)
+            #print(predictions)
 
 
         return []


### PR DESCRIPTION
## Description
A pytorch-based dataloader and transformation for faster tokenization inferencing implementing the bulk_process mechanism. Makes use of batch-wise model inferencing, multiprocessed dataloader and tranformations to prepare the data. Currently, only the docs forward pass through the model is implemented. I have no glue how your code to convert the neural network results back to a tokenization result works (the code in tokenization/utils/output_prediction line 144 on).
I had to implemented the data preparation in an ugly way. Currently, it is realized as a transformation (which is automatically multiprocessed by pytorch which is nice) called transform(). This transformation calls your DataLoader and its next() function (which is ugly). However, I suggest to reimplement the functionality of next() directly into the transformation. I wasn't able to do it.
I tested this on one of our server using 8 workers and a batch size of 256 on100k documents. Inferencing is more than 20x faster (21s vs. 443s) than the standard bulk_process mechanism (as mentioned, the conversion back to tokens is not implemented yet).
All other parts of stanza using pytorch models can use almost the same logic to inference/train their models. 

## Fixes Issues
#615 

## Unit test coverage
Could not be tested so far.

## Known breaking changes/behaviors
No.
