### PR TITLE
Refactor the wiki selftrain script so most of the pieces can be reuse…

### DIFF
--- a/stanza/models/constituency/utils.py
+++ b/stanza/models/constituency/utils.py
@@ -10,6 +10,16 @@ from torch import optim
 
 from stanza.models.common.doc import TEXT, Document
 
+class TextTooLongError(ValueError):
+    """
+    A text was too long for the underlying model (possibly BERT)
+    """
+    def __init__(self, length, max_len, line_num, text):
+        super().__init__("Found a text of length %d (possibly after tokenizing).  Maximum handled length is %d  Error occurred at line %d" % (length, max_len, line_num))
+        self.line_num = line_num
+        self.text = text
+
+
 def replace_tags(tree, tags):
     if tree.is_leaf():
         raise ValueError("Must call replace_tags with non-leaf")

--- a/stanza/tests/constituency/test_selftrain_vi_quad.py
+++ b/stanza/tests/constituency/test_selftrain_vi_quad.py
@@ -1,0 +1,23 @@
+"""
+Test some of the methods in the vi_quad dataset
+
+Uses a small section of the dataset as a test
+"""
+
+import pytest
+
+from stanza.utils.datasets.constituency import selftrain_vi_quad
+
+from stanza.tests import *
+
+pytestmark = [pytest.mark.pipeline, pytest.mark.travis]
+
+SAMPLE_TEXT = """
+{"version": "1.1", "data": [{"title": "Ph\u1ea1m V\u0103n \u0110\u1ed3ng", "paragraphs": [{"qas": [{"question": "T\u00ean g\u1ecdi n\u00e0o \u0111\u01b0\u1ee3c Ph\u1ea1m V\u0103n \u0110\u1ed3ng s\u1eed d\u1ee5ng khi l\u00e0m Ph\u00f3 ch\u1ee7 nhi\u1ec7m c\u01a1 quan Bi\u1ec7n s\u1ef1 x\u1ee9 t\u1ea1i Qu\u1ebf L\u00e2m?", "answers": [{"answer_start": 507, "text": "L\u00e2m B\u00e1 Ki\u1ec7t"}], "id": "uit_01__05272_0_1"}, {"question": "Ph\u1ea1m V\u0103n \u0110\u1ed3ng gi\u1eef ch\u1ee9c v\u1ee5 g\u00ec trong b\u1ed9 m\u00e1y Nh\u00e0 n\u01b0\u1edbc C\u1ed9ng h\u00f2a X\u00e3 h\u1ed9i ch\u1ee7 ngh\u0129a Vi\u1ec7t Nam?", "answers": [{"answer_start": 60, "text": "Th\u1ee7 t\u01b0\u1edbng"}], "id": "uit_01__05272_0_2"}, {"question": "Giai \u0111o\u1ea1n n\u0103m 1955-1976, Ph\u1ea1m V\u0103n \u0110\u1ed3ng n\u1eafm gi\u1eef ch\u1ee9c v\u1ee5 g\u00ec?", "answers": [{"answer_start": 245, "text": "Th\u1ee7 t\u01b0\u1edbng Ch\u00ednh ph\u1ee7 Vi\u1ec7t Nam D\u00e2n ch\u1ee7 C\u1ed9ng h\u00f2a"}], "id": "uit_01__05272_0_3"}], "context": "Ph\u1ea1m V\u0103n \u0110\u1ed3ng (1 th\u00e1ng 3 n\u0103m 1906 \u2013 29 th\u00e1ng 4 n\u0103m 2000) l\u00e0 Th\u1ee7 t\u01b0\u1edbng \u0111\u1ea7u ti\u00ean c\u1ee7a n\u01b0\u1edbc C\u1ed9ng h\u00f2a X\u00e3 h\u1ed9i ch\u1ee7 ngh\u0129a Vi\u1ec7t Nam t\u1eeb n\u0103m 1976 (t\u1eeb n\u0103m 1981 g\u1ecdi l\u00e0 Ch\u1ee7 t\u1ecbch H\u1ed9i \u0111\u1ed3ng B\u1ed9 tr\u01b0\u1edfng) cho \u0111\u1ebfn khi ngh\u1ec9 h\u01b0u n\u0103m 1987. Tr\u01b0\u1edbc \u0111\u00f3 \u00f4ng t\u1eebng gi\u1eef ch\u1ee9c v\u1ee5 Th\u1ee7 t\u01b0\u1edbng Ch\u00ednh ph\u1ee7 Vi\u1ec7t Nam D\u00e2n ch\u1ee7 C\u1ed9ng h\u00f2a t\u1eeb n\u0103m 1955 \u0111\u1ebfn n\u0103m 1976. \u00d4ng l\u00e0 v\u1ecb Th\u1ee7 t\u01b0\u1edbng Vi\u1ec7t Nam t\u1ea1i v\u1ecb l\u00e2u nh\u1ea5t (1955\u20131987). \u00d4ng l\u00e0 h\u1ecdc tr\u00f2, c\u1ed9ng s\u1ef1 c\u1ee7a Ch\u1ee7 t\u1ecbch H\u1ed3 Ch\u00ed Minh. \u00d4ng c\u00f3 t\u00ean g\u1ecdi th\u00e2n m\u1eadt l\u00e0 T\u00f4, \u0111\u00e2y t\u1eebng l\u00e0 b\u00ed danh c\u1ee7a \u00f4ng. \u00d4ng c\u00f2n c\u00f3 t\u00ean g\u1ecdi l\u00e0 L\u00e2m B\u00e1 Ki\u1ec7t khi l\u00e0m Ph\u00f3 ch\u1ee7 nhi\u1ec7m c\u01a1 quan Bi\u1ec7n s\u1ef1 x\u1ee9 t\u1ea1i Qu\u1ebf L\u00e2m (Ch\u1ee7 nhi\u1ec7m l\u00e0 H\u1ed3 H\u1ecdc L\u00e3m)."}, {"qas": [{"question": "S\u1ef1 ki\u1ec7n quan tr\u1ecdng n\u00e0o \u0111\u00e3 di\u1ec5n ra v\u00e0o ng\u00e0y 20/7/1954?", "answers": [{"answer_start": 364, "text": "b\u1ea3n Hi\u1ec7p \u0111\u1ecbnh \u0111\u00ecnh ch\u1ec9 chi\u1ebfn s\u1ef1 \u1edf Vi\u1ec7t Nam, Campuchia v\u00e0 L\u00e0o \u0111\u00e3 \u0111\u01b0\u1ee3c k\u00fd k\u1ebft th\u1eeba nh\u1eadn t\u00f4n tr\u1ecdng \u0111\u1ed9c l\u1eadp, ch\u1ee7 quy\u1ec1n, c\u1ee7a n\u01b0\u1edbc Vi\u1ec7t Nam, L\u00e0o v\u00e0 Campuchia"}], "id": "uit_01__05272_1_1"}, {"question": "Ch\u1ee9c v\u1ee5 m\u00e0 Ph\u1ea1m V\u0103n \u0110\u1ed3ng \u0111\u1ea3m nhi\u1ec7m t\u1ea1i H\u1ed9i ngh\u1ecb Gen\u00e8ve v\u1ec1 \u0110\u00f4ng D\u01b0\u01a1ng?", "answers": [{"answer_start": 33, "text": "Tr\u01b0\u1edfng ph\u00e1i \u0111o\u00e0n Ch\u00ednh ph\u1ee7"}], "id": "uit_01__05272_1_2"}, {"question": "H\u1ed9i ngh\u1ecb Gen\u00e8ve v\u1ec1 \u0110\u00f4ng D\u01b0\u01a1ng c\u00f3 t\u00ednh ch\u1ea5t nh\u01b0 th\u1ebf n\u00e0o?", "answers": [{"answer_start": 262, "text": "r\u1ea5t c\u0103ng th\u1eb3ng v\u00e0 ph\u1ee9c t\u1ea1p"}], "id": "uit_01__05272_1_3"}]}]}]}
+"""
+
+EXPECTED = ['Tên gọi nào được Phạm Văn Đồng sử dụng khi làm Phó chủ nhiệm cơ quan Biện sự xứ tại Quế Lâm?', 'Phạm Văn Đồng giữ chức vụ gì trong bộ máy Nhà nước Cộng hòa Xã hội chủ nghĩa Việt Nam?', 'Giai đoạn năm 1955-1976, Phạm Văn Đồng nắm giữ chức vụ gì?', 'Sự kiện quan trọng nào đã diễn ra vào ngày 20/7/1954?', 'Chức vụ mà Phạm Văn Đồng đảm nhiệm tại Hội nghị Genève về Đông Dương?', 'Hội nghị Genève về Đông Dương có tính chất như thế nào?']
+
+def test_read_file():
+    results = selftrain_vi_quad.parse_quad(SAMPLE_TEXT)
+    assert results == EXPECTED

--- a/stanza/utils/datasets/constituency/selftrain.py
+++ b/stanza/utils/datasets/constituency/selftrain.py
@@ -1,0 +1,112 @@
+"""
+Common methods for the various self-training data collection scripts
+"""
+
+import logging
+import os
+import random
+
+import stanza
+from stanza.models.common import utils
+from stanza.models.constituency.utils import TextTooLongError
+
+logger = logging.getLogger('stanza')
+tqdm = utils.get_tqdm()
+
+def common_args(parser):
+    parser.add_argument(
+        '--output_file',
+        default='data/constituency/vi_silver.mrg',
+        help='Where to write the silver trees'
+    )
+    parser.add_argument(
+        '--lang',
+        default='vi',
+        help='Which language tools to use for tokenization and POS'
+    )
+    parser.add_argument(
+        '--num_sentences',
+        type=int,
+        default=-1,
+        help='How many sentences to get per file (max)'
+    )
+    parser.add_argument(
+        '--models',
+        default='saved_models/constituency/vi_vlsp21_inorder.pt',
+        help='What models to use for parsing.  comma-separated'
+    )
+
+
+def build_tag_pipe(ssplit, lang):
+    if ssplit:
+        return stanza.Pipeline(lang, processors="tokenize,pos")
+    else:
+        return stanza.Pipeline(lang, processors="tokenize,pos", tokenize_no_ssplit=True)
+
+def build_parser_pipes(lang, models):
+    """
+    Build separate pipelines for each parser model we want to use
+    """
+    parser_pipes = []
+    for model_name in models.split(","):
+        if os.path.exists(model_name):
+            # if the model name exists as a file, treat it as the path to the model
+            pipe = stanza.Pipeline(lang, processors="constituency", constituency_model_path=model_name, constituency_pretagged=True)
+        else:
+            # otherwise, assume it is a package name?
+            pipe = stanza.Pipeline(lang, processors={"constituency": model_name}, constituency_pretagged=True, package=None)
+        parser_pipes.append(pipe)
+    return parser_pipes
+
+def find_matching_trees(docs, num_sentences, accepted_trees, tag_pipe, parser_pipes, shuffle=True, chunk_size=10, max_len=140):
+    """
+    Find trees where all the parsers in parser_pipes agree
+
+    docs should be a list of strings.
+      one sentence per string or a whole block of text as long as the tag_pipe can process it correctly
+    """
+    if num_sentences < 0:
+        tqdm_total = len(docs)
+    else:
+        tqdm_total = num_sentences
+
+    with tqdm(total=tqdm_total, leave=False) as pbar:
+        if shuffle:
+            random.shuffle(docs)
+        new_trees = set()
+        for chunk_start in range(0, len(docs), chunk_size):
+            chunk = docs[chunk_start:chunk_start+chunk_size]
+            chunk = [stanza.Document([], text=t) for t in chunk]
+            tag_pipe(chunk)
+
+            if max_len is not None:
+                # for now, we don't have a good way to deal with sentences longer than the bert maxlen
+                chunk = [d for d in chunk if max(len(s.words) for s in d.sentences) < max_len]
+
+            parses = []
+            try:
+                for pipe in parser_pipes:
+                    pipe(chunk)
+                    trees = ["{:L}".format(sent.constituency) for doc in chunk for sent in doc.sentences]
+                    parses.append(trees)
+            except TextTooLongError as e:
+                # easiest is to skip this chunk - could theoretically save the other sentences
+                continue
+
+            for tree in zip(*parses):
+                if num_sentences < 0:
+                    pbar.update(1)
+                if len(set(tree)) != 1:
+                    continue
+                tree = tree[0]
+                if tree in accepted_trees:
+                    continue
+                if tree not in new_trees:
+                    new_trees.add(tree)
+                    if num_sentences >= 0:
+                        pbar.update(1)
+                if num_sentences >= 0 and len(new_trees) >= num_sentences:
+                    return new_trees
+
+    return new_trees
+

--- a/stanza/utils/datasets/constituency/selftrain_vi_quad.py
+++ b/stanza/utils/datasets/constituency/selftrain_vi_quad.py
@@ -1,0 +1,82 @@
+"""
+Processes the train section of VI QuAD into trees suitable for use in the conparser lm
+"""
+
+import argparse
+import json
+import logging
+
+from stanza.utils.datasets.constituency import selftrain
+
+logger = logging.getLogger('stanza')
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Script that converts vi quad to silver standard trees"
+    )
+    selftrain.common_args(parser)
+    parser.add_argument(
+        '--input_file',
+        default="extern_data/vietnamese/ViQuAD/train_ViQuAD.json",
+        help='Path to the ViQuAD train file'
+    )
+
+    args = parser.parse_args()
+    return args
+
+def parse_quad(text):
+    """
+    Read in a file from the VI quad dataset
+
+    The train file has a specific format:
+    the doc has a 'data' section
+    each block in the data is a separate document (138 in the train file, for example)
+    each block has a 'paragraphs' section
+    each paragrah has 'qas' and 'context'.  we care about the qas
+    each piece of qas has 'question', which is what we actually want
+    """
+    doc = json.loads(text)
+
+    questions = []
+
+    for block in doc['data']:
+        paragraphs = block['paragraphs']
+        for paragraph in paragraphs:
+            qas = paragraph['qas']
+            for question in qas:
+                questions.append(question['question'])
+
+    return questions
+
+
+def read_quad(train_file):
+    with open(train_file) as fin:
+        text = fin.read()
+
+    return parse_quad(text)
+
+def main():
+    """
+    Turn the train section of VI quad into a list of trees
+    """
+    args = parse_args()
+
+    tag_pipe = selftrain.build_tag_pipe(ssplit=False, lang=args.lang)
+    parser_pipes = selftrain.build_parser_pipes(args.lang, args.models)
+
+    # create a blank file.  we will append to this file so that partial results can be used
+    with open(args.output_file, "w") as fout:
+        pass
+
+    accepted_trees = set()
+    docs = read_quad(args.input_file)
+    logger.info("Read %d lines from %s", len(docs), args.input_file)
+    new_trees = selftrain.find_matching_trees(docs, args.num_sentences, accepted_trees, tag_pipe, parser_pipes, shuffle=False, chunk_size=100)
+    new_trees = [tree for tree in new_trees if tree.find("(_SQ") >= 0]
+    with open(args.output_file, "a") as fout:
+        for tree in sorted(new_trees):
+            fout.write(tree)
+            fout.write("\n")
+
+if __name__ == '__main__':
+    main()

--- a/stanza/utils/datasets/constituency/selftrain_wiki.py
+++ b/stanza/utils/datasets/constituency/selftrain_wiki.py
@@ -16,8 +16,8 @@ import glob
 import os
 import random
 
-import stanza
 from stanza.models.common import utils
+from stanza.utils.datasets.constituency import selftrain
 
 tqdm = utils.get_tqdm()
 
@@ -25,31 +25,11 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Script that converts part of a wikipedia dump to silver standard trees"
     )
+    selftrain.common_args(parser)
     parser.add_argument(
         '--input_dir',
         default='extern_data/vietnamese/wikipedia/text',
         help='Path to the wikipedia dump after processing by wikiextractor'
-    )
-    parser.add_argument(
-        '--output_file',
-        default='data/constituency/vi_silver.mrg',
-        help='Where to write the silver trees'
-    )
-    parser.add_argument(
-        '--lang',
-        default='vi',
-        help='Which language tools to use for tokenization and POS'
-    )
-    parser.add_argument(
-        '--num_sentences',
-        type=int,
-        default=1000,
-        help='How many sentences to get per file (max)'
-    )
-    parser.add_argument(
-        '--models',
-        default='saved_models/constituency/vi_vlsp21_inorder.pt',
-        help='What models to use for parsing.  comma-separated'
     )
     parser.add_argument(
         '--no_shuffle',
@@ -57,6 +37,8 @@ def parse_args():
         action='store_false',
         help="Don't shuffle files when processing the directory"
     )
+
+    parser.set_defaults(num_sentences=10000)
 
     args = parser.parse_args()
     return args
@@ -119,63 +101,6 @@ def read_wiki_file(filename):
         docs.append("\n\n".join(current_doc))
     return docs
 
-def find_matching_trees(docs, num_sentences, accepted_trees, tag_pipe, parser_pipes):
-    """
-    Find trees where all the parsers in parser_pipes agree
-    """
-    random.shuffle(docs)
-    chunk_size = 10
-    new_trees = set()
-    with tqdm(total=num_sentences, leave=False) as pbar:
-        for chunk_start in range(0, len(docs), chunk_size):
-            chunk = docs[chunk_start:chunk_start+chunk_size]
-            chunk = [stanza.Document([], text=t) for t in chunk]
-            tag_pipe(chunk)
-
-            # for now, we don't have a good way to deal with sentences longer than the bert maxlen
-            chunk = [d for d in chunk if max(len(s.words) for s in d.sentences) < 145]
-
-            parses = []
-            for pipe in parser_pipes:
-                pipe(chunk)
-                trees = ["{:L}".format(sent.constituency) for doc in chunk for sent in doc.sentences]
-                parses.append(trees)
-
-            for tree in zip(*parses):
-                if len(set(tree)) != 1:
-                    continue
-                tree = tree[0]
-                if tree in accepted_trees:
-                    continue
-                if tree not in new_trees:
-                    new_trees.add(tree)
-                    pbar.update(1)
-                if len(new_trees) >= num_sentences:
-                    return new_trees
-
-    return new_trees
-
-def build_tag_pipe(ssplit, lang):
-    if ssplit:
-        return stanza.Pipeline(lang, processors="tokenize,pos")
-    else:
-        return stanza.Pipeline(lang, processors="tokenize,pos", tokenize_no_ssplit=True)
-
-def build_parser_pipes(lang, models):
-    """
-    Build separate pipelines for each parser model we want to use
-    """
-    parser_pipes = []
-    for model_name in models.split(","):
-        if os.path.exists(model_name):
-            # if the model name exists as a file, treat it as the path to the model
-            pipe = stanza.Pipeline(lang, processors="constituency", constituency_model_path=model_name, constituency_pretagged=True)
-        else:
-            # otherwise, assume it is a package name?
-            pipe = stanza.Pipeline(lang, processors={"constituency": model_name}, constituency_pretagged=True, package=None)
-        parser_pipes.append(pipe)
-    return parser_pipes
-
 def main():
     args = parse_args()
 
@@ -185,8 +110,8 @@ def main():
     if args.shuffle:
         random.shuffle(wiki_files)
 
-    tag_pipe = build_tag_pipe(ssplit=True, lang=args.lang)
-    parser_pipes = build_parser_pipes(args.lang, args.models)
+    tag_pipe = selftrain.build_tag_pipe(ssplit=True, lang=args.lang)
+    parser_pipes = selftrain.build_parser_pipes(args.lang, args.models)
 
     # create a blank file.  we will append to this file so that partial results can be used
     with open(args.output_file, "w") as fout:
@@ -195,7 +120,7 @@ def main():
     accepted_trees = set()
     for filename in tqdm(wiki_files, disable=False):
         docs = read_wiki_file(filename)
-        new_trees = find_matching_trees(docs, args.num_sentences, accepted_trees, tag_pipe, parser_pipes)
+        new_trees = selftrain.find_matching_trees(docs, args.num_sentences, accepted_trees, tag_pipe, parser_pipes, shuffle=args.shuffle)
         accepted_trees.update(new_trees)
 
         with open(args.output_file, "a") as fout:


### PR DESCRIPTION
Refactor the wiki selftrain script so most of the pieces can be reused for vi quad

Adjust maxlen to be smaller?  Lots of files are causing cuda errors

Turn off shuffle of docs and files using a flag

Also, throw an exception for text too long in the parser, skipping those sentences when building a silver dataset

VI quad dataset filter non-SQ sentences.

Adds a simple test for parsing the vi_quad data
