### PR TITLE
Add bert embeddings to the bottom layer of the NER.

### DIFF
--- a/stanza/models/common/bert_embedding.py
+++ b/stanza/models/common/bert_embedding.py
@@ -1,0 +1,181 @@
+import math
+import logging
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.utils.rnn import pad_packed_sequence, pack_padded_sequence, pack_sequence, PackedSequence
+from transformers import AutoModel, AutoTokenizer
+
+logger = logging.getLogger('stanza')
+
+BERT_ARGS = {
+    "vinai/phobert-base": { "use_fast": True },
+    "vinai/phobert-large": { "use_fast": True },
+}
+
+
+def load_tokenizer(model_name):
+    if model_name:
+        # note that use_fast is the default
+        bert_args = BERT_ARGS.get(model_name, dict())
+        if not model_name.startswith("vinai/phobert"):
+            bert_args["add_prefix_space"] = True
+        bert_tokenizer = AutoTokenizer.from_pretrained(model_name, **bert_args)
+        return bert_tokenizer
+    return None
+
+def load_bert(model_name):
+    if model_name:
+        # such as: "vinai/phobert-base"
+        bert_model = AutoModel.from_pretrained(model_name)
+        bert_tokenizer = load_tokenizer(model_name)
+        return bert_model, bert_tokenizer
+    return None, None
+
+def tokenize_manual(model_name, sent, tokenizer):
+    """
+    Tokenize a sentence manually, using for checking long sentences and PHOBert.
+    """
+    #replace \xa0 or whatever the space character is by _ since PhoBERT expects _ between syllables
+    tokenized = [word.replace("\xa0","_").replace(" ", "_") for word in sent] if model_name.startswith("vinai/phobert") else [word.replace("\xa0"," ") for word in sent]
+
+    #concatenate to a sentence
+    sentence = ' '.join(tokenized)
+
+    #tokenize using AutoTokenizer PhoBERT
+    tokenized = tokenizer.tokenize(sentence)
+
+    #convert tokens to ids
+    sent_ids = tokenizer.convert_tokens_to_ids(tokenized)
+
+    #add start and end tokens to sent_ids
+    tokenized_sent = [tokenizer.bos_token_id] + sent_ids + [tokenizer.eos_token_id]
+
+    return tokenized, tokenized_sent
+
+def filter_data(model_name, data, tokenizer = None):
+    """
+    Filter out the (NER) data that is too long for BERT model.
+    """
+    if tokenizer is None:
+        tokenizer = load_tokenizer(model_name) 
+    filtered_data = []
+    #eliminate all the sentences that are too long for bert model
+    for sent in data:
+        sentence = [word[0] for word in sent]
+        _, tokenized_sent = tokenize_manual(model_name, sentence, tokenizer)
+        
+        if len(tokenized_sent) > tokenizer.model_max_length:
+            continue
+
+        filtered_data.append(sent)
+
+    logger.info("Eliminated {} datapoints because their length is over maximum size of BERT model. ".format(len(data)-len(filtered_data)))
+    
+    return filtered_data
+
+
+def extract_phobert_embeddings(model_name, tokenizer, model, data, device):
+    """
+    Extract transformer embeddings using a method specifically for phobert
+    Since phobert doesn't have the is_split_into_words / tokenized.word_ids(batch_index=0)
+    capability, we instead look for @@ to denote a continued token.
+    data: list of list of string (the text tokens)
+    """
+    processed = [] # final product, returns the list of list of word representation
+    tokenized_sents = [] # list of sentences, each is a torch tensor with start and end token
+    list_tokenized = [] # list of tokenized sentences from phobert
+    for idx, sent in enumerate(data):
+
+        tokenized, tokenized_sent = tokenize_manual(model_name, sent, tokenizer)
+
+        #add tokenized to list_tokenzied for later checking
+        list_tokenized.append(tokenized)
+
+        if len(tokenized_sent) > tokenizer.model_max_length:
+            logger.error("Invalid size, max size: %d, got %d %s", tokenizer.model_max_length, len(tokenized_sent), data[idx])
+            #raise TextTooLongError(len(tokenized_sent), tokenizer.model_max_length, idx, " ".join(data[idx]))
+
+        #add to tokenized_sents
+        tokenized_sents.append(torch.tensor(tokenized_sent).detach())
+
+        processed_sent = []
+        processed.append(processed_sent)
+
+        # done loading bert emb
+
+    size = len(tokenized_sents)
+
+    #padding the inputs
+    tokenized_sents_padded = torch.nn.utils.rnn.pad_sequence(tokenized_sents,batch_first=True,padding_value=tokenizer.pad_token_id)
+
+    features = []
+
+    # Feed into PhoBERT 128 at a time in a batch fashion. In testing, the loop was
+    # run only 1 time as the batch size seems to be 30
+    for i in range(int(math.ceil(size/128))):
+        with torch.no_grad():
+            feature = model(tokenized_sents_padded[128*i:128*i+128].clone().detach().to(device), output_hidden_states=True)
+            # averaging the last four layers worked well for non-VI languages
+            feature = feature[2]
+            feature = torch.stack(feature[-4:-1], axis=3).sum(axis=3) / 4
+            features += feature.clone().detach()
+
+    assert len(features)==size
+    assert len(features)==len(processed)
+
+    #process the output
+    #only take the vector of the last word piece of a word/ you can do other methods such as first word piece or averaging.
+    # idx2+1 compensates for the start token at the start of a sentence
+    # [0] and [-1] grab the start and end representations as well
+    offsets = [[idx2+1 for idx2, _ in enumerate(list_tokenized[idx]) if (idx2 > 0 and not list_tokenized[idx][idx2-1].endswith("@@")) or (idx2==0)] 
+                for idx, sent in enumerate(processed)]
+    processed = [feature[offset] for feature, offset in zip(features, offsets)]
+
+    # This is a list of ltensors
+    # Each tensor holds the representation of a sentence extracted from phobert
+    return processed
+
+def extract_bert_embeddings(model_name, tokenizer, model, data, device):
+    """
+    Extract transformer embeddings using a generic roberta extraction
+    data: list of list of string (the text tokens)
+    """
+    if model_name.startswith("vinai/phobert"):
+        return extract_phobert_embeddings(model_name, tokenizer, model, data, device)
+
+    #add add_prefix_space = True for RoBerTa-- error if not
+    tokenized = tokenizer(data, padding="longest", is_split_into_words=True, return_offsets_mapping=False, return_attention_mask=False)
+    list_offsets = [[None] * (len(sentence)+2) for sentence in data]
+    for idx in range(len(data)):
+        offsets = tokenized.word_ids(batch_index=idx)
+        for pos, offset in enumerate(offsets):
+            if offset is None:
+                continue
+            # this uses the last token piece for any offset by overwriting the previous value
+            list_offsets[idx][offset+1] = pos
+        list_offsets[idx][0] = 0
+        list_offsets[idx][-1] = -1
+
+        if len(offsets) > tokenizer.model_max_length:
+            logger.error("Invalid size, max size: %d, got %d %s", tokenizer.model_max_length, len(offsets), data[idx])
+            raise TextTooLongError(len(offsets), tokenizer.model_max_length, idx, " ".join(data[idx]))
+
+    features = []
+    for i in range(int(math.ceil(len(data)/128))):
+        with torch.no_grad():
+            feature = model(torch.tensor(tokenized['input_ids'][128*i:128*i+128]).to(device), output_hidden_states=True)
+            feature = feature[2]
+            feature = torch.stack(feature[-4:-1], axis=3).sum(axis=3) / 4
+            features += feature.clone().detach()
+
+    processed = []
+    #remove the bos and eos tokens
+    list_offsets = [ sent[1:-1] for sent in list_offsets]
+    #process the output
+    for feature, offsets in zip(features, list_offsets):
+        new_sent = feature[offsets]
+        processed.append(new_sent)
+
+    return processed

--- a/stanza/models/ner/model.py
+++ b/stanza/models/ner/model.py
@@ -1,20 +1,26 @@
 import os
+import logging
+
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.nn.utils.rnn import pad_packed_sequence, pack_padded_sequence, pack_sequence, PackedSequence
+from torch.nn.utils.rnn import pad_packed_sequence, pack_padded_sequence, pack_sequence, pad_sequence, PackedSequence
+from stanza.models.common.data import map_to_ids, get_long_tensor
 
 from stanza.models.common.packed_lstm import PackedLSTM
 from stanza.models.common.dropout import WordDropout, LockedDropout
 from stanza.models.common.char_model import CharacterModel, CharacterLanguageModel
 from stanza.models.common.crf import CRFLoss
 from stanza.models.common.vocab import PAD_ID
+from stanza.models.common.bert_embedding import extract_bert_embeddings
+logger = logging.getLogger('stanza')
 
 class NERTagger(nn.Module):
-    def __init__(self, args, vocab, emb_matrix=None):
+    def __init__(self, args, vocab, emb_matrix=None, bert_model=None, bert_tokenizer=None, use_cuda=False):
         super().__init__()
 
+        self.use_cuda = use_cuda
         self.vocab = vocab
         self.args = args
         self.unsaved_modules = []
@@ -22,6 +28,9 @@ class NERTagger(nn.Module):
         def add_unsaved_module(name, module):
             self.unsaved_modules += [name]
             setattr(self, name, module)
+
+        add_unsaved_module('bert_model', bert_model)
+        add_unsaved_module('bert_tokenizer', bert_tokenizer)
 
         # input layers
         input_size = 0
@@ -33,6 +42,8 @@ class NERTagger(nn.Module):
             if not self.args.get('emb_finetune', True):
                 self.word_emb.weight.detach_()
             input_size += self.args['word_emb_dim']
+            if self.bert_model is not None:
+                input_size += self.bert_model.config.hidden_size
 
         if self.args['char'] and self.args['char_emb_dim'] > 0:
             if self.args['charlm']:
@@ -82,16 +93,31 @@ class NERTagger(nn.Module):
             "Input embedding matrix must match size: {} x {}, found {}".format(vocab_size, dim, emb_matrix.size())
         self.word_emb.weight.data.copy_(emb_matrix)
 
-    def forward(self, word, word_mask, wordchars, wordchars_mask, tags, word_orig_idx, sentlens, wordlens, chars, charoffsets, charlens, char_orig_idx):
+    def forward(self, sentences, wordchars, wordchars_mask, tags, word_orig_idx, sentlens, wordlens, chars, charoffsets, charlens, char_orig_idx):
         
         def pack(x):
             return pack_padded_sequence(x, sentlens, batch_first=True)
         
         inputs = []
+        batch_size = len(sentences)
+
         if self.args['word_emb_dim'] > 0:
-            word_emb = self.word_emb(word)
-            word_emb = pack(word_emb)
+            #extract static embeddings
+            static_words, word_mask = self.extract_static_embeddings(self.args, sentences)
+
+            if self.use_cuda:
+                word_mask = word_mask.cuda()
+                static_words = static_words.cuda()
+                
+            word_static_emb = self.word_emb(static_words)
+            word_emb = pack(word_static_emb)
             inputs += [word_emb]
+
+        if self.bert_model is not None:
+            device = next(self.parameters()).device
+            processed_bert = extract_bert_embeddings(self.args['bert_model'], self.bert_tokenizer, self.bert_model, sentences, device)
+            processed_bert = pad_sequence(processed_bert, batch_first=True)
+            inputs += [pack(processed_bert)]
 
         def pad(x):
             return pad_packed_sequence(PackedSequence(x, word_emb.batch_sizes), batch_first=True)[0]
@@ -121,8 +147,8 @@ class NERTagger(nn.Module):
 
         lstm_inputs = PackedSequence(lstm_inputs, inputs[0].batch_sizes)
         lstm_outputs, _ = self.taggerlstm(lstm_inputs, sentlens, hx=(\
-                self.taggerlstm_h_init.expand(2 * self.args['num_layers'], word.size(0), self.args['hidden_dim']).contiguous(), \
-                self.taggerlstm_c_init.expand(2 * self.args['num_layers'], word.size(0), self.args['hidden_dim']).contiguous()))
+                self.taggerlstm_h_init.expand(2 * self.args['num_layers'], batch_size, self.args['hidden_dim']).contiguous(), \
+                self.taggerlstm_c_init.expand(2 * self.args['num_layers'], batch_size, self.args['hidden_dim']).contiguous()))
         lstm_outputs = lstm_outputs.data
 
 
@@ -135,3 +161,19 @@ class NERTagger(nn.Module):
         loss, trans = self.crit(logits, word_mask, tags)
         
         return loss, logits, trans
+
+    def extract_static_embeddings(self, args, sents):
+        processed = []
+        if args.get('lowercase', True): # handle word case
+            case = lambda x: x.lower()
+        else:
+            case = lambda x: x
+        for idx, sent in enumerate(sents):
+            processed_sent = [self.vocab['word'].map([case(w) for w in sent])]
+            processed.append(processed_sent[0])
+
+        words = get_long_tensor(processed, len(sents))
+        words_mask = torch.eq(words, PAD_ID)
+
+        return words, words_mask
+

--- a/stanza/models/ner_tagger.py
+++ b/stanza/models/ner_tagger.py
@@ -73,6 +73,10 @@ def parse_args(args=None):
     parser.add_argument('--no_input_transform', dest='input_transform', action='store_false', help="Do not use input transformation layer before tagger lstm.")
     parser.add_argument('--scheme', type=str, default='bioes', help="The tagging scheme to use: bio or bioes.")
 
+
+    parser.add_argument('--bert_model', type=str, default=None, help="Use an external bert model (requires the transformers package)")
+    parser.add_argument('--no_bert_model', dest='bert_model', action="store_const", const=None, help="Don't use bert")
+
     parser.add_argument('--sample_train', type=float, default=1.0, help='Subsample training data.')
     parser.add_argument('--optim', type=str, default='sgd', help='sgd, adagrad, adam or adamax.')
     parser.add_argument('--lr', type=float, default=0.1, help='Learning rate.')
@@ -265,7 +269,7 @@ def evaluate(args):
     # load data
     logger.info("Loading data with batch size {}...".format(args['batch_size']))
     doc = Document(json.load(open(args['eval_file'])))
-    batch = DataLoader(doc, args['batch_size'], loaded_args, vocab=vocab, evaluation=True)
+    batch = DataLoader(doc, args['batch_size'], loaded_args, vocab=vocab, evaluation=True, bert_tokenizer=trainer.bert_tokenizer)
     utils.warn_missing_tags([i for i in trainer.vocab['tag']], batch.tags, "eval_file")
 
     logger.info("Start evaluation...")

--- a/stanza/pipeline/ner_processor.py
+++ b/stanza/pipeline/ner_processor.py
@@ -77,7 +77,7 @@ class NERProcessor(UDProcessor):
         all_preds = []
         for trainer, config in zip(self.trainers, self.configs):
             # set up a eval-only data loader and skip tag preprocessing
-            batch = DataLoader(document, config['batch_size'], config, vocab=trainer.vocab, evaluation=True, preprocess_tags=False)
+            batch = DataLoader(document, config['batch_size'], config, vocab=trainer.vocab, evaluation=True, preprocess_tags=False, bert_tokenizer=trainer.bert_tokenizer)
             preds = []
             for i, b in enumerate(batch):
                 preds += trainer.predict(b)

--- a/stanza/utils/training/common.py
+++ b/stanza/utils/training/common.py
@@ -43,6 +43,9 @@ BERT = {
     # "it": "idb-ita/gilberto-uncased-from-camembert",
 
     # from https://github.com/musixmatchresearch/umberto
+    # on NER, this gets 88.37 dev and 91.02 test
+    # another option is dbmdz/bert-base-italian-cased,
+    # which gets 87.27 dev and 90.32 test
     "it": "Musixmatch/umberto-commoncrawl-cased-v1",
 
     # from https://github.com/VinAIResearch/PhoBERT

--- a/stanza/utils/training/common.py
+++ b/stanza/utils/training/common.py
@@ -23,6 +23,54 @@ class Mode(Enum):
     SCORE_DEV = 2
     SCORE_TEST = 3
 
+BERT = {
+    # https://huggingface.co/dbmdz/bert-base-turkish-128k-cased
+    # helps the Turkish model quite a bit
+    "tr": "dbmdz/bert-base-turkish-128k-cased",
+
+    # https://huggingface.co/Maltehb/danish-bert-botxo
+    # contrary to normal expectations, this hurts F1
+    # on a dev split by about 1 F1
+    # "da": "Maltehb/danish-bert-botxo",
+
+    # the multilingual bert is a marginal improvement for conparse
+    "da": "bert-base-multilingual-cased",
+
+    # from https://github.com/idb-ita/GilBERTo
+    # annoyingly, it doesn't handle cased text
+    # supposedly there is an argument "do_lower_case"
+    # but that still leaves a lot of unk tokens
+    # "it": "idb-ita/gilberto-uncased-from-camembert",
+
+    # from https://github.com/musixmatchresearch/umberto
+    "it": "Musixmatch/umberto-commoncrawl-cased-v1",
+
+    # from https://github.com/VinAIResearch/PhoBERT
+    # "vi": "vinai/phobert-base",
+    # another option is phobert-large, but that doesn't
+    # change the scores any
+    "vi": "vinai/phobert-large",
+
+    # https://huggingface.co/roberta-base
+    "en": "roberta-base",
+
+    # https://github.com/ymcui/Chinese-BERT-wwm
+    # there's also hfl/chinese-roberta-wwm-ext-large
+    "zh-hans": "hfl/chinese-roberta-wwm-ext",
+
+    # experiments on the cintil dataset
+    # ran a variety of transformer settings
+    # found the following dev set scores after 400 iterations:
+    # Geotrend/distilbert-base-pt-cased : not plug & play
+    # no bert: 0.9082
+    # xlm-roberta-base: 0.9109
+    # xlm-roberta-large: 0.9254
+    # adalbertojunior/distilbert-portuguese-cased: 0.9300
+    # neuralmind/bert-base-portuguese-cased: 0.9307
+    # neuralmind/bert-large-portuguese-cased: 0.9343
+    "pt": "neuralmind/bert-large-portuguese-cased",
+}
+
 def build_argparse():
     parser = argparse.ArgumentParser()
     parser.add_argument('--save_output', dest='temp_output', default=True, action='store_false', help="Save output - default is to use a temp directory.")

--- a/stanza/utils/training/run_constituency.py
+++ b/stanza/utils/training/run_constituency.py
@@ -25,54 +25,6 @@ RETAG_METHOD = {
     "pt": "upos",   # default PT model has no xpos either
 }
 
-BERT = {
-    # https://huggingface.co/dbmdz/bert-base-turkish-128k-cased
-    # helps the Turkish model quite a bit
-    "tr": "dbmdz/bert-base-turkish-128k-cased",
-
-    # https://huggingface.co/Maltehb/danish-bert-botxo
-    # contrary to normal expectations, this hurts F1
-    # on a dev split by about 1 F1
-    # "da": "Maltehb/danish-bert-botxo",
-
-    # the multilingual bert is a marginal improvement for conparse
-    "da": "bert-base-multilingual-cased",
-
-    # from https://github.com/idb-ita/GilBERTo
-    # annoyingly, it doesn't handle cased text
-    # supposedly there is an argument "do_lower_case"
-    # but that still leaves a lot of unk tokens
-    # "it": "idb-ita/gilberto-uncased-from-camembert",
-
-    # from https://github.com/musixmatchresearch/umberto
-    "it": "Musixmatch/umberto-commoncrawl-cased-v1",
-
-    # from https://github.com/VinAIResearch/PhoBERT
-    # "vi": "vinai/phobert-base",
-    # another option is phobert-large, but that doesn't
-    # change the scores any
-    "vi": "vinai/phobert-large",
-
-    # https://huggingface.co/roberta-base
-    "en": "roberta-base",
-
-    # https://github.com/ymcui/Chinese-BERT-wwm
-    # there's also hfl/chinese-roberta-wwm-ext-large
-    "zh-hans": "hfl/chinese-roberta-wwm-ext",
-
-    # experiments on the cintil dataset
-    # ran a variety of transformer settings
-    # found the following dev set scores after 400 iterations:
-    # Geotrend/distilbert-base-pt-cased : not plug & play
-    # no bert: 0.9082
-    # xlm-roberta-base: 0.9109
-    # xlm-roberta-large: 0.9254
-    # adalbertojunior/distilbert-portuguese-cased: 0.9300
-    # neuralmind/bert-base-portuguese-cased: 0.9307
-    # neuralmind/bert-large-portuguese-cased: 0.9343
-    "pt": "neuralmind/bert-large-portuguese-cased",
-}
-
 def add_constituency_args(parser):
     parser.add_argument('--charlm', default="default", type=str, help='Which charlm to run on.  Will use the default charlm for this language/model if not set.  Set to None to turn off charlm for languages with a default charlm')
     parser.add_argument('--no_charlm', dest='charlm', action="store_const", const=None, help="Don't use a charlm, even if one is used by default for this package")
@@ -110,7 +62,7 @@ def run_treebank(mode, paths, treebank, short_name,
     charlm_args = build_charlm_args(language, charlm, base_args=False)
 
     default_args = retag_args + wordvec_args + charlm_args
-    if language in BERT:
+    if language in common.BERT:
         default_args.extend(['--bert_model', BERT.get(language)])
 
     if mode == Mode.TRAIN:

--- a/stanza/utils/training/run_ner.py
+++ b/stanza/utils/training/run_ner.py
@@ -81,13 +81,17 @@ def run_treebank(mode, paths, treebank, short_name,
         #   --charlm --charlm_shorthand vi_conll17
         #   --dropout 0.6 --word_dropout 0.1 --locked_dropout 0.1 --char_dropout 0.1
         dataset_args = DATASET_EXTRA_ARGS.get(short_name, [])
+        if language in common.BERT:
+            bert_args = ['--bert_model', common.BERT.get(language)]
+        else:
+            bert_args = []
 
         train_args = ['--train_file', train_file,
                       '--eval_file', dev_file,
                       '--lang', language,
                       '--shorthand', short_name,
                       '--mode', 'train']
-        train_args = train_args + charlm_args + dataset_args + extra_args
+        train_args = train_args + charlm_args + bert_args + dataset_args + extra_args
         if '--wordvec_pretrain_file' not in train_args:
             # will throw an error if the pretrain can't be found
             wordvec_pretrain = find_wordvec_pretrain(language, default_treebanks)


### PR DESCRIPTION
Refactor filter data code and extractions stanza/models/common/bert_embedding.py
this will make it easier to add bert embeddings to the bottom layer of other models

TODO: process long sentences rather than discarding or having an error
TODO: put bert tokenizers and models into a separate module so that when the same bert
is used in multiple models, it doesn't have to be loaded twice
