### PR TITLE
Fix charoffset in edge case when a token begins with whitespace and skip_newline is enabled

### DIFF
--- a/stanza/models/tokenization/utils.py
+++ b/stanza/models/tokenization/utils.py
@@ -363,7 +363,7 @@ def output_predictions(output_file, trainer, data_generator, vocab, mwt_dict, ma
                             partlen = len(part)
                         lstripped = part.lstrip()
                         if st < 0:
-                            st = char_offset + st0 + (len(part) - len(lstripped))
+                            st = char_offset + st0 + (partlen - len(lstripped))
                         char_offset += st0 + partlen
                     position_info = (st, char_offset)
                 else:

--- a/stanza/models/tokenization/utils.py
+++ b/stanza/models/tokenization/utils.py
@@ -358,10 +358,11 @@ def output_predictions(output_file, trainer, data_generator, vocab, mwt_dict, ma
                             match = part_pattern.search(text, char_offset)
                             st0 = match.start(0) - char_offset
                             partlen = match.end(0) - match.start(0)
+                            lstripped = match.group(0).lstrip()
                         else:
                             st0 = text.index(part, char_offset) - char_offset
                             partlen = len(part)
-                        lstripped = part.lstrip()
+                            lstripped = part.lstrip()
                         if st < 0:
                             st = char_offset + st0 + (partlen - len(lstripped))
                         char_offset += st0 + partlen

--- a/stanza/tests/pipeline/test_tokenizer.py
+++ b/stanza/tests/pipeline/test_tokenizer.py
@@ -142,6 +142,7 @@ JA_DOC_GOLD_NOSSPLIT_TOKENS = """
 
 ZH_DOC = "北京是中国的首都。 北京有2100万人口，是一个直辖市。\n"
 ZH_DOC1 = "北\n京是中\n国的首\n都。 北京有2100万人口，是一个直辖市。\n"
+ZH_DOC2 = "北\n京是中\n国的首\n都。\n\n 北京有2100万人口，是一个直辖市。\n"
 ZH_DOC_GOLD_TOKENS = """
 <Token id=1;words=[<Word id=1;text=北京>]>
 <Token id=2;words=[<Word id=2;text=是>]>
@@ -163,24 +164,24 @@ ZH_DOC_GOLD_TOKENS = """
 """.strip()
 
 ZH_DOC1_GOLD_TOKENS="""
-<Token id=1;words=[<Word id=1;text=北京;lemma=北京;upos=PROPN;xpos=NNP;head=5;deprel=nsubj>]>
-<Token id=2;words=[<Word id=2;text=是;lemma=是;upos=AUX;xpos=VC;head=5;deprel=cop>]>
-<Token id=3;words=[<Word id=3;text=中国;lemma=中国;upos=PROPN;xpos=NNP;head=5;deprel=nmod>]>
-<Token id=4;words=[<Word id=4;text=的;lemma=的;upos=PART;xpos=DEC;feats=Case=Gen;head=3;deprel=case>]>
-<Token id=5;words=[<Word id=5;text=首都;lemma=首都;upos=NOUN;xpos=NN;head=0;deprel=root>]>
-<Token id=6;words=[<Word id=6;text=。;lemma=。;upos=PUNCT;xpos=.;head=5;deprel=punct>]>
+<Token id=1;words=[<Word id=1;text=北京>]>
+<Token id=2;words=[<Word id=2;text=是>]>
+<Token id=3;words=[<Word id=3;text=中国>]>
+<Token id=4;words=[<Word id=4;text=的>]>
+<Token id=5;words=[<Word id=5;text=首都>]>
+<Token id=6;words=[<Word id=6;text=。>]>
 
-<Token id=1;words=[<Word id=1;text=北京;lemma=北京;upos=PROPN;xpos=NNP;head=2;deprel=nsubj>]>
-<Token id=2;words=[<Word id=2;text=有;lemma=有;upos=VERB;xpos=VV;head=10;deprel=acl>]>
-<Token id=3;words=[<Word id=3;text=2100万;lemma=2100万;upos=NUM;xpos=CD;feats=NumType=Card;head=4;deprel=nummod>]>
-<Token id=4;words=[<Word id=4;text=人口;lemma=人口;upos=NOUN;xpos=NN;head=2;deprel=obj>]>
-<Token id=5;words=[<Word id=5;text=，;lemma=，;upos=PUNCT;xpos=,;head=10;deprel=punct>]>
-<Token id=6;words=[<Word id=6;text=是;lemma=是;upos=AUX;xpos=VC;head=10;deprel=cop>]>
-<Token id=7;words=[<Word id=7;text=一;lemma=一;upos=NUM;xpos=CD;feats=NumType=Card;head=8;deprel=nummod>]>
-<Token id=8;words=[<Word id=8;text=个;lemma=个;upos=NOUN;xpos=NNB;head=10;deprel=nmod>]>
-<Token id=9;words=[<Word id=9;text=直辖;lemma=直辖;upos=VERB;xpos=VV;head=10;deprel=compound>]>
-<Token id=10;words=[<Word id=10;text=市;lemma=市;upos=PART;xpos=SFN;head=0;deprel=root>]>
-<Token id=11;words=[<Word id=11;text=。;lemma=。;upos=PUNCT;xpos=.;head=10;deprel=punct>]>
+<Token id=1;words=[<Word id=1;text=北京>]>
+<Token id=2;words=[<Word id=2;text=有>]>
+<Token id=3;words=[<Word id=3;text=2100万>]>
+<Token id=4;words=[<Word id=4;text=人口>]>
+<Token id=5;words=[<Word id=5;text=，>]>
+<Token id=6;words=[<Word id=6;text=是>]>
+<Token id=7;words=[<Word id=7;text=一>]>
+<Token id=8;words=[<Word id=8;text=个>]>
+<Token id=9;words=[<Word id=9;text=直辖>]>
+<Token id=10;words=[<Word id=10;text=市>]>
+<Token id=11;words=[<Word id=11;text=。>]>
 """.strip()
 
 ZH_DOC_GOLD_NOSSPLIT_TOKENS = """
@@ -281,8 +282,15 @@ def test_no_ssplit():
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
 
 def test_zh_tokenizer_skip_newline():
-    nlp = stanza.Pipeline(lang='zh', dir=TEST_MODELS_DIR)
+    nlp = stanza.Pipeline(lang='zh', processors='tokenize', dir=TEST_MODELS_DIR)
     doc = nlp(ZH_DOC1)
+
+    assert ZH_DOC1_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
+    assert all([doc.text[token._start_char: token._end_char].replace('\n', '') == token.text for sent in doc.sentences for token in sent.tokens])
+
+def test_zh_tokenizer_skip_newline_offsets():
+    nlp = stanza.Pipeline(lang='zh', processors='tokenize', dir=TEST_MODELS_DIR)
+    doc = nlp(ZH_DOC2)
 
     assert ZH_DOC1_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char].replace('\n', '') == token.text for sent in doc.sentences for token in sent.tokens])


### PR DESCRIPTION
## Description
The start offset for tokens is wrong when the tokenizer has `skip_newline` enabled (e.g., in Chinese) and a token is preceded by whitespace.

## Fixes Issues
N/A

## Unit test coverage
New unit test `test_zh_tokenizer_skip_newline_offsets` added in `stanza/tests/pipeline/test_tokenizer.py`, also reduced the scope of the original `test_zh_tokenizer_skip_newline` to only consider tokenizers.

## Known breaking changes/behaviors
No breaking changes, but the behavior of char offsets should improve for languages that use `skip_newline` in their tokenizers.