### PR TITLE
Reverse words

### DIFF
--- a/stanza/_version.py
+++ b/stanza/_version.py
@@ -1,4 +1,4 @@
 """ Single source of truth for version number """
 
-__version__ = "1.3.0"
-__resources_version__ = '1.3.0'
+__version__ = "1.3.1"
+__resources_version__ = '1.3.1'

--- a/stanza/models/constituency/base_model.py
+++ b/stanza/models/constituency/base_model.py
@@ -147,7 +147,6 @@ class SimpleModel(BaseModel):
         word_queues = []
         for tagged_words in tagged_word_lists:
             word_queue = [tag_node for tag_node in tagged_words]
-            word_queue.reverse()
             word_queue.append(None)
             word_queues.append(word_queue)
         return word_queues

--- a/stanza/models/constituency/lstm_model.py
+++ b/stanza/models/constituency/lstm_model.py
@@ -223,10 +223,8 @@ class LSTMModel(BaseModel, nn.Module):
 
         all_data = []
         for idx, word_labels in enumerate(all_word_labels):
-            if forward:
-                word_labels = reversed(word_labels)
-            else:
-                word_labels = [x[::-1] for x in word_labels]
+            if not forward:
+                word_labels = [x[::-1] for x in reversed(word_labels)]
 
             chars = [CHARLM_START]
             offsets = []
@@ -246,8 +244,7 @@ class LSTMModel(BaseModel, nn.Module):
         # TODO: surely this should be stuffed in the charlm model itself rather than done here
         with torch.no_grad():
             output, _, _ = charlm.forward(chars, char_lens)
-            # TODO: if we stop reversing the inputs, don't forget to flip this back
-            res = [output[i, offsets].flip(0) for i, offsets in enumerate(char_offsets)]
+            res = [output[i, offsets] for i, offsets in enumerate(char_offsets)]
             res = unsort(res, orig_idx)
 
         return res
@@ -335,7 +332,6 @@ class LSTMModel(BaseModel, nn.Module):
             # and use that instead
             word_queue = [WordNode(tag_node, sentence_output[idx, :])
                           for idx, tag_node in enumerate(tagged_words)]
-            word_queue.reverse()
             word_queue.append(WordNode(None, self.word_zeros))
 
             word_queues.append(word_queue)

--- a/stanza/models/constituency/parse_transitions.py
+++ b/stanza/models/constituency/parse_transitions.py
@@ -100,7 +100,7 @@ class State(namedtuple('State', ['word_queue', 'transitions', 'constituents', 'g
         return [model.get_word(x) for x in self.word_queue]
 
     def to_string(self, model):
-        return "State(\n  buffer:%s\n  transitions:%s\n  constituents:%s)" % (str(self.all_words(model)), str(self.all_transitions(model)), str(self.all_constituents(model)))
+        return "State(\n  buffer:%s\n  transitions:%s\n  constituents:%s\n  word_position:%d num_opens:%d)" % (str(self.all_words(model)), str(self.all_transitions(model)), str(self.all_constituents(model)), self.word_position, self.num_opens)
 
     def __str__(self):
         return "State(\n  buffer:%s\n  transitions:%s\n  constituents:%s)" % (str(self.word_queue), str(self.transitions), str(self.constituents))
@@ -127,11 +127,10 @@ def initial_state_from_preterminals(preterminal_lists, model, gold_trees):
     return states
 
 def initial_state_from_words(word_lists, model):
-    # TODO: stop reversing the words
     preterminal_lists = []
     for words in word_lists:
         preterminals = []
-        for word, tag in reversed(words):
+        for word, tag in words:
             word_node = Tree(label=word)
             tag_node = Tree(label=tag, children=[word_node])
             preterminals.append(tag_node)
@@ -139,9 +138,8 @@ def initial_state_from_words(word_lists, model):
     return initial_state_from_preterminals(preterminal_lists, model, gold_trees=None)
 
 def initial_state_from_gold_trees(trees, model):
-    # reversed so we put the words on the stack backwards
     preterminal_lists = [[Tree(label=pt.label, children=Tree(label=pt.children[0].label))
-                          for pt in tree.yield_reversed_preterminals()]
+                          for pt in tree.yield_preterminals()]
                          for tree in trees]
     return initial_state_from_preterminals(preterminal_lists, model, gold_trees=trees)
 

--- a/stanza/models/constituency/parse_tree.py
+++ b/stanza/models/constituency/parse_tree.py
@@ -79,6 +79,9 @@ class Tree(StanzaObject):
         else:
             space_replacement = " "
 
+        def normalize(text):
+            return text.replace(" ", space_replacement).replace("(", "-LRB-").replace(")", "-RRB-")
+
         with StringIO() as buf:
             stack = deque()
             stack.append(self)
@@ -90,11 +93,11 @@ class Tree(StanzaObject):
                     continue
                 if len(node.children) == 0:
                     if node.label is not None:
-                        buf.write(node.label.replace(" ", space_replacement))
+                        buf.write(normalize(node.label))
                     continue
                 buf.write(OPEN_PAREN)
                 if node.label is not None:
-                    buf.write(node.label.replace(" ", space_replacement))
+                    buf.write(normalize(node.label))
                 stack.append(CLOSE_PAREN)
                 for child in reversed(node.children):
                     stack.append(child)

--- a/stanza/models/constituency/trainer.py
+++ b/stanza/models/constituency/trainer.py
@@ -45,6 +45,9 @@ class Trainer:
         self.model = model
         self.optimizer = optimizer
 
+    def uses_xpos(self):
+        return self.model.args['retag_package'] is not None and self.model.args['retag_method'] == 'xpos'
+
     def save(self, filename, save_optimizer=True):
         """
         Save the model (and by default the optimizer) to the given path

--- a/stanza/models/constituency/trainer.py
+++ b/stanza/models/constituency/trainer.py
@@ -504,6 +504,11 @@ def parse_sentences(data_iterator, build_batch_fn, batch_size, model):
     The return is a list of tuples: (gold_tree, [(predicted, score) ...])
     gold_tree will be left blank if the data did not include gold trees
     currently score is always 1.0, but the interface may be expanded to get a score from the result of the parsing
+
+    TODO: in large bulk operations this runs out of memory because the
+    State objects and the associated tensors are kept until parsing is
+    finished.  This is not necessary in the case of parsing a large
+    dataset for the trees, though.
     """
     treebank = []
     tree_batch = build_batch_fn(batch_size, data_iterator, model)

--- a/stanza/models/constituency/tree_reader.py
+++ b/stanza/models/constituency/tree_reader.py
@@ -42,6 +42,8 @@ class MixedTreeError(ValueError):
         super().__init__("Found a tree with both text children and bracketed children!  Line number %d" % line_num)
         self.line_num = line_num
 
+def normalize(text):
+    return text.replace("-LRB-", "(").replace("-RRB-", ")")
 
 def recursive_open_tree(token_iterator, at_root, broken_ok):
     """
@@ -80,7 +82,7 @@ def recursive_open_tree(token_iterator, at_root, broken_ok):
                     return Tree(label=label, children=children + [Tree(label=child_label)])
                 else:
                     raise MixedTreeError(token_iterator.line_num)
-            return Tree(label=label, children=Tree(label=child_label))
+            return Tree(label=label, children=Tree(label=normalize(child_label)))
         else:
             text.append(token)
         token = next(token_iterator, None)

--- a/stanza/models/constituency/utils.py
+++ b/stanza/models/constituency/utils.py
@@ -46,7 +46,7 @@ def retag_trees(trees, pipeline, xpos=True):
     sentences = []
     try:
         for idx, tree in enumerate(trees):
-            tokens = [{TEXT: pt.children[0].label} for pt in tree.preterminals()]
+            tokens = [{TEXT: pt.children[0].label} for pt in tree.yield_preterminals()]
             sentences.append(tokens)
     except ValueError as e:
         raise ValueError("Unable to process tree %d" % idx) from e

--- a/stanza/pipeline/constituency_processor.py
+++ b/stanza/pipeline/constituency_processor.py
@@ -48,6 +48,7 @@ class ConstituencyProcessor(UDProcessor):
                                            forward_charlm=trainer.load_charlm(charlm_forward_file),
                                            backward_charlm=trainer.load_charlm(charlm_backward_file),
                                            use_gpu=use_gpu)
+        self._model.model.eval()
         # batch size counted as sentences
         self._batch_size = config.get('batch_size', ConstituencyProcessor.DEFAULT_BATCH_SIZE)
         self._tqdm = 'tqdm' in config and config['tqdm']

--- a/stanza/pipeline/constituency_processor.py
+++ b/stanza/pipeline/constituency_processor.py
@@ -55,10 +55,10 @@ class ConstituencyProcessor(UDProcessor):
     def process(self, document):
         sentences = document.sentences
 
-        # TODO: perhaps MWT should be relevant here?
-        # certainly parsing across an MWT boundary is an error
-        # TODO: maybe some constituency models are trained on UPOS not XPOS
-        words = [[(w.text, w.xpos) for w in s.words] for s in sentences]
+        if self._model.uses_xpos():
+            words = [[(w.text, w.xpos) for w in s.words] for s in sentences]
+        else:
+            words = [[(w.text, w.upos) for w in s.words] for s in sentences]
         if self._tqdm:
             words = tqdm(words)
 

--- a/stanza/tests/constituency/test_parse_tree.py
+++ b/stanza/tests/constituency/test_parse_tree.py
@@ -31,7 +31,7 @@ def test_yield_preterminals():
     text = "((S (VP (VB Unban)) (NP (NNP Mox) (NNP Opal))))"
     trees = tree_reader.read_trees(text)
 
-    preterminals = trees[0].preterminals()
+    preterminals = list(trees[0].yield_preterminals())
     assert len(preterminals) == 3
     assert str(preterminals) == "[(VB Unban), (NNP Mox), (NNP Opal)]"
 

--- a/stanza/tests/constituency/test_tree_reader.py
+++ b/stanza/tests/constituency/test_tree_reader.py
@@ -28,6 +28,22 @@ def test_newlines():
     trees = tree_reader.read_trees(text)
     assert len(trees) == 2
 
+def test_parens():
+    """
+    Parens should be escaped in the tree files and escaped when written
+    """
+    text = "(-LRB- -LRB-) (-RRB- -RRB-)"
+    trees = tree_reader.read_trees(text)
+    assert len(trees) == 2
+
+    assert trees[0].label == '-LRB-'
+    assert trees[0].children[0].label == '('
+    assert "{}".format(trees[0]) == '(-LRB- -LRB-)'
+
+    assert trees[1].label == '-RRB-'
+    assert trees[1].children[0].label == ')'
+    assert "{}".format(trees[1]) == '(-RRB- -RRB-)'
+
 def test_complicated():
     """
     A more complicated tree that should successfully read

--- a/stanza/utils/training/run_constituency.py
+++ b/stanza/utils/training/run_constituency.py
@@ -21,6 +21,12 @@ RETAG_PACKAGE = {
     "vi": "vi_vtb",
 }
 
+# xpos tagger doesn't produce PP tag on the turin treebank,
+# so instead we use upos to avoid unknown tag errors
+RETAG_METHOD = {
+    "it": "upos",
+}
+
 def run_treebank(mode, paths, treebank, short_name,
                  temp_output_file, command_args, extra_args):
     constituency_dir = paths["CONSTITUENCY_DATA_DIR"]
@@ -42,6 +48,9 @@ def run_treebank(mode, paths, treebank, short_name,
         retag_args = ["--retag_package", RETAG_PACKAGE[language]]
     else:
         retag_args = []
+
+    if language in RETAG_METHOD:
+        retag_args.extend(["--retag_method", "upos"])
 
     if '--wordvec_pretrain_file' not in extra_args:
         # will throw an error if the pretrain can't be found


### PR DESCRIPTION
Initial word queues were built backwards in the conparser.  This change flips them to a more normal forward direction.

(This destroys the existing models, but that's okay)