### PR TITLE
Self-Attention + Label Attention Modules

### DIFF
--- a/stanza/models/constituency/label_attention.py
+++ b/stanza/models/constituency/label_attention.py
@@ -168,13 +168,12 @@ class MultiHeadAttention(nn.Module):
     Multi-head attention module
     """
 
-    def __init__(self, hparams, n_head, d_model, d_k, d_v, residual_dropout=0.1, attention_dropout=0.1, d_positional=None):
+    def __init__(self, n_head, d_model, d_k, d_v, residual_dropout=0.1, attention_dropout=0.1, d_positional=None):
         super(MultiHeadAttention, self).__init__()
 
         self.n_head = n_head
         self.d_k = d_k
         self.d_v = d_v
-        self.hparams = hparams
 
         if d_positional is None:
             self.partitioned = False
@@ -392,9 +391,8 @@ class LabelAttention(nn.Module):
     Single-head Attention layer for label-specific representations
     """
 
-    def __init__(self, hparams, d_model, d_k, d_v, d_l, d_proj, use_resdrop=True, q_as_matrix=False, residual_dropout=0.1, attention_dropout=0.1, d_positional=None):
+    def __init__(self, d_model, d_k, d_v, d_l, d_proj, combine_as_self, use_resdrop=True, q_as_matrix=False, residual_dropout=0.1, attention_dropout=0.1, d_positional=None):
         super(LabelAttention, self).__init__()
-        self.hparams = hparams
         self.d_k = d_k
         self.d_v = d_v
         self.d_l = d_l # Number of Labels
@@ -402,7 +400,7 @@ class LabelAttention(nn.Module):
         self.d_proj = d_proj # Projection dimension of each label output
         self.use_resdrop = use_resdrop # Using Residual Dropout?
         self.q_as_matrix = q_as_matrix # Using a Matrix of Q to be multiplied with input instead of learned q vectors
-        self.combine_as_self = hparams["lal_combine_as_self"] # Using the Combination Method of Self-Attention
+        self.combine_as_self = combine_as_self # Using the Combination Method of Self-Attention
 
         if d_positional is None:
             self.partitioned = False
@@ -627,75 +625,4 @@ class LabelAttention(nn.Module):
             outputs = outputs.view(len_inp, -1).contiguous() # len_inp x (d_l * d_proj)
         
         return outputs, attns_padded
-
     
-class Encoder(nn.Module):
-    def __init__(self, hparams, embedding,
-                    num_layers=1, num_heads=2, d_kv = 32, d_ff=1024, d_l=112,
-                    d_positional=None,
-                    num_layers_position_only=0,
-                    relu_dropout=0.1, residual_dropout=0.1, attention_dropout=0.1,
-                    use_lal=True,
-                    lal_d_kv=128,
-                    lal_d_proj=128,
-                    lal_resdrop=True,
-                    lal_pwff=True,
-                    lal_q_as_matrix=False,
-                    lal_partitioned=True):
-        super().__init__()
-        self.embedding_container = [embedding]
-        d_model = embedding.d_embedding
-        self.hparams = hparams
-
-        d_k = d_v = d_kv
-
-        self.stacks = []
-
-        for i in range(hparams.num_layers):
-            attn = MultiHeadAttention(hparams, num_heads, d_model, d_k, d_v, residual_dropout=residual_dropout,
-                                      attention_dropout=attention_dropout, d_positional=d_positional)
-            if d_positional is None:
-                ff = PositionwiseFeedForward(d_model, d_ff, relu_dropout=relu_dropout,
-                                             residual_dropout=residual_dropout)
-            else:
-                ff = PartitionedPositionwiseFeedForward(d_model, d_ff, d_positional, relu_dropout=relu_dropout,
-                                                        residual_dropout=residual_dropout)
-
-            self.add_module(f"attn_{i}", attn)
-            self.add_module(f"ff_{i}", ff)
-
-            self.stacks.append((attn, ff))
-
-        if use_lal:
-            lal_d_positional = d_positional if lal_partitioned else None
-            attn = LabelAttention(hparams, d_model, lal_d_kv, lal_d_kv, d_l, lal_d_proj, use_resdrop=lal_resdrop, q_as_matrix=lal_q_as_matrix,
-                                  residual_dropout=residual_dropout, attention_dropout=attention_dropout, d_positional=lal_d_positional)
-            ff_dim = lal_d_proj * d_l
-            if hparams.lal_combine_as_self:
-                ff_dim = d_model
-            if lal_pwff:
-                if d_positional is None or not lal_partitioned:
-                    ff = PositionwiseFeedForward(ff_dim, d_ff, relu_dropout=relu_dropout, residual_dropout=residual_dropout)
-                else:
-                    ff = PartitionedPositionwiseFeedForward(ff_dim, d_ff, d_positional, relu_dropout=relu_dropout, residual_dropout=residual_dropout)
-            else:
-                ff = None
-
-            self.add_module(f"attn_{num_layers}", attn)
-            self.add_module(f"ff_{num_layers}", ff)
-            self.stacks.append((attn, ff))
-
-        self.num_layers_position_only = num_layers_position_only
-        if self.num_layers_position_only > 0:
-            assert d_positional is None, "num_layers_position_only and partitioned are incompatible"
-
-    def forward(self, xs, pre_words_idxs, batch_idxs, extra_content_annotations=None):
-        emb = self.embedding_container[0]
-        res, res_c, timing_signal, batch_idxs = emb(xs, pre_words_idxs, batch_idxs, extra_content_annotations=extra_content_annotations)
-
-        for i, (attn, ff) in enumerate(self.stacks):
-            res, current_attns = attn(res, batch_idxs)
-            if ff is not None:
-                res = ff(res, batch_idxs)
-
-        return res, current_attns #batch_idxs

--- a/stanza/models/constituency/lstm_model.py
+++ b/stanza/models/constituency/lstm_model.py
@@ -226,7 +226,7 @@ class LSTMModel(BaseModel, nn.Module):
 
 
         # Integration of the Label Attention Layer
-        
+        '''
         lal_params = {
             "lal_d_kv": 64,
             "lal_d_proj": 64,
@@ -239,7 +239,7 @@ class LSTMModel(BaseModel, nn.Module):
         }
 
         d_l = 112
-        
+       
         self.label_attention = LabelAttention(lal_params, self.pattn_d_model, lal_params["lal_d_kv"],
                                               lal_params["lal_d_kv"], d_l, lal_params["lal_d_proj"], use_resdrop=lal_params["lal_resdrop"], q_as_matrix=lal_params["lal_q_as_matrix"],
                                               residual_dropout=self.args['pattn_residual_dropout'], attention_dropout=self.args['pattn_attention_dropout'], d_positional=lal_params["lal_d_positional"])
@@ -256,6 +256,17 @@ class LSTMModel(BaseModel, nn.Module):
             self.lal_ff = PositionwiseFeedForward(ff_dim, d_ff, lal_params["lal_d_positional"], relu_dropout=relu_dropout, residual_dropout=residual_dropout)
         else:
             self.lal_ff = PartitionedPositionwiseFeedForward(ff_dim, d_ff, lal_params["lal_d_positional"], relu_dropout=relu_dropout, residual_dropout=residual_dropout)
+        '''
+        self.label_attention = LabelAttention(self.args['lattn_d_model'],
+                                              self.args['lattn_d_kv'],
+                                              self.args['lattn_d_kv'],
+                                              self.args['lattn_d_l'],
+                                              self.args['lattn_d_proj'],
+                                              self.args['lattn_resdrop'],
+                                              self.args['lattn_q_as_matrix'],
+                                              self.args['lattn_residual_dropout'],
+                                              self.args['lattn_attention_dropout'],
+                                              self.args['lattn_d_positional'])
         # End of Label Attention Specs
             
         self.word_lstm = nn.LSTM(input_size=self.word_input_size, hidden_size=self.hidden_size, num_layers=self.num_layers, bidirectional=True, dropout=self.lstm_layer_dropout)

--- a/stanza/models/constituency/lstm_model.py
+++ b/stanza/models/constituency/lstm_model.py
@@ -26,14 +26,8 @@ from stanza.models.constituency.parse_transitions import TransitionScheme
 from stanza.models.constituency.parse_tree import Tree
 from stanza.models.constituency.tree_stack import TreeStack
 from stanza.models.constituency.utils import build_nonlinearity, initialize_linear, TextTooLongError
-from stanza.models.constituency.partitioned_transformer import (
-    ConcatPositionalEncoding,
-    ConcatSinusoidalEncoding,
-    FeatureDropout,
-    PartitionedTransformerEncoder,
-    PartitionedTransformerModule
-)
-from stanza.models.constituency.label_attention import LabelAttention, PositionwiseFeedForward, PartitionedPositionwiseFeedForward, BatchIndices, LabelAttentionModule
+from stanza.models.constituency.partitioned_transformer import PartitionedTransformerModule
+from stanza.models.constituency.label_attention import LabelAttentionModule
 import numpy as np
 
 logger = logging.getLogger('stanza')
@@ -199,29 +193,6 @@ class LSTMModel(BaseModel, nn.Module):
 
             # Initializations for the Partitioned Attention
             # experiments suggest having a bias does not help here
-            '''
-            self.project_pretrained = nn.Linear(
-                self.word_input_size, self.pattn_d_model // 2, bias=True
-            )
-
-            self.pattention_morpho_emb_dropout = FeatureDropout(self.args['pattn_morpho_emb_dropout'])
-            if self.args['pattn_timing'] == 'sin':
-                self.add_timing = ConcatSinusoidalEncoding(d_model=self.pattn_d_model, max_len=self.args['pattn_encoder_max_len'])
-            elif self.args['pattn_timing'] == 'learned':
-                self.add_timing = ConcatPositionalEncoding(d_model=self.pattn_d_model, max_len=self.args['pattn_encoder_max_len'])
-            else:
-                raise ValueError("Unhandled timing type: %s" % self.args['pattn_timing'])
-            self.pattn_encoder = PartitionedTransformerEncoder(
-                self.args['pattn_num_layers'],
-                d_model=self.pattn_d_model,
-                n_head=self.args['pattn_num_heads'],
-                d_qkv=self.args['pattn_d_kv'],
-                d_ff=self.args['pattn_d_ff'],
-                ff_dropout=self.args['pattn_relu_dropout'],
-                residual_dropout=self.args['pattn_residual_dropout'],
-                attention_dropout=self.args['pattn_attention_dropout'],
-            )
-            '''
             self.partitioned_transformer_module = PartitionedTransformerModule(
                 self.args['pattn_num_layers'],
                 d_model=self.pattn_d_model,
@@ -505,45 +476,6 @@ class LSTMModel(BaseModel, nn.Module):
         # This is a list of ltensors
         # Each tensor holds the representation of a sentence extracted from phobert
         return processed
-
-    def partitioned_attention(self, attention_mask, bert_embeddings):
-        """
-        Partitioned Self Attention layer
-        This can take in an attention_mask for the normal BERT, for
-        phobert, the attention_mask will be obtained from the phobert_embeddings
-        """
-        # Prepares attention mask for feeding into the self-attention
-        if attention_mask:
-            valid_token_mask = attention_mask
-        else:
-            valids = []
-            for sent in bert_embeddings:
-                valids.append(torch.ones(len(sent)))
-
-            padded_data = torch.nn.utils.rnn.pad_sequence(
-                valids,
-                batch_first=True,
-                padding_value=-100
-            )
-
-            valid_token_mask = padded_data != -100
-
-        valid_token_mask = valid_token_mask.to(device="cuda:0")
-        padded_embeddings = torch.nn.utils.rnn.pad_sequence(
-            bert_embeddings,
-            batch_first=True,
-            padding_value=0
-        )
-
-        # Project the pretrained embedding onto the desired dimension
-        extra_content_annotations = self.project_pretrained(padded_embeddings)
-
-        # Add positional information through the table
-        encoder_in = self.add_timing(self.pattention_morpho_emb_dropout(extra_content_annotations))
-        # Put the partitioned input through the partitioned attention
-        annotations = self.pattn_encoder(encoder_in, valid_token_mask)
-
-        return annotations
 
     def initial_word_queues(self, tagged_word_lists):
         """

--- a/stanza/models/constituency/lstm_model.py
+++ b/stanza/models/constituency/lstm_model.py
@@ -239,8 +239,8 @@ class LSTMModel(BaseModel, nn.Module):
             )
             self.word_input_size += self.pattn_d_model
         else:
+            self.partitioned_transformer_module = None
             self.pattn_d_model = None
-            self.pattn_encoder = None
 
 
         # Integration of the Label Attention Layer
@@ -620,7 +620,7 @@ class LSTMModel(BaseModel, nn.Module):
             all_word_inputs = [torch.cat((x, y), axis=1) for x, y in zip(all_word_inputs, bert_embeddings)]
 
         # Extract partitioned representation
-        if self.pattn_encoder is not None:
+        if self.partitioned_transformer_module is not None:
             partitioned_embeddings = self.partitioned_transformer_module(None, all_word_inputs)
             all_word_inputs = [torch.cat((x, y[:x.shape[0], :]), axis=1) for x, y in zip(all_word_inputs, partitioned_embeddings)]
 

--- a/stanza/models/constituency/lstm_model.py
+++ b/stanza/models/constituency/lstm_model.py
@@ -226,6 +226,7 @@ class LSTMModel(BaseModel, nn.Module):
 
 
         # Integration of the Label Attention Layer
+        
         lal_params = {
             "lal_d_kv": 64,
             "lal_d_proj": 64,
@@ -238,7 +239,7 @@ class LSTMModel(BaseModel, nn.Module):
         }
 
         d_l = 112
-
+        
         self.label_attention = LabelAttention(lal_params, self.pattn_d_model, lal_params["lal_d_kv"],
                                               lal_params["lal_d_kv"], d_l, lal_params["lal_d_proj"], use_resdrop=lal_params["lal_resdrop"], q_as_matrix=lal_params["lal_q_as_matrix"],
                                               residual_dropout=self.args['pattn_residual_dropout'], attention_dropout=self.args['pattn_attention_dropout'], d_positional=lal_params["lal_d_positional"])

--- a/stanza/models/constituency/lstm_model.py
+++ b/stanza/models/constituency/lstm_model.py
@@ -31,6 +31,7 @@ from stanza.models.constituency.partitioned_transformer import (
     ConcatSinusoidalEncoding,
     FeatureDropout,
     PartitionedTransformerEncoder,
+    PartitionedTransformerModule
 )
 from stanza.models.constituency.label_attention import LabelAttention, PositionwiseFeedForward, PartitionedPositionwiseFeedForward, BatchIndices, LabelAttentionModule
 import numpy as np
@@ -198,6 +199,7 @@ class LSTMModel(BaseModel, nn.Module):
 
             # Initializations for the Partitioned Attention
             # experiments suggest having a bias does not help here
+            '''
             self.project_pretrained = nn.Linear(
                 self.word_input_size, self.pattn_d_model // 2, bias=True
             )
@@ -218,6 +220,22 @@ class LSTMModel(BaseModel, nn.Module):
                 ff_dropout=self.args['pattn_relu_dropout'],
                 residual_dropout=self.args['pattn_residual_dropout'],
                 attention_dropout=self.args['pattn_attention_dropout'],
+            )
+            '''
+            self.partitioned_transformer_module = PartitionedTransformerModule(
+                self.args['pattn_num_layers'],
+                d_model=self.pattn_d_model,
+                n_head=self.args['pattn_num_heads'],
+                d_qkv=self.args['pattn_d_kv'],
+                d_ff=self.args['pattn_d_ff'],
+                ff_dropout=self.args['pattn_relu_dropout'],
+                residual_dropout=self.args['pattn_residual_dropout'],
+                attention_dropout=self.args['pattn_attention_dropout'],
+                word_input_size=self.word_input_size,
+                bias=self.args['pattn_bias'],
+                morpho_emb_dropout=self.args['pattn_morpho_emb_dropout'],
+                timing=self.args['pattn_timing'],
+                encoder_max_len=self.args['pattn_encoder_max_len']
             )
             self.word_input_size += self.pattn_d_model
         else:
@@ -603,7 +621,7 @@ class LSTMModel(BaseModel, nn.Module):
 
         # Extract partitioned representation
         if self.pattn_encoder is not None:
-            partitioned_embeddings = self.partitioned_attention(None, all_word_inputs)
+            partitioned_embeddings = self.partitioned_transformer_module(None, all_word_inputs)
             all_word_inputs = [torch.cat((x, y[:x.shape[0], :]), axis=1) for x, y in zip(all_word_inputs, partitioned_embeddings)]
 
         # Extract Labeled Representation

--- a/stanza/models/constituency/lstm_model.py
+++ b/stanza/models/constituency/lstm_model.py
@@ -262,11 +262,27 @@ class LSTMModel(BaseModel, nn.Module):
                                               self.args['lattn_d_kv'],
                                               self.args['lattn_d_l'],
                                               self.args['lattn_d_proj'],
+                                              self.args['lattn_combine_as_self'],
                                               self.args['lattn_resdrop'],
                                               self.args['lattn_q_as_matrix'],
                                               self.args['lattn_residual_dropout'],
                                               self.args['lattn_attention_dropout'],
                                               self.args['lattn_d_positional'])
+
+        if not self.args['lattn_partitioned']:
+            self.lal_ff = PositionwiseFeedForward(self.args['lattn_d_proj']*self.args['lattn_d_l'],
+                                                  self.args['lattn_d_ff'],
+                                                  self.args['lattn_d_positional'],
+                                                  self.args['lattn_relu_dropout'],
+                                                  self.args['lattn_residual_dropout'])
+        else:
+            self.lal_ff = PartitionedPositionwiseFeedForward(self.args['lattn_d_proj']*self.args['lattn_d_l'],
+                                                             self.args['lattn_d_ff'],
+                                                             self.args['lattn_d_positional'],
+                                                             self.args['lattn_relu_dropout'],
+                                                             self.args['lattn_residual_dropout'])
+
+        self.word_input_size = self.word_input_size + self.args['lattn_d_proj']*self.args['lattn_d_l'] # ff_dim
         # End of Label Attention Specs
             
         self.word_lstm = nn.LSTM(input_size=self.word_input_size, hidden_size=self.hidden_size, num_layers=self.num_layers, bidirectional=True, dropout=self.lstm_layer_dropout)

--- a/stanza/models/constituency/partitioned_transformer.py
+++ b/stanza/models/constituency/partitioned_transformer.py
@@ -239,3 +239,81 @@ class ConcatSinusoidalEncoding(nn.Module):
         out = torch.cat([x, timing], dim=-1)
         out = self.norm(out)
         return out
+
+#
+class PartitionedTransformerModule(nn.Module):
+    def __init__(self,
+                 n_layers,
+                 d_model,
+                 n_head,
+                 d_qkv,
+                 d_ff,
+                 ff_dropout,
+                 residual_dropout,
+                 attention_dropout, #
+                 word_input_size,
+                 bias,
+                 morpho_emb_dropout,
+                 timing,
+                 encoder_max_len,
+                 activation=PartitionedReLU()
+    ):
+        super().__init__()
+        self.project_pretrained = nn.Linear(
+            word_input_size, d_model // 2, bias=bias
+        )
+
+        self.pattention_morpho_emb_dropout = FeatureDropout(morpho_emb_dropout)
+        if timing == 'sin':
+            self.add_timing = ConcatSinusoidalEncoding(d_model=d_model, max_len=encoder_max_len)
+        elif timing == 'learned':
+            self.add_timing = ConcatPositionalEncoding(d_model=d_model, max_len=encoder_max_len)
+        else:
+            raise ValueError("Unhandled timing type: %s" % timing)
+        self.pattn_encoder = PartitionedTransformerEncoder(
+            num_layers,
+            d_model=d_model,
+            n_head=num_heads,
+            d_qkv=d_kv,
+            d_ff=d_ff,
+            ff_dropout=relu_dropout,
+            residual_dropout=residual_dropout,
+            attention_dropout=attention_dropout,
+        )
+
+
+    #
+    def forward(self, attention_mask, bert_embeddings):
+        # Prepares attention mask for feeding into the self-attention
+        if attention_mask:
+            valid_token_mask = attention_mask
+        else:
+            valids = []
+            for sent in bert_embeddings:
+                valids.append(torch.ones(len(sent)))
+
+            padded_data = torch.nn.utils.rnn.pad_sequence(
+                valids,
+                batch_first=True,
+                padding_value=-100
+            )
+
+            valid_token_mask = padded_data != -100
+
+        valid_token_mask = valid_token_mask.to(device="cuda:0")
+        padded_embeddings = torch.nn.utils.rnn.pad_sequence(
+            bert_embeddings,
+            batch_first=True,
+            padding_value=0
+        )
+
+        # Project the pretrained embedding onto the desired dimension
+        extra_content_annotations = self.project_pretrained(padded_embeddings)
+
+        # Add positional information through the table
+        encoder_in = self.add_timing(self.pattention_morpho_emb_dropout(extra_content_annotations))
+        # Put the partitioned input through the partitioned attention
+        annotations = self.pattn_encoder(encoder_in, valid_token_mask)
+
+        return annotations
+

--- a/stanza/models/constituency/partitioned_transformer.py
+++ b/stanza/models/constituency/partitioned_transformer.py
@@ -271,12 +271,12 @@ class PartitionedTransformerModule(nn.Module):
         else:
             raise ValueError("Unhandled timing type: %s" % timing)
         self.pattn_encoder = PartitionedTransformerEncoder(
-            num_layers,
+            n_layers,
             d_model=d_model,
-            n_head=num_heads,
-            d_qkv=d_kv,
+            n_head=n_head,
+            d_qkv=d_qkv,
             d_ff=d_ff,
-            ff_dropout=relu_dropout,
+            ff_dropout=ff_dropout,
             residual_dropout=residual_dropout,
             attention_dropout=attention_dropout,
         )

--- a/stanza/models/constituency_parser.py
+++ b/stanza/models/constituency_parser.py
@@ -330,7 +330,6 @@ def parse_args(args=None):
     parser.add_argument('--lattn_d_ff', default=2048, type=int, help='Dimension of the Feed-forward layer')
     parser.add_argument('--lattn_relu_dropout', default=0.2, type=float, help='Relu dropout for the label attention')
     parser.add_argument('--lattn_residual_dropout', default=0.2, type=float, help='Residual dropout for the label attention')
-    parser.add_argument('--lattn_partitioned', default=True, action='store_true', help='Whether or to partition the PositionwiseFeedForward layer')
     
     args = parser.parse_args(args=args)
     if not args.lang and args.shorthand and len(args.shorthand.split("_")) == 2:

--- a/stanza/models/constituency_parser.py
+++ b/stanza/models/constituency_parser.py
@@ -301,6 +301,7 @@ def parse_args(args=None):
     parser.add_argument('--retag_method', default='xpos', choices=['xpos', 'upos'], help='Which tags to use when retagging')
     parser.add_argument('--no_retag', dest='retag_package', action="store_const", const=None, help="Don't retag the trees")
 
+    # Partitioned Attention 
     parser.add_argument('--pattn_d_model', default=1024, type=int, help='Partitioned attention model dimensionality')
     parser.add_argument('--pattn_morpho_emb_dropout', default=0.2, type=float, help='Dropout rate for morphological features obtained from pretrained model')
     parser.add_argument('--pattn_encoder_max_len', default=512, type=int, help='Max length that can be put into the transformer attention layer')
@@ -314,6 +315,22 @@ def parse_args(args=None):
     # Results seem relatively similar with learned position embeddings or sin/cos position embeddings
     parser.add_argument('--pattn_timing', default='sin', choices=['learned', 'sin'], help='Use a learned embedding or a sin embedding')
 
+    # Label Attention
+    parser.add_argument('--lattn_d_kv', default=64, type=int, help='Dimension of the key/query vector')
+    parser.add_argument('--lattn_d_proj', default=64, type=int, help='Dimension of the output vector from each label attention head')
+    parser.add_argument('--lattn_resdrop', default=True, action='store_true', help='Whether or not to use Residual Dropout')
+    parser.add_argument('--lattn_pwff', default=True, action='store_true', help='Whether or not to use a Position-wise Feed-forward Layer')
+    parser.add_argument('--lattn_q_as_matrix', default=False, action='store_true', help='Whether or not Label Attention uses learned query vectors. False means it does')
+    parser.add_argument('--lattn_partitioned', default=True, action='store_true', help='Whether or not it is partitioned')
+    parser.add_argument('--lattn_combine_as_self', default=False, action='store_true', help='Whether or not the layer uses concatenation. False means it does')
+    parser.add_argument('--lattn_d_positional', default=512, type=int, help='Dimension for the positional embedding')
+    parser.add_argument('--lattn_d_l', default=32, type=int, help='Number of labels')
+    parser.add_argument('--lattn_attention_dropout', default=0.2, type=float, help='Dropout for attention layer')
+    parser.add_argument('--lattn_d_ff', default=2048, type=int, help='Dimension of the Feed-forward layer')
+    parser.add_argument('--lattn_relu_dropout', default=0.2, type=float, help='Relu dropout for the label attention')
+    parser.add_argument('--lattn_residual_dropout', default=0.2, type=float, help='Residual dropout for the label attention')
+    parser.add_argument('--lattn_partitioned', default=True, action='store_true', help='Whether or to partition the PositionwiseFeedForward layer')
+    
     args = parser.parse_args(args=args)
     if not args.lang and args.shorthand and len(args.shorthand.split("_")) == 2:
         args.lang = args.shorthand.split("_")[0]

--- a/stanza/models/constituency_parser.py
+++ b/stanza/models/constituency_parser.py
@@ -312,6 +312,7 @@ def parse_args(args=None):
     parser.add_argument('--pattn_residual_dropout', default=0.2, type=float, help='Residual dropout probability for all residual connections')
     parser.add_argument('--pattn_attention_dropout', default=0.2, type=float, help='Attention dropout probability')
     parser.add_argument('--pattn_num_layers', default=12, type=int, help='Number of layers for the Partitioned Attention')
+    parser.add_argument('--pattn_bias', default=True, action='store_true', help='Whether or not to learn an additive bias')
     # Results seem relatively similar with learned position embeddings or sin/cos position embeddings
     parser.add_argument('--pattn_timing', default='sin', choices=['learned', 'sin'], help='Use a learned embedding or a sin embedding')
 

--- a/stanza/models/constituency_parser.py
+++ b/stanza/models/constituency_parser.py
@@ -316,6 +316,7 @@ def parse_args(args=None):
     parser.add_argument('--pattn_timing', default='sin', choices=['learned', 'sin'], help='Use a learned embedding or a sin embedding')
 
     # Label Attention
+    parser.add_argument('--lattn_d_model', default=1024, type=int, help='Label Attention Layer dimensionality')
     parser.add_argument('--lattn_d_kv', default=64, type=int, help='Dimension of the key/query vector')
     parser.add_argument('--lattn_d_proj', default=64, type=int, help='Dimension of the output vector from each label attention head')
     parser.add_argument('--lattn_resdrop', default=True, action='store_true', help='Whether or not to use Residual Dropout')


### PR DESCRIPTION
Adding the PartitionedTransformerModule and the LabelAttentionModule, both of which can be used for further testing with other layers of the parser. It would be easy to import these modules and plug them into other Stanza tools, such as the NER, or any other tools that have not incorporated attention.

The two modules, as of now, require an embedding and the appropriate maskings for the embedding. The PartitionedTransformerModule returns a partitioned representation that takes into account both content and positional information. The LabelAttentionModule returns a labeled representation that takes into account the appropriate labels. 