### PR TITLE
fix args tagmethod error message, formats, types

### DIFF
--- a/stanza/utils/datasets/prepare_depparse_treebank.py
+++ b/stanza/utils/datasets/prepare_depparse_treebank.py
@@ -31,7 +31,7 @@ def add_specific_args(parser):
     parser.add_argument('--wordvec_pretrain_file', type=str, default=None, help='Exact name of the pretrain file to read')
 
 
-def process_treebank(treebank, paths, args):
+def process_treebank(treebank, paths, args) -> None:
     if args.tag_method is Tags.GOLD:
         prepare_tokenizer_treebank.copy_conllu_treebank(treebank, paths, paths["DEPPARSE_DATA_DIR"])
     elif args.tag_method is Tags.PREDICTED:
@@ -59,13 +59,12 @@ def process_treebank(treebank, paths, args):
 
         prepare_tokenizer_treebank.copy_conllu_treebank(treebank, paths, paths["DEPPARSE_DATA_DIR"], retag_dataset)
     else:
-        raise ValueError("Unknown tags method: {}".format(arg.tag_method))
+        raise ValueError("Unknown tags method: {}".format(args.tag_method))
 
 
-def main():
+def main() -> None:
     common.main(process_treebank, add_specific_args)
+
 
 if __name__ == '__main__':
     main()
-
-

--- a/stanza/utils/datasets/prepare_depparse_treebank.py
+++ b/stanza/utils/datasets/prepare_depparse_treebank.py
@@ -19,9 +19,11 @@ from stanza.utils.training.run_pos import pos_batch_size, wordvec_args
 
 logger = logging.getLogger('stanza')
 
+
 class Tags(Enum):
     GOLD = 1
     PREDICTED = 2
+
 
 # fmt: off
 def add_specific_args(parser) -> None:
@@ -29,8 +31,10 @@ def add_specific_args(parser) -> None:
                         help='Use gold tags for building the depparse data')
     parser.add_argument("--predicted", dest='tag_method', action='store_const', const=Tags.PREDICTED,
                         help='Use predicted tags for building the depparse data')
-    parser.add_argument('--wordvec_pretrain_file', type=str, default=None, help='Exact name of the pretrain file to read')
+    parser.add_argument('--wordvec_pretrain_file', type=str, default=None,
+                        help='Exact name of the pretrain file to read')
 # fmt: on
+
 
 def process_treebank(treebank, paths, args) -> None:
     if args.tag_method is Tags.GOLD:
@@ -70,7 +74,6 @@ def process_treebank(treebank, paths, args) -> None:
 def main() -> None:
     common.main(process_treebank, add_specific_args)
 
+
 if __name__ == '__main__':
     main()
-
-

--- a/stanza/utils/datasets/prepare_depparse_treebank.py
+++ b/stanza/utils/datasets/prepare_depparse_treebank.py
@@ -1,14 +1,14 @@
 """
 A script to prepare all depparse datasets.
 
-For example, do
-  python -m stanza.utils.datasets.prepare_depparse_treebank TREEBANK
-such as
+Prepares each of train, dev, test.
+
+Example:
+  python -m stanza.utils.datasets.prepare_depparse_treebank {TREEBANK}
+Example:
   python -m stanza.utils.datasets.prepare_depparse_treebank UD_English-EWT
-
-and it will prepare each of train, dev, test
 """
-
+from argparse import ArgumentParser
 from enum import Enum
 import logging
 
@@ -17,47 +17,89 @@ import stanza.utils.datasets.prepare_tokenizer_treebank as prepare_tokenizer_tre
 from stanza.models import tagger
 from stanza.utils.training.run_pos import pos_batch_size, wordvec_args
 
-logger = logging.getLogger('stanza')
+logger = logging.getLogger("stanza")
+
 
 class Tags(Enum):
-    GOLD = 1
-    PREDICTED = 2
+    GOLD: int = 1
+    PREDICTED: int = 2
 
-def add_specific_args(parser):
-    parser.add_argument("--gold", dest='tag_method', action='store_const', const=Tags.GOLD, default=Tags.PREDICTED,
-                        help='Use gold tags for building the depparse data')
-    parser.add_argument("--predicted", dest='tag_method', action='store_const', const=Tags.PREDICTED,
-                        help='Use predicted tags for building the depparse data')
-    parser.add_argument('--wordvec_pretrain_file', type=str, default=None, help='Exact name of the pretrain file to read')
+
+def add_specific_args(parser: ArgumentParser) -> None:
+    parser.add_argument(
+        "--gold",
+        dest="tag_method",
+        action="store_const",
+        const=Tags.GOLD,
+        default=Tags.PREDICTED,
+        help="Use gold tags for building the depparse data",
+    )
+    parser.add_argument(
+        "--predicted",
+        dest="tag_method",
+        action="store_const",
+        const=Tags.PREDICTED,
+        help="Use predicted tags for building the depparse data",
+    )
+    parser.add_argument(
+        "--wordvec_pretrain_file",
+        type=str,
+        default=None,
+        help="Exact name of the pretrain file to read",
+    )
 
 
 def process_treebank(treebank, paths, args) -> None:
     if args.tag_method is Tags.GOLD:
-        prepare_tokenizer_treebank.copy_conllu_treebank(treebank, paths, paths["DEPPARSE_DATA_DIR"])
+        prepare_tokenizer_treebank.copy_conllu_treebank(
+            treebank, paths, paths["DEPPARSE_DATA_DIR"]
+        )
     elif args.tag_method is Tags.PREDICTED:
         short_name = common.project_to_short_name(treebank)
         short_language = short_name.split("_")[0]
 
-        base_args = ["--wordvec_dir", paths["WORDVEC_DIR"],
-                     "--lang", short_language,
-                     "--shorthand", short_name,
-                     "--batch_size", pos_batch_size(short_name),
-                     "--mode", "predict"]
+        base_args = [
+            "--wordvec_dir",
+            paths["WORDVEC_DIR"],
+            "--lang",
+            short_language,
+            "--shorthand",
+            short_name,
+            "--batch_size",
+            pos_batch_size(short_name),
+            "--mode",
+            "predict",
+        ]
         base_args = base_args + wordvec_args(short_language)
 
-        def retag_dataset(tokenizer_dir, tokenizer_file, dest_dir, dest_file, short_name):
+        def retag_dataset(
+            tokenizer_dir, tokenizer_file, dest_dir, dest_file, short_name
+        ) -> None:
             original = f"{tokenizer_dir}/{short_name}.{tokenizer_file}.conllu"
             retagged = f"{dest_dir}/{short_name}.{dest_file}.conllu"
-            tagger_args = ["--eval_file", original,
-                           "--gold_file", original,
-                           "--output_file", retagged]
+            tagger_args = [
+                "--eval_file",
+                original,
+                "--gold_file",
+                original,
+                "--output_file",
+                retagged,
+            ]
             if args.wordvec_pretrain_file:
-                tagger_args.extend(["--wordvec_pretrain_file", args.wordvec_pretrain_file])
+                tagger_args.extend(
+                    ["--wordvec_pretrain_file", args.wordvec_pretrain_file]
+                )
             tagger_args = base_args + tagger_args
-            logger.info("Running tagger to retag {} to {}\n  Args: {}".format(original, retagged, tagger_args))
+            logger.info(
+                "Running tagger to retag {} to {}\n  Args: {}".format(
+                    original, retagged, tagger_args
+                )
+            )
             tagger.main(tagger_args)
 
-        prepare_tokenizer_treebank.copy_conllu_treebank(treebank, paths, paths["DEPPARSE_DATA_DIR"], retag_dataset)
+        prepare_tokenizer_treebank.copy_conllu_treebank(
+            treebank, paths, paths["DEPPARSE_DATA_DIR"], retag_dataset
+        )
     else:
         raise ValueError("Unknown tags method: {}".format(args.tag_method))
 
@@ -66,5 +108,5 @@ def main() -> None:
     common.main(process_treebank, add_specific_args)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/stanza/utils/datasets/prepare_depparse_treebank.py
+++ b/stanza/utils/datasets/prepare_depparse_treebank.py
@@ -4,11 +4,11 @@ A script to prepare all depparse datasets.
 Prepares each of train, dev, test.
 
 Example:
-  python -m stanza.utils.datasets.prepare_depparse_treebank {TREEBANK}
+    python -m stanza.utils.datasets.prepare_depparse_treebank {TREEBANK}
 Example:
-  python -m stanza.utils.datasets.prepare_depparse_treebank UD_English-EWT
+    python -m stanza.utils.datasets.prepare_depparse_treebank UD_English-EWT
 """
-from argparse import ArgumentParser
+
 from enum import Enum
 import logging
 
@@ -17,89 +17,52 @@ import stanza.utils.datasets.prepare_tokenizer_treebank as prepare_tokenizer_tre
 from stanza.models import tagger
 from stanza.utils.training.run_pos import pos_batch_size, wordvec_args
 
-logger = logging.getLogger("stanza")
-
+logger = logging.getLogger('stanza')
 
 class Tags(Enum):
-    GOLD: int = 1
-    PREDICTED: int = 2
+    GOLD = 1
+    PREDICTED = 2
 
-
-def add_specific_args(parser: ArgumentParser) -> None:
-    parser.add_argument(
-        "--gold",
-        dest="tag_method",
-        action="store_const",
-        const=Tags.GOLD,
-        default=Tags.PREDICTED,
-        help="Use gold tags for building the depparse data",
-    )
-    parser.add_argument(
-        "--predicted",
-        dest="tag_method",
-        action="store_const",
-        const=Tags.PREDICTED,
-        help="Use predicted tags for building the depparse data",
-    )
-    parser.add_argument(
-        "--wordvec_pretrain_file",
-        type=str,
-        default=None,
-        help="Exact name of the pretrain file to read",
-    )
-
+# fmt: off
+def add_specific_args(parser) -> None:
+    parser.add_argument("--gold", dest='tag_method', action='store_const', const=Tags.GOLD, default=Tags.PREDICTED,
+                        help='Use gold tags for building the depparse data')
+    parser.add_argument("--predicted", dest='tag_method', action='store_const', const=Tags.PREDICTED,
+                        help='Use predicted tags for building the depparse data')
+    parser.add_argument('--wordvec_pretrain_file', type=str, default=None, help='Exact name of the pretrain file to read')
+# fmt: on
 
 def process_treebank(treebank, paths, args) -> None:
     if args.tag_method is Tags.GOLD:
-        prepare_tokenizer_treebank.copy_conllu_treebank(
-            treebank, paths, paths["DEPPARSE_DATA_DIR"]
-        )
+        prepare_tokenizer_treebank.copy_conllu_treebank(treebank, paths, paths["DEPPARSE_DATA_DIR"])
     elif args.tag_method is Tags.PREDICTED:
         short_name = common.project_to_short_name(treebank)
         short_language = short_name.split("_")[0]
 
-        base_args = [
-            "--wordvec_dir",
-            paths["WORDVEC_DIR"],
-            "--lang",
-            short_language,
-            "--shorthand",
-            short_name,
-            "--batch_size",
-            pos_batch_size(short_name),
-            "--mode",
-            "predict",
-        ]
+        # fmt: off
+        base_args = ["--wordvec_dir", paths["WORDVEC_DIR"],
+                     "--lang", short_language,
+                     "--shorthand", short_name,
+                     "--batch_size", pos_batch_size(short_name),
+                     "--mode", "predict"]
+        # fmt: on
         base_args = base_args + wordvec_args(short_language)
 
-        def retag_dataset(
-            tokenizer_dir, tokenizer_file, dest_dir, dest_file, short_name
-        ) -> None:
+        def retag_dataset(tokenizer_dir, tokenizer_file, dest_dir, dest_file, short_name):
             original = f"{tokenizer_dir}/{short_name}.{tokenizer_file}.conllu"
             retagged = f"{dest_dir}/{short_name}.{dest_file}.conllu"
-            tagger_args = [
-                "--eval_file",
-                original,
-                "--gold_file",
-                original,
-                "--output_file",
-                retagged,
-            ]
+            # fmt: off
+            tagger_args = ["--eval_file", original,
+                           "--gold_file", original,
+                           "--output_file", retagged]
+            # fmt: on
             if args.wordvec_pretrain_file:
-                tagger_args.extend(
-                    ["--wordvec_pretrain_file", args.wordvec_pretrain_file]
-                )
+                tagger_args.extend(["--wordvec_pretrain_file", args.wordvec_pretrain_file])
             tagger_args = base_args + tagger_args
-            logger.info(
-                "Running tagger to retag {} to {}\n  Args: {}".format(
-                    original, retagged, tagger_args
-                )
-            )
+            logger.info("Running tagger to retag {} to {}\n  Args: {}".format(original, retagged, tagger_args))
             tagger.main(tagger_args)
 
-        prepare_tokenizer_treebank.copy_conllu_treebank(
-            treebank, paths, paths["DEPPARSE_DATA_DIR"], retag_dataset
-        )
+        prepare_tokenizer_treebank.copy_conllu_treebank(treebank, paths, paths["DEPPARSE_DATA_DIR"], retag_dataset)
     else:
         raise ValueError("Unknown tags method: {}".format(args.tag_method))
 
@@ -107,6 +70,7 @@ def process_treebank(treebank, paths, args) -> None:
 def main() -> None:
     common.main(process_treebank, add_specific_args)
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()
+
+

--- a/stanza/utils/datasets/prepare_depparse_treebank.py
+++ b/stanza/utils/datasets/prepare_depparse_treebank.py
@@ -21,12 +21,15 @@ logger = logging.getLogger('stanza')
 
 
 class Tags(Enum):
+    """Tags parameter values."""
+
     GOLD = 1
     PREDICTED = 2
 
 
 # fmt: off
 def add_specific_args(parser) -> None:
+    """Add specific args."""
     parser.add_argument("--gold", dest='tag_method', action='store_const', const=Tags.GOLD, default=Tags.PREDICTED,
                         help='Use gold tags for building the depparse data')
     parser.add_argument("--predicted", dest='tag_method', action='store_const', const=Tags.PREDICTED,
@@ -37,6 +40,7 @@ def add_specific_args(parser) -> None:
 
 
 def process_treebank(treebank, paths, args) -> None:
+    """Process treebank."""
     if args.tag_method is Tags.GOLD:
         prepare_tokenizer_treebank.copy_conllu_treebank(treebank, paths, paths["DEPPARSE_DATA_DIR"])
     elif args.tag_method is Tags.PREDICTED:
@@ -72,6 +76,7 @@ def process_treebank(treebank, paths, args) -> None:
 
 
 def main() -> None:
+    """Call Process Treebank."""
     common.main(process_treebank, add_specific_args)
 
 


### PR DESCRIPTION
## Description

Start implementing static types and return values.  Fix ValueError incorrect reference in file.

Still some outstanding issues.

```shell
mypy --follow-imports=skip --disallow-untyped-defs --ignore-missing-imports stanza\utils\datasets\prepare_depparse_treebank.py
stanza\utils\datasets\prepare_depparse_treebank.py:52: error: Function is missing a type annotation for one or more arguments
stanza\utils\datasets\prepare_depparse_treebank.py:75: error: Function is missing a type annotation for one or more arguments
```

Is there a flake8 configuration preference, formatter preference for this project?

## Fixes Issues

Fixes incorrect valueerror parameter reference.
Formats file with black.
Fixes some mypy errors.

## Unit test coverage

I didn't see any existing unit test to modify here.

## Known breaking changes/behaviors

None
