### PR TITLE
Add typing, remove unused imports, add missing re import, format

### DIFF
--- a/stanza/models/classifiers/data.py
+++ b/stanza/models/classifiers/data.py
@@ -41,7 +41,7 @@ def update_text(sentence: List[str], wordvec_type: classifier_args.WVType) -> Li
         raise ValueError("Unknown wordvec_type {}".format(wordvec_type))
 
 
-def read_dataset(dataset, wordvec_type: classifier_args.WVType, min_len: bool) -> List[tuple]:
+def read_dataset(dataset, wordvec_type: classifier_args.WVType, min_len: int) -> List[tuple]:
     """
     returns a list where the values of the list are
       label, [token...]

--- a/stanza/models/classifiers/data.py
+++ b/stanza/models/classifiers/data.py
@@ -1,9 +1,15 @@
+"""Stanza models classifier data functions."""
+
 import logging
+import re
+from typing import List
+
 import stanza.models.classifiers.classifier_args as classifier_args
 
 logger = logging.getLogger('stanza')
 
-def update_text(sentence, wordvec_type):
+
+def update_text(sentence: List[str], wordvec_type: classifier_args.WVType) -> List[str]:
     """
     Process a line of text (with tokenization provided as whitespace)
     into a list of strings.
@@ -35,7 +41,7 @@ def update_text(sentence, wordvec_type):
         raise ValueError("Unknown wordvec_type {}".format(wordvec_type))
 
 
-def read_dataset(dataset, wordvec_type, min_len):
+def read_dataset(dataset, wordvec_type: classifier_args.WVType, min_len: bool) -> List[tuple]:
     """
     returns a list where the values of the list are
       label, [token...]
@@ -58,4 +64,3 @@ def read_dataset(dataset, wordvec_type, min_len):
     if min_len:
         lines = [x for x in lines if len(x[1]) >= min_len]
     return lines
-

--- a/stanza/models/classifiers/iterate_test.py
+++ b/stanza/models/classifiers/iterate_test.py
@@ -3,10 +3,9 @@ import glob
 import logging
 
 import stanza.models.classifier as classifier
-import stanza.models.classifiers.cnn_classifier as cnn_classifier
 import stanza.models.classifiers.classifier_args as classifier_args
+import stanza.models.classifiers.cnn_classifier as cnn_classifier
 from stanza.models.common import utils
-from stanza.models.common.pretrain import Pretrain
 
 """
 A script for running the same test file on several different classifiers.
@@ -22,17 +21,20 @@ Example command line:
 
 logger = logging.getLogger('stanza')
 
-def parse_args():
+
+def parse_args() -> None:
     parser = argparse.ArgumentParser()
 
     classifier_args.add_common_args(parser)
 
+    # fmt:off
     parser.add_argument('--test_file', type=str, default='extern_data/sentiment/sst-processed/binary/test-binary-roots.txt', help='Input file to use as the test set.')
-
     parser.add_argument('--glob', type=str, default='saved_models/classifier/*classifier*pt', help='Model file(s) to test.')
+    # fmt:on
 
     args = parser.parse_args()
     return args
+
 
 args = parse_args()
 seed = utils.set_random_seed(args.seed, args.cuda)
@@ -62,6 +64,9 @@ for load_name in model_files:
 
     confusion = classifier.confusion_dataset(model, test_set, device=device)
     correct, total = classifier.confusion_to_accuracy(confusion)
+    # fmt:off
     logger.info("  Results: %d correct of %d examples.  Accuracy: %f" %
                 (correct, total, correct / total))
     logger.info("Confusion matrix:\n{}".format(classifier.format_confusion(confusion, model.labels)))
+    # fmt:on
+

--- a/stanza/models/classifiers/iterate_test.py
+++ b/stanza/models/classifiers/iterate_test.py
@@ -1,3 +1,4 @@
+"""Iterate test."""
 import argparse
 import glob
 import logging
@@ -23,14 +24,13 @@ logger = logging.getLogger('stanza')
 
 
 def parse_args() -> None:
+    """Add and parse arguments."""
     parser = argparse.ArgumentParser()
 
     classifier_args.add_common_args(parser)
 
-    # fmt:off
     parser.add_argument('--test_file', type=str, default='extern_data/sentiment/sst-processed/binary/test-binary-roots.txt', help='Input file to use as the test set.')
     parser.add_argument('--glob', type=str, default='saved_models/classifier/*classifier*pt', help='Model file(s) to test.')
-    # fmt:on
 
     args = parser.parse_args()
     return args
@@ -64,9 +64,5 @@ for load_name in model_files:
 
     confusion = classifier.confusion_dataset(model, test_set, device=device)
     correct, total = classifier.confusion_to_accuracy(confusion)
-    # fmt:off
-    logger.info("  Results: %d correct of %d examples.  Accuracy: %f" %
-                (correct, total, correct / total))
+    logger.info("  Results: %d correct of %d examples.  Accuracy: %f" % (correct, total, correct / total))
     logger.info("Confusion matrix:\n{}".format(classifier.format_confusion(confusion, model.labels)))
-    # fmt:on
-

--- a/stanza/models/classifiers/iterate_test.py
+++ b/stanza/models/classifiers/iterate_test.py
@@ -22,7 +22,7 @@ Example command line:
 logger = logging.getLogger('stanza')
 
 
-def parse_args() -> None:
+def parse_args():
     parser = argparse.ArgumentParser()
 
     classifier_args.add_common_args(parser)


### PR DESCRIPTION
## Description

Fix missing re import in models/classifier/data.py script.
Remove unused pretrain import.
Sort imports.
Improve typing.
Formatting with black.

## Fixes Issues

Fix missing re import in models/classifier/data.py script.

## Unit test coverage

Existing tests should cover
stanza/models/classifiers/data.py
stanza/models/classifiers/iterate_test.py

## Known breaking changes/behaviors
n/a