### PR TITLE
Opts

### DIFF
--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -122,12 +122,12 @@ class TokenizeProcessor(UDProcessor):
 
                 # fix char offsets for tokens and words
                 for token in sent.tokens:
-                    token._misc = token._misc.replace(f"{doc.START_CHAR}={token.start_char}", f"{doc.START_CHAR}={token.start_char - charoffset}")
-                    token._misc = token._misc.replace(f"{doc.END_CHAR}={token.end_char}", f"{doc.END_CHAR}={token.end_char - charoffset}")
                     token._start_char -= charoffset
                     token._end_char -= charoffset
                     if token.words:  # not-yet-processed MWT can leave empty tokens
-                        token.words[0]._misc = token._misc
+                        for word in token.words:
+                            word._start_char -= charoffset
+                            word._end_char -= charoffset
 
             thisdoc.num_tokens = sum(len(sent.tokens) for sent in sentences)
             thisdoc.num_words = sum(len(sent.words) for sent in sentences)

--- a/stanza/utils/conll.py
+++ b/stanza/utils/conll.py
@@ -6,6 +6,7 @@ import io
 
 FIELD_NUM = 10
 
+# TODO: unify this list with the list in common/doc.py
 ID = 'id'
 TEXT = 'text'
 LEMMA = 'lemma'
@@ -16,6 +17,9 @@ HEAD = 'head'
 DEPREL = 'deprel'
 DEPS = 'deps'
 MISC = 'misc'
+NER = 'ner'
+START_CHAR = 'start_char'
+END_CHAR = 'end_char'
 FIELD_TO_IDX = {ID: 0, TEXT: 1, LEMMA: 2, UPOS: 3, XPOS: 4, FEATS: 5, HEAD: 6, DEPREL: 7, DEPS: 8, MISC: 9}
 
 class CoNLL:
@@ -122,11 +126,20 @@ class CoNLL:
         Output: CoNLL-U format token, which is a list for the token.
         """
         token_conll = ['_' for i in range(FIELD_NUM)]
+        misc = []
         for key in token_dict:
-            if key == ID:
+            if key == START_CHAR or key == END_CHAR:
+                misc.append("{}={}".format(key, token_dict[key]))
+            elif key == MISC:
+                misc.append(token_dict[key])
+            elif key == ID:
                 token_conll[FIELD_TO_IDX[key]] = '-'.join([str(x) for x in token_dict[key]]) if isinstance(token_dict[key], tuple) else str(token_dict[key])
             elif key in FIELD_TO_IDX:
                 token_conll[FIELD_TO_IDX[key]] = str(token_dict[key])
+        if misc:
+            token_conll[FIELD_TO_IDX[MISC]] = "|".join(misc)
+        else:
+            token_conll[FIELD_TO_IDX[MISC]] = '_'
         # when a word (not mwt token) without head is found, we insert dummy head as required by the UD eval script
         if '-' not in token_conll[FIELD_TO_IDX[ID]] and HEAD not in token_dict:
             token_conll[FIELD_TO_IDX[HEAD]] = str(int(token_dict[ID] if isinstance(token_dict[ID], int) else token_dict[ID][0]) - 1) # evaluation script requires head: int

--- a/tests/test_data_conversion.py
+++ b/tests/test_data_conversion.py
@@ -43,6 +43,12 @@ def test_dict_to_conll():
     assert conll == CONLL
 
 def test_dict_to_doc_and_doc_to_dict():
+    """
+    Test the conversion from raw dict to Document and back
+    This code path will first turn start_char|end_char into start_char & end_char fields in the Document
+    That version to a dict will have separate fields for each of those
+    Finally, the conversion from that dict to a list of conll entries should convert that back to misc
+    """
     doc = Document(DICT)
     dicts = doc.to_dict()
     dicts_tupleid = []
@@ -52,4 +58,5 @@ def test_dict_to_doc_and_doc_to_dict():
             item['id'] = item['id'] if isinstance(item['id'], tuple) else (item['id'], )
             items.append(item)
         dicts_tupleid.append(items)
-    assert dicts_tupleid == DICT
+    conll = CoNLL.convert_dict(DICT)
+    assert conll == CONLL

--- a/tests/test_data_conversion.py
+++ b/tests/test_data_conversion.py
@@ -11,8 +11,28 @@ from tests import *
 pytestmark = pytest.mark.pipeline
 
 # data for testing
-CONLL = [[['1', 'Nous', 'il', 'PRON', '_', 'Number=Plur|Person=1|PronType=Prs', '3', 'nsubj', '_', 'start_char=0|end_char=4'], ['2', 'avons', 'avoir', 'AUX', '_', 'Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin', '3', 'aux:tense', '_', 'start_char=5|end_char=10'], ['3', 'atteint', 'atteindre', 'VERB', '_', 'Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part', '0', 'root', '_', 'start_char=11|end_char=18'], ['4', 'la', 'le', 'DET', '_', 'Definite=Def|Gender=Fem|Number=Sing|PronType=Art', '5', 'det', '_', 'start_char=19|end_char=21'], ['5', 'fin', 'fin', 'NOUN', '_', 'Gender=Fem|Number=Sing', '3', 'obj', '_', 'start_char=22|end_char=25'], ['6-7', 'du', '_', '_', '_', '_', '_', '_', '_', 'start_char=26|end_char=28'], ['6', 'de', 'de', 'ADP', '_', '_', '8', 'case', '_', '_'], ['7', 'le', 'le', 'DET', '_', 'Definite=Def|Gender=Masc|Number=Sing|PronType=Art', '8', 'det', '_', '_'], ['8', 'sentier', 'sentier', 'NOUN', '_', 'Gender=Masc|Number=Sing', '5', 'nmod', '_', 'start_char=29|end_char=36'], ['9', '.', '.', 'PUNCT', '_', '_', '3', 'punct', '_', 'start_char=36|end_char=37']]]
-DICT = [[{'id': (1,), 'text': 'Nous', 'lemma': 'il', 'upos': 'PRON', 'feats': 'Number=Plur|Person=1|PronType=Prs', 'head': 3, 'deprel': 'nsubj', 'misc': 'start_char=0|end_char=4'}, {'id': (2,), 'text': 'avons', 'lemma': 'avoir', 'upos': 'AUX', 'feats': 'Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin', 'head': 3, 'deprel': 'aux:tense', 'misc': 'start_char=5|end_char=10'}, {'id': (3,), 'text': 'atteint', 'lemma': 'atteindre', 'upos': 'VERB', 'feats': 'Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part', 'head': 0, 'deprel': 'root', 'misc': 'start_char=11|end_char=18'}, {'id': (4,), 'text': 'la', 'lemma': 'le', 'upos': 'DET', 'feats': 'Definite=Def|Gender=Fem|Number=Sing|PronType=Art', 'head': 5, 'deprel': 'det', 'misc': 'start_char=19|end_char=21'}, {'id': (5,), 'text': 'fin', 'lemma': 'fin', 'upos': 'NOUN', 'feats': 'Gender=Fem|Number=Sing', 'head': 3, 'deprel': 'obj', 'misc': 'start_char=22|end_char=25'}, {'id': (6, 7), 'text': 'du', 'misc': 'start_char=26|end_char=28'}, {'id': (6,), 'text': 'de', 'lemma': 'de', 'upos': 'ADP', 'head': 8, 'deprel': 'case'}, {'id': (7,), 'text': 'le', 'lemma': 'le', 'upos': 'DET', 'feats': 'Definite=Def|Gender=Masc|Number=Sing|PronType=Art', 'head': 8, 'deprel': 'det'}, {'id': (8,), 'text': 'sentier', 'lemma': 'sentier', 'upos': 'NOUN', 'feats': 'Gender=Masc|Number=Sing', 'head': 5, 'deprel': 'nmod', 'misc': 'start_char=29|end_char=36'}, {'id': (9,), 'text': '.', 'lemma': '.', 'upos': 'PUNCT', 'head': 3, 'deprel': 'punct', 'misc': 'start_char=36|end_char=37'}]] 
+CONLL = [[['1', 'Nous', 'il', 'PRON', '_', 'Number=Plur|Person=1|PronType=Prs', '3', 'nsubj', '_', 'start_char=0|end_char=4'],
+          ['2', 'avons', 'avoir', 'AUX', '_', 'Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin', '3', 'aux:tense', '_', 'start_char=5|end_char=10'],
+          ['3', 'atteint', 'atteindre', 'VERB', '_', 'Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part', '0', 'root', '_', 'start_char=11|end_char=18'],
+          ['4', 'la', 'le', 'DET', '_', 'Definite=Def|Gender=Fem|Number=Sing|PronType=Art', '5', 'det', '_', 'start_char=19|end_char=21'],
+          ['5', 'fin', 'fin', 'NOUN', '_', 'Gender=Fem|Number=Sing', '3', 'obj', '_', 'start_char=22|end_char=25'],
+          ['6-7', 'du', '_', '_', '_', '_', '_', '_', '_', 'start_char=26|end_char=28'],
+          ['6', 'de', 'de', 'ADP', '_', '_', '8', 'case', '_', '_'],
+          ['7', 'le', 'le', 'DET', '_', 'Definite=Def|Gender=Masc|Number=Sing|PronType=Art', '8', 'det', '_', '_'],
+          ['8', 'sentier', 'sentier', 'NOUN', '_', 'Gender=Masc|Number=Sing', '5', 'nmod', '_', 'start_char=29|end_char=36'],
+          ['9', '.', '.', 'PUNCT', '_', '_', '3', 'punct', '_', 'start_char=36|end_char=37']]]
+
+
+DICT = [[{'id': (1,), 'text': 'Nous', 'lemma': 'il', 'upos': 'PRON', 'feats': 'Number=Plur|Person=1|PronType=Prs', 'head': 3, 'deprel': 'nsubj', 'misc': 'start_char=0|end_char=4'},
+         {'id': (2,), 'text': 'avons', 'lemma': 'avoir', 'upos': 'AUX', 'feats': 'Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin', 'head': 3, 'deprel': 'aux:tense', 'misc': 'start_char=5|end_char=10'},
+         {'id': (3,), 'text': 'atteint', 'lemma': 'atteindre', 'upos': 'VERB', 'feats': 'Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part', 'head': 0, 'deprel': 'root', 'misc': 'start_char=11|end_char=18'},
+         {'id': (4,), 'text': 'la', 'lemma': 'le', 'upos': 'DET', 'feats': 'Definite=Def|Gender=Fem|Number=Sing|PronType=Art', 'head': 5, 'deprel': 'det', 'misc': 'start_char=19|end_char=21'},
+         {'id': (5,), 'text': 'fin', 'lemma': 'fin', 'upos': 'NOUN', 'feats': 'Gender=Fem|Number=Sing', 'head': 3, 'deprel': 'obj', 'misc': 'start_char=22|end_char=25'},
+         {'id': (6, 7), 'text': 'du', 'misc': 'start_char=26|end_char=28'},
+         {'id': (6,), 'text': 'de', 'lemma': 'de', 'upos': 'ADP', 'head': 8, 'deprel': 'case'},
+         {'id': (7,), 'text': 'le', 'lemma': 'le', 'upos': 'DET', 'feats': 'Definite=Def|Gender=Masc|Number=Sing|PronType=Art', 'head': 8, 'deprel': 'det'},
+         {'id': (8,), 'text': 'sentier', 'lemma': 'sentier', 'upos': 'NOUN', 'feats': 'Gender=Masc|Number=Sing', 'head': 5, 'deprel': 'nmod', 'misc': 'start_char=29|end_char=36'},
+         {'id': (9,), 'text': '.', 'lemma': '.', 'upos': 'PUNCT', 'head': 3, 'deprel': 'punct', 'misc': 'start_char=36|end_char=37'}]]
 
 def test_conll_to_dict():
     dicts = CoNLL.convert_conll(CONLL)

--- a/tests/test_french_pipeline.py
+++ b/tests/test_french_pipeline.py
@@ -27,7 +27,8 @@ EXPECTED_RESULT = """
       "upos": "ADV",
       "head": 3,
       "deprel": "advmod",
-      "misc": "start_char=0|end_char=5"
+      "start_char": 0,
+      "end_char": 5
     },
     {
       "id": 2,
@@ -36,7 +37,8 @@ EXPECTED_RESULT = """
       "upos": "ADV",
       "head": 3,
       "deprel": "advmod",
-      "misc": "start_char=6|end_char=12"
+      "start_char": 6,
+      "end_char": 12
     },
     {
       "id": 3,
@@ -46,7 +48,8 @@ EXPECTED_RESULT = """
       "feats": "Gender=Masc|Number=Sing",
       "head": 11,
       "deprel": "advcl",
-      "misc": "start_char=13|end_char=20"
+      "start_char": 13,
+      "end_char": 20
     },
     {
       "id": [
@@ -54,7 +57,8 @@ EXPECTED_RESULT = """
         5
       ],
       "text": "du",
-      "misc": "start_char=21|end_char=23"
+      "start_char": 21,
+      "end_char": 23
     },
     {
       "id": 4,
@@ -81,7 +85,8 @@ EXPECTED_RESULT = """
       "feats": "Gender=Masc|Number=Sing",
       "head": 7,
       "deprel": "amod",
-      "misc": "start_char=24|end_char=29"
+      "start_char": 24,
+      "end_char": 29
     },
     {
       "id": 7,
@@ -91,7 +96,8 @@ EXPECTED_RESULT = """
       "feats": "Gender=Masc|Number=Sing",
       "head": 3,
       "deprel": "obl:arg",
-      "misc": "start_char=30|end_char=36"
+      "start_char": 30,
+      "end_char": 36
     },
     {
       "id": 8,
@@ -100,7 +106,8 @@ EXPECTED_RESULT = """
       "upos": "PUNCT",
       "head": 3,
       "deprel": "punct",
-      "misc": "start_char=36|end_char=37"
+      "start_char": 36,
+      "end_char": 37
     },
     {
       "id": 9,
@@ -109,7 +116,8 @@ EXPECTED_RESULT = """
       "upos": "PROPN",
       "head": 11,
       "deprel": "nsubj",
-      "misc": "start_char=38|end_char=46"
+      "start_char": 38,
+      "end_char": 46
     },
     {
       "id": 10,
@@ -118,7 +126,8 @@ EXPECTED_RESULT = """
       "upos": "PROPN",
       "head": 9,
       "deprel": "flat:name",
-      "misc": "start_char=47|end_char=53"
+      "start_char": 47,
+      "end_char": 53
     },
     {
       "id": 11,
@@ -128,7 +137,8 @@ EXPECTED_RESULT = """
       "feats": "Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin",
       "head": 0,
       "deprel": "root",
-      "misc": "start_char=54|end_char=61"
+      "start_char": 54,
+      "end_char": 61
     },
     {
       "id": 12,
@@ -137,7 +147,8 @@ EXPECTED_RESULT = """
       "upos": "ADP",
       "head": 13,
       "deprel": "case",
-      "misc": "start_char=62|end_char=64"
+      "start_char": 62,
+      "end_char": 64
     },
     {
       "id": 13,
@@ -147,7 +158,8 @@ EXPECTED_RESULT = """
       "feats": "Number=Plur",
       "head": 11,
       "deprel": "obl:mod",
-      "misc": "start_char=65|end_char=69"
+      "start_char": 65,
+      "end_char": 69
     },
     {
       "id": 14,
@@ -157,7 +169,8 @@ EXPECTED_RESULT = """
       "feats": "Gender=Masc|Number=Sing",
       "head": 11,
       "deprel": "xcomp:pred",
-      "misc": "start_char=70|end_char=78"
+      "start_char": 70,
+      "end_char": 78
     },
     {
       "id": 15,
@@ -166,7 +179,8 @@ EXPECTED_RESULT = """
       "upos": "ADP",
       "head": 17,
       "deprel": "case",
-      "misc": "start_char=79|end_char=81"
+      "start_char": 79,
+      "end_char": 81
     },
     {
       "id": 16,
@@ -176,7 +190,8 @@ EXPECTED_RESULT = """
       "feats": "Definite=Def|Number=Sing|PronType=Art",
       "head": 17,
       "deprel": "det",
-      "misc": "start_char=82|end_char=84"
+      "start_char": 82,
+      "end_char": 84
     },
     {
       "id": 17,
@@ -186,7 +201,8 @@ EXPECTED_RESULT = """
       "feats": "Gender=Fem|Number=Sing",
       "head": 14,
       "deprel": "nmod",
-      "misc": "start_char=84|end_char=92"
+      "start_char": 84,
+      "end_char": 92
     },
     {
       "id": 18,
@@ -195,7 +211,8 @@ EXPECTED_RESULT = """
       "upos": "PUNCT",
       "head": 21,
       "deprel": "punct",
-      "misc": "start_char=92|end_char=93"
+      "start_char": 92,
+      "end_char": 93
     },
     {
       "id": 19,
@@ -204,7 +221,8 @@ EXPECTED_RESULT = """
       "upos": "ADP",
       "head": 21,
       "deprel": "case",
-      "misc": "start_char=94|end_char=96"
+      "start_char": 94,
+      "end_char": 96
     },
     {
       "id": 20,
@@ -214,7 +232,8 @@ EXPECTED_RESULT = """
       "feats": "Definite=Def|Number=Sing|PronType=Art",
       "head": 21,
       "deprel": "det",
-      "misc": "start_char=97|end_char=99"
+      "start_char": 97,
+      "end_char": 99
     },
     {
       "id": 21,
@@ -224,7 +243,8 @@ EXPECTED_RESULT = """
       "feats": "Gender=Fem|Number=Sing",
       "head": 17,
       "deprel": "conj",
-      "misc": "start_char=99|end_char=108"
+      "start_char": 99,
+      "end_char": 108
     },
     {
       "id": 22,
@@ -233,7 +253,8 @@ EXPECTED_RESULT = """
       "upos": "CCONJ",
       "head": 25,
       "deprel": "cc",
-      "misc": "start_char=109|end_char=111"
+      "start_char": 109,
+      "end_char": 111
     },
     {
       "id": [
@@ -241,7 +262,8 @@ EXPECTED_RESULT = """
         24
       ],
       "text": "du",
-      "misc": "start_char=112|end_char=114"
+      "start_char": 112,
+      "end_char": 114
     },
     {
       "id": 23,
@@ -268,7 +290,8 @@ EXPECTED_RESULT = """
       "feats": "Gender=Masc|Number=Sing",
       "head": 17,
       "deprel": "conj",
-      "misc": "start_char=115|end_char=124"
+      "start_char": 115,
+      "end_char": 124
     },
     {
       "id": 26,
@@ -277,7 +300,8 @@ EXPECTED_RESULT = """
       "upos": "PUNCT",
       "head": 11,
       "deprel": "punct",
-      "misc": "start_char=124|end_char=125"
+      "start_char": 124,
+      "end_char": 125
     }
   ]
 ]


### PR DESCRIPTION
Splitting out the start_char and end_char from misc actually saves about 8% of the time spent in the tokenizer simply by not creating and then splitting strings