### PR TITLE
fix data prepocess problem

### DIFF
--- a/stanza/utils/datasets/constituency/vtb_convert.py
+++ b/stanza/utils/datasets/constituency/vtb_convert.py
@@ -41,7 +41,6 @@ def convert_file(org_dir, new_dir):
             elif line == '<s>':
                 tree += '(ROOT '
                 reading_tree = True
-                # writer.write('(ROOT ')
             elif line == '</s>' and reading_tree:
                 tree += ')\n'
                 writer.write(tree)

--- a/stanza/utils/datasets/constituency/vtb_convert.py
+++ b/stanza/utils/datasets/constituency/vtb_convert.py
@@ -9,9 +9,15 @@ The script requires two arguments:
 2. New directory storing the converted trees
 """
 
-
 import os
 import argparse
+
+
+def is_valid_line(line):
+    if line.startswith('(') and line.endswith(')'):
+        return True
+
+    return False
 
 
 def convert_file(org_dir, new_dir):
@@ -23,16 +29,31 @@ def convert_file(org_dir, new_dir):
     """
     with open(org_dir, 'r') as reader, open(new_dir, 'w') as writer:
         content = reader.readlines()
+        # Tree string will only be written if the currently read
+        # tree is a valid tree. It will not be written if it
+        # does not have a '(' that signifies the presence of constituents
+        tree = ""
+        reading_tree = False
         for line in content:
             line = ' '.join(line.split())
             if line == '':
                 continue
             elif line == '<s>':
-                writer.write('(ROOT ')
-            elif line == '</s>':
-                writer.write(')\n')
+                tree += '(ROOT '
+                reading_tree = True
+                # writer.write('(ROOT ')
+            elif line == '</s>' and reading_tree:
+                tree += ')\n'
+                writer.write(tree)
+                reading_tree = False
+                tree = ""
             else:
-                writer.write(line)
+                if is_valid_line(line):
+                    tree += line
+                else:
+                    tree = ""
+                    reading_tree = False
+
 
 def convert_dir(org_dir, new_dir):
     for filename in os.listdir(org_dir):
@@ -72,6 +93,7 @@ def main():
     new_dir = args.new_dir
 
     convert_dir(org_dir, new_dir)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
If the script is reading and detects an error, it immediately refuses the tree that it is reading. I added a reading_tree boolean that keeps track of whether or not the current tree is valid and should be written or not. I also added a is_valid_line that checks for properly opened and closed constituents
