### PR TITLE
Fix pickling issue on Windows with lambdas

### DIFF
--- a/stanza/models/classifiers/cnn_classifier.py
+++ b/stanza/models/classifiers/cnn_classifier.py
@@ -74,10 +74,7 @@ class CNNClassifier(nn.Module):
                                       charlm_projection = args.charlm_projection,
                                       model_type = 'CNNClassifier')
 
-        if args.char_lowercase:
-            self.char_case = lambda x: x.lower()
-        else:
-            self.char_case = lambda x: x
+        self.char_lowercase = args.char_lowercase
 
         self.unsaved_modules = []
 
@@ -171,7 +168,6 @@ class CNNClassifier(nn.Module):
 
         self.dropout = nn.Dropout(self.config.dropout)
 
-
     def add_unsaved_module(self, name, module):
         self.unsaved_modules += [name]
         setattr(self, name, module)
@@ -202,6 +198,8 @@ class CNNClassifier(nn.Module):
 
         return char_reps
 
+    def char_case(self, x: str) -> str:
+        return x.lower() if self.char_lowercase else x
 
     def forward(self, inputs, device=None):
         if not device:


### PR DESCRIPTION
## Description
Because the CNNClassifier contains two lambda functions to lower case a string in init, pickling fails on Windows.

## Fixes Issues
Fixes an issue I originally encountered when using `nlp.pipe()` of `spacy_stanza`, which uses multiprocessing under the hood. So it tries to pickle the model for new processes, but fails due to the lambdas. So this relates to https://github.com/explosion/spacy-stanza/issues/34

## Unit test coverage
Not necessary: the new added method has the same name as the original lambda property. Usage is identical as before. 
