### PR TITLE
Add mwt if tokenize is passed without MWT

### DIFF
--- a/stanza/resources/common.py
+++ b/stanza/resources/common.py
@@ -150,11 +150,30 @@ def sort_processors(processor_list):
                 sorted_list.append(item)
     return sorted_list
 
+def add_mwt(processors, resources, lang):
+    """Add mwt if tokenize is passed without mwt.
+
+    If tokenize is in the list, but mwt is not, and there is a corresponding
+    tokenize and mwt pair in the resources file, mwt is added so no missing
+    mwt errors are raised.
+    """
+    value = processors[TOKENIZE]
+    if value == "default" and MWT in resources[lang]['default_processors']:
+        logger.warning("Language %s package default expects mwt, which has been added", lang)
+        processors[MWT] = 'default'
+    elif (value in resources[lang][TOKENIZE]
+          and MWT in resources[lang]
+          and value in resources[lang][MWT]):
+        logger.warning("Language %s package %s expects mwt, which has been added", lang, value)
+        processors[MWT] = value
+
 def maintain_processor_list(resources, lang, package, processors):
     processor_list = {}
     # resolve processor models
     if processors:
         logger.debug(f'Processing parameter "processors"...')
+        if TOKENIZE in processors and MWT not in processors:
+            add_mwt(processors, resources, lang)
         for key, value in processors.items():
             assert(isinstance(key, str) and isinstance(value, str))
             if key not in PIPELINE_NAMES:

--- a/stanza/tests/test_installation.py
+++ b/stanza/tests/test_installation.py
@@ -37,3 +37,9 @@ def test_download_corenlp_models():
 
         dest_file = os.path.join(test_dir, f"stanford-corenlp-{version}-models-{model_name}.jar")
         assert os.path.isfile(dest_file), "Downloaded model file not found."
+
+def test_download_tokenize_mwt():
+    with tempfile.TemporaryDirectory(dir=".") as test_dir:
+        stanza.download("en", model_dir=test_dir, processors="tokenize", package="ewt", verbose=False)
+        pipeline = stanza.Pipeline("en", model_dir=test_dir, processors="tokenize", package="ewt")
+        assert isinstance(pipeline, stanza.Pipeline)


### PR DESCRIPTION
## Description
This PR fixes an issue where if `tokenize` processor is passed without `mwt` and there is a corresponding `tokenize` and `mwt` pair in the resources file. This fixes the scenario where the user downloads and uses only the `tokenize` processor.

## Fixes Issues
#774

## Unit test coverage
Unit test to that download and installation for package that has tokenize and mwt pair works. 

## Known breaking changes/behaviors
N / A
