### PR TITLE
Fix misc field

### DIFF
--- a/stanza/utils/conll.py
+++ b/stanza/utils/conll.py
@@ -144,7 +144,10 @@ class CoNLL:
             if key == START_CHAR or key == END_CHAR:
                 misc.append("{}={}".format(key, token_dict[key]))
             elif key == MISC:
-                misc.append(token_dict[key])
+                # avoid appending a blank misc entry.
+                # otherwise the resulting misc field in the conll doc will wind up being blank text
+                if token_dict[key]:
+                    misc.append(token_dict[key])
             elif key == ID:
                 token_conll[FIELD_TO_IDX[key]] = '-'.join([str(x) for x in token_dict[key]]) if isinstance(token_dict[key], tuple) else str(token_dict[key])
             elif key in FIELD_TO_IDX:

--- a/stanza/utils/conll.py
+++ b/stanza/utils/conll.py
@@ -37,7 +37,7 @@ class CoNLL:
         # f is open() or io.StringIO()
         doc, sent = [], []
         doc_comments, sent_comments = [], []
-        for line in f:
+        for line_idx, line in enumerate(f):
             line = line.strip()
             if len(line) == 0:
                 if len(sent) > 0:
@@ -53,7 +53,7 @@ class CoNLL:
                 if ignore_gapping and '.' in array[0]:
                     continue
                 assert len(array) == FIELD_NUM, \
-                        f"Cannot parse CoNLL line: expecting {FIELD_NUM} fields, {len(array)} found."
+                        f"Cannot parse CoNLL line {line_idx+1}: expecting {FIELD_NUM} fields, {len(array)} found.\n  {array}"
                 sent += [array]
         if len(sent) > 0:
             doc.append(sent)

--- a/tests/test_data_conversion.py
+++ b/tests/test_data_conversion.py
@@ -60,3 +60,43 @@ def test_dict_to_doc_and_doc_to_dict():
         dicts_tupleid.append(items)
     conll = CoNLL.convert_dict(DICT)
     assert conll == CONLL
+
+RUSSIAN_SAMPLE="""
+# sent_id = yandex.reviews-f-8xh5zqnmwak3t6p68y4rhwd4e0-1969-9253
+# genre = review
+# text = Как- то слишком мало цветов получают актёры после спектакля.
+1	Как	как-то	ADV	_	Degree=Pos|PronType=Ind	7	advmod	_	SpaceAfter=No
+2	-	-	PUNCT	_	_	3	punct	_	_
+3	то	то	PART	_	_	1	list	_	deprel=list:goeswith
+4	слишком	слишком	ADV	_	Degree=Pos	5	advmod	_	_
+5	мало	мало	ADV	_	Degree=Pos	6	advmod	_	_
+6	цветов	цветок	NOUN	_	Animacy=Inan|Case=Gen|Gender=Masc|Number=Plur	7	obj	_	_
+7	получают	получать	VERB	_	Aspect=Imp|Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin|Voice=Act	0	root	_	_
+8	актёры	актер	NOUN	_	Animacy=Anim|Case=Nom|Gender=Masc|Number=Plur	7	nsubj	_	_
+9	после	после	ADP	_	_	10	case	_	_
+10	спектакля	спектакль	NOUN	_	Animacy=Inan|Case=Gen|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
+11	.	.	PUNCT	_	_	7	punct	_	_
+""".strip()
+
+
+def test_doc_with_comments():
+    """
+    Test that a doc with comments gets converted back with comments
+    """
+    lines = RUSSIAN_SAMPLE.split("\n")
+
+    doc = CoNLL.conll2doc(input_str=RUSSIAN_SAMPLE)
+    assert len(doc.sentences) == 1
+    assert len(doc.sentences[0].comments) == 3
+    assert lines[0] == doc.sentences[0].comments[0]
+    assert lines[1] == doc.sentences[0].comments[1]
+    assert lines[2] == doc.sentences[0].comments[2]
+
+    sentences = CoNLL.doc2conll(doc)
+    assert len(sentences) == 1
+
+    sentence = sentences[0]
+    assert len(sentence) == 14
+    assert lines[0] == sentence[0]
+    assert lines[1] == sentence[1]
+    assert lines[2] == sentence[2]

--- a/tests/test_data_conversion.py
+++ b/tests/test_data_conversion.py
@@ -100,3 +100,19 @@ def test_doc_with_comments():
     assert lines[0] == sentence[0]
     assert lines[1] == sentence[1]
     assert lines[2] == sentence[2]
+
+def test_unusual_misc():
+    """
+    The above RUSSIAN_SAMPLE resulted in a blank misc field in one particular implementation of the conll code
+    (the below test would fail)
+    """
+    doc = CoNLL.conll2doc(input_str=RUSSIAN_SAMPLE)
+    sentences = CoNLL.doc2conll(doc)
+    assert len(sentences) == 1
+    assert len(sentences[0]) == 14
+
+    for word in sentences[0]:
+        pieces = word.split("\t")
+        assert len(pieces) == 1 or len(pieces) == 10
+        if len(pieces) == 10:
+            assert all(piece for piece in pieces)


### PR DESCRIPTION
Misc field would not print out correctly if there was an annotation in the misc column of the conll doc.  Fix this bug and add some more tests of the data conversion code