### PR TITLE
Read as nbsp

### DIFF
--- a/stanza/models/common/pretrain.py
+++ b/stanza/models/common/pretrain.py
@@ -144,7 +144,9 @@ class Pretrain:
 
                 line = tab_space_pattern.split((line.rstrip()))
                 emb[i+len(VOCAB_PREFIX)-1-failed, :] = [float(x) for x in line[-cols:]]
-                words.append(' '.join(line[:-cols]))
+                # if there were word pieces separated with spaces, rejoin them with nbsp instead
+                # this way, the normalize_unit method in vocab.py can find the word at test time
+                words.append('\xa0'.join(line[:-cols]))
         return words, emb, failed
 
 

--- a/tests/test_pretrain.py
+++ b/tests/test_pretrain.py
@@ -60,3 +60,30 @@ def test_resave_pretrain():
         check_embedding(pt3['emb'])
     finally:
         os.unlink(test_pt_file.name)
+
+SPACE_PRETRAIN="""
+3 4
+unban mox 1 2 3 4
+opal 5 6 7 8
+foo 9 10 11 12
+""".strip()
+
+def test_whitespace():
+    """
+    Test reading a pretrain with an ascii space in it
+
+    The vocab word with a space in it should have the correct number
+    of dimensions read, with the space converted to nbsp
+    """
+    test_txt_file = tempfile.NamedTemporaryFile(dir=f'{TEST_WORKING_DIR}/out', suffix=".txt", delete=False)
+    try:
+        test_txt_file.write(SPACE_PRETRAIN.encode())
+        test_txt_file.close()
+
+        pt = pretrain.Pretrain(vec_filename=test_txt_file.name, save_to_file=False)
+        check_embedding(pt.emb)
+        assert "unban\xa0mox" in pt.vocab
+        # this one also works because of the normalize_text in vocab.py
+        assert "unban mox" in pt.vocab
+    finally:
+        os.unlink(test_txt_file.name)


### PR DESCRIPTION
Read an embedding vocab with spaces as nbsp instead of ascii space.  Includes a toy test of this behavior