### PR TITLE
Add pyproject.toml config for pytest, fix test server request

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,3 @@ markers = [
     "pipeline",
     "client",
 ]
-
-norecursedirs= [
-    '/stanza/',
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.pytest.ini_options]
+
+addopts = "--ignore-glob='*iterate_test*'"
+
+filterwarnings = [
+    'ignore:the imp module is deprecated in favour of importlib:DeprecationWarning',
+    'ignore:Using or importing the ABCs from:DeprecationWarning'
+]
+
+markers = [
+    "travis",
+    "pipeline",
+    "client",
+]
+
+norecursedirs= [
+    '/stanza/',
+]

--- a/stanza/tests/test_server_request.py
+++ b/stanza/tests/test_server_request.py
@@ -3,6 +3,7 @@ Tests for setting request properties of servers
 """
 
 import json
+import os
 import pytest
 import stanza.server as corenlp
 
@@ -147,7 +148,17 @@ advmod(jours-13, tôt-15)
 punct(fait-4, .-16)
 """
 
-FRENCH_JSON_GOLD = json.loads(open(f'{TEST_WORKING_DIR}/out/example_french.json').read())
+# Try to load the FRENCH_JSON_GOLD example for testing.
+# If the test working directory is not setup, it will default to the stanza/tests/data folder
+try:
+  FRENCH_JSON_GOLD = json.loads(open(f'{TEST_WORKING_DIR}/out/example_french.json').read())
+except FileNotFoundError:
+  TEST_WORKING_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    'data',
+    )
+  FRENCH_JSON_GOLD = json.loads(open(f'{TEST_WORKING_DIR}/example_french.json').read())
+
 
 ES_DOC = 'Andrés Manuel López Obrador es el presidente de México.'
 


### PR DESCRIPTION
## Description

This adds a pyproject toml to the project for configuration of various tools.  

- Configure pytest warning filters and markers. 
- exclude a src location file which is not a test

Add a fallback in case the test_server_request test fails to find its test file.  Copying this file and other test files to the out folder could be removed if not essential for testing.

Default branch in Github could be set to dev instead of main, to remove need to notify users on PR.

