### PR TITLE
Sort and then unsort the text by length in the sentiment processor.  …

### DIFF
--- a/stanza/models/classifiers/cnn_classifier.py
+++ b/stanza/models/classifiers/cnn_classifier.py
@@ -12,6 +12,7 @@ import stanza.models.classifiers.classifier_args as classifier_args
 import stanza.models.classifiers.data as data
 from stanza.models.common.vocab import PAD_ID, UNK_ID
 from stanza.models.common.data import get_long_tensor, sort_all
+from stanza.models.common.utils import split_into_batches, sort_with_indices, unsort
 # TODO: move CharVocab to common
 from stanza.models.pos.vocab import CharVocab
 
@@ -445,9 +446,10 @@ def label_text(model, text, batch_size=None, reverse_label_map=None, device=None
 
     if batch_size is None:
         intervals = [(0, len(text))]
+        orig_idx = None
     else:
-        # TODO: results would be better if we sort by length and then unsort
-        intervals = [(i, min(i+batch_size, len(text))) for i in range(0, len(text), batch_size)]
+        text, orig_idx = sort_with_indices(text, key=len, reverse=True)
+        intervals = split_into_batches(text, batch_size)
     labels = []
     for interval in intervals:
         if interval[1] - interval[0] == 0:
@@ -456,6 +458,10 @@ def label_text(model, text, batch_size=None, reverse_label_map=None, device=None
         output = model(text[interval[0]:interval[1]], device)
         predicted = torch.argmax(output, dim=1)
         labels.extend(predicted.tolist())
+
+    if orig_idx:
+        text = unsort(text, orig_idx)
+        labels = unsort(labels, orig_idx)
 
     logger.debug("Found labels")
     for (label, sentence) in zip(labels, text):

--- a/stanza/pipeline/sentiment_processor.py
+++ b/stanza/pipeline/sentiment_processor.py
@@ -24,6 +24,9 @@ class SentimentProcessor(UDProcessor):
     # set of processor requirements for this processor
     REQUIRES_DEFAULT = set([TOKENIZE])
 
+    # default batch size, measured in words per batch
+    DEFAULT_BATCH_SIZE = 5000
+
     def _set_up_model(self, config, use_gpu):
         # get pretrained word vectors
         pretrain_path = config.get('pretrain_path', None)
@@ -37,7 +40,8 @@ class SentimentProcessor(UDProcessor):
                                           pretrain=self._pretrain,
                                           charmodel_forward=charmodel_forward,
                                           charmodel_backward=charmodel_backward)
-        self._batch_size = config.get('batch_size', None)
+        # batch size counted as words
+        self._batch_size = config.get('batch_size', SentimentProcessor.DEFAULT_BATCH_SIZE)
 
         # TODO: move this call to load()
         if use_gpu:

--- a/stanza/tests/test_pipeline_sentiment_processor.py
+++ b/stanza/tests/test_pipeline_sentiment_processor.py
@@ -1,0 +1,38 @@
+
+import pytest
+import stanza
+from stanza.utils.conll import CoNLL
+from stanza.models.common.doc import Document
+
+from stanza.tests import *
+
+pytestmark = [pytest.mark.pipeline, pytest.mark.travis]
+
+# data for testing
+EN_DOCS = ["Ragavan is terrible and should go away.",  "Today is okay.",  "Urza's Saga is great."]
+
+EN_DOC = "  ".join(EN_DOCS)
+
+EXPECTED = [0, 1, 2]
+
+@pytest.fixture(scope="module")
+def pipeline():
+    """
+    A reusable pipeline with the NER module
+    """
+    return stanza.Pipeline(dir=TEST_MODELS_DIR, processors="tokenize,sentiment")
+
+def test_simple(pipeline):
+    results = []
+    for text in EN_DOCS:
+        doc = pipeline(text)
+        assert len(doc.sentences) == 1
+        results.append(doc.sentences[0].sentiment)
+    assert EXPECTED == results
+
+def test_multiple_sentences(pipeline):
+    doc = pipeline(EN_DOC)
+    assert len(doc.sentences) == 3
+    results = [sentence.sentiment for sentence in doc.sentences]
+    assert EXPECTED == results
+

--- a/stanza/tests/test_utils.py
+++ b/stanza/tests/test_utils.py
@@ -75,3 +75,42 @@ def test_wordvec_type():
         with pytest.raises(FileNotFoundError):
             utils.get_wordvec_file(wordvec_dir=temp_dir, shorthand='en_foo')
 
+def test_sort_with_indices():
+    data = [[1, 2, 3], [4, 5], [6]]
+    ordered, orig_idx = utils.sort_with_indices(data, key=len)
+    assert ordered == ([6], [4, 5], [1, 2, 3])
+    assert orig_idx == (2, 1, 0)
+
+    unsorted = utils.unsort(ordered, orig_idx)
+    assert data == unsorted
+
+def test_split_into_batches():
+    data = []
+    for i in range(5):
+        data.append(["Unban", "mox", "opal", str(i)])
+
+    data.append(["Do", "n't", "ban", "Urza", "'s", "Saga", "that", "card", "is", "great"])
+    data.append(["Ban", "Ragavan"])
+
+    # small batches will put one element in each interval
+    batches = utils.split_into_batches(data, 5)
+    assert batches == [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
+
+    # this one has a batch interrupted in the middle by a large element
+    batches = utils.split_into_batches(data, 8)
+    assert batches == [(0, 2), (2, 4), (4, 5), (5, 6), (6, 7)]
+
+    # this one has the large element at the start of its own batch
+    batches = utils.split_into_batches(data[1:], 8)
+    assert batches == [(0, 2), (2, 4), (4, 5), (5, 6)]
+
+    # overloading the test!  assert that the key & reverse is working
+    ordered, orig_idx = utils.sort_with_indices(data, key=len, reverse=True)
+    assert [len(x) for x in ordered] == [10, 4, 4, 4, 4, 4, 2]
+
+    # this has the large element at the start
+    batches = utils.split_into_batches(ordered, 8)
+    assert batches == [(0, 1), (1, 3), (3, 5), (5, 7)]
+
+    # double check that unsort is working as expected
+    assert data == utils.unsort(ordered, orig_idx)


### PR DESCRIPTION
Sort and then unsort the text by length in the sentiment processor.  Use this to set a limit on processing length by text length.  Set the default batch limit to 5000.  Makes it so that a huge document doesn't default to using up the entire GPU
