### PR TITLE
Cache loading bert/transformer models in the pipeline

### DIFF
--- a/stanza/models/common/foundation_cache.py
+++ b/stanza/models/common/foundation_cache.py
@@ -1,0 +1,57 @@
+"""
+Keeps BERT, charlm, word embedings in a cache to save memory
+"""
+
+import logging
+import threading
+
+from stanza.models.common import bert_embedding
+from stanza.models.common.pretrain import Pretrain
+
+logger = logging.getLogger('stanza')
+
+class FoundationCache:
+    def __init__(self):
+        self.bert = {}
+        self.pretrains = {}
+        # future proof the module by using a lock for the glorious day
+        # when the GIL is finally gone
+        self.lock = threading.Lock()
+
+    def load_bert(self, transformer_name):
+        """
+        Load a transformer only once
+
+        Uses a lock for thread safety
+        """
+        if transformer_name is None:
+            return None, None
+        with self.lock:
+            if transformer_name not in self.bert:
+                model, tokenizer = bert_embedding.load_bert(transformer_name)
+                self.bert[transformer_name] = (model, tokenizer)
+
+            return self.bert[transformer_name]
+
+    def load_pretrain(self, filename):
+        """
+        Load a pretrained word embedding only once
+
+        Uses a lock for thread safety
+        """
+        if filename is None:
+            return None
+        with self.lock:
+            if filename not in self.pretrains:
+                logger.debug("Loading pretrain %s", filename)
+                self.pretrains[filename] = Pretrain(filename)
+            else:
+                logger.debug("Reusing pretrain %s", filename)
+
+            return self.pretrains[filename]
+
+def load_bert(model_name, foundation_cache=None):
+    if foundation_cache is None:
+        return bert_embedding.load_bert(model_name)
+    else:
+        return foundation_cache.load_bert(model_name)

--- a/stanza/pipeline/core.py
+++ b/stanza/pipeline/core.py
@@ -14,6 +14,7 @@ import os
 from distutils.util import strtobool
 from stanza.pipeline._constants import *
 from stanza.models.common.doc import Document
+from stanza.models.common.foundation_cache import FoundationCache
 from stanza.pipeline.processor import Processor, ProcessorRequirementsException
 from stanza.pipeline.registry import NAME_TO_PROCESSOR_CLASS, PIPELINE_NAMES, PROCESSOR_VARIANTS
 from stanza.pipeline.langid_processor import LangIDProcessor
@@ -177,6 +178,10 @@ class Pipeline:
 
         # set global logging level
         set_logging_level(logging_level, verbose)
+
+        # processors can use this to save on the effort of loading
+        # large sub-models, such as pretrained embeddings, bert, etc
+        self.foundation_cache = FoundationCache()
 
         if (download_method is DownloadMethod.DOWNLOAD_RESOURCES or
             (download_method is DownloadMethod.REUSE_RESOURCES and not os.path.exists(os.path.join(self.dir, "resources.json")))):

--- a/stanza/pipeline/depparse_processor.py
+++ b/stanza/pipeline/depparse_processor.py
@@ -3,7 +3,6 @@ Processor for performing dependency parsing
 """
 
 from stanza.models.common import doc
-from stanza.models.common.pretrain import Pretrain
 from stanza.models.common.utils import unsort
 from stanza.models.depparse.data import DataLoader
 from stanza.models.depparse.trainer import Trainer
@@ -31,8 +30,8 @@ class DepparseProcessor(UDProcessor):
         else:
             self._requires = self.__class__.REQUIRES_DEFAULT
 
-    def _set_up_model(self, config, use_gpu):
-        self._pretrain = Pretrain(config['pretrain_path']) if 'pretrain_path' in config else None
+    def _set_up_model(self, config, pipeline, use_gpu):
+        self._pretrain = pipeline.foundation_cache.load_pretrain(config['pretrain_path']) if 'pretrain_path' in config else None
         self._trainer = Trainer(pretrain=self.pretrain, model_file=config['model_path'], use_cuda=use_gpu)
 
     def process(self, document):

--- a/stanza/pipeline/langid_processor.py
+++ b/stanza/pipeline/langid_processor.py
@@ -28,7 +28,7 @@ class LangIDProcessor(UDProcessor):
     # default max sequence length
     MAX_SEQ_LENGTH_DEFAULT = 1000
 
-    def _set_up_model(self, config, use_gpu):
+    def _set_up_model(self, config, pipeline, use_gpu):
         batch_size = config.get("batch_size", 64)
         self._model = LangIDBiLSTM.load(path=config["model_path"], use_cuda=use_gpu,
                                         batch_size=batch_size, lang_subset=config.get("lang_subset"))

--- a/stanza/pipeline/lemma_processor.py
+++ b/stanza/pipeline/lemma_processor.py
@@ -29,7 +29,7 @@ class LemmaProcessor(UDProcessor):
     def use_identity(self):
         return self._use_identity
 
-    def _set_up_model(self, config, use_gpu):
+    def _set_up_model(self, config, pipeline, use_gpu):
         if config.get('use_identity') in ['True', True]:
             self._use_identity = True
             self._config = config

--- a/stanza/pipeline/mwt_processor.py
+++ b/stanza/pipeline/mwt_processor.py
@@ -17,7 +17,7 @@ class MWTProcessor(UDProcessor):
     # set of processor requirements for this processor
     REQUIRES_DEFAULT = set([TOKENIZE])
 
-    def _set_up_model(self, config, use_gpu):
+    def _set_up_model(self, config, pipeline, use_gpu):
         self._trainer = Trainer(model_file=config['model_path'], use_cuda=use_gpu)
 
     def process(self, document):

--- a/stanza/pipeline/ner_processor.py
+++ b/stanza/pipeline/ner_processor.py
@@ -30,7 +30,7 @@ class NERProcessor(UDProcessor):
             dependencies = [x.get(dep_name) for x in config.get('dependencies', [])]
         return dependencies
 
-    def _set_up_model(self, config, use_gpu):
+    def _set_up_model(self, config, pipeline, use_gpu):
         # set up trainer
         model_paths = config.get('model_path')
         if isinstance(model_paths, str):
@@ -44,7 +44,7 @@ class NERProcessor(UDProcessor):
             logger.debug("Loading %s with forward charlm %s and backward charlm %s", model_path, charlm_forward, charlm_backward)
             args = {'charlm_forward_file': charlm_forward,
                     'charlm_backward_file': charlm_backward}
-            trainer = Trainer(args=args, model_file=model_path, use_cuda=use_gpu)
+            trainer = Trainer(args=args, model_file=model_path, use_cuda=use_gpu, foundation_cache=pipeline.foundation_cache)
             self.trainers.append(trainer)
 
         self._trainer = self.trainers[0]

--- a/stanza/pipeline/pos_processor.py
+++ b/stanza/pipeline/pos_processor.py
@@ -3,7 +3,6 @@ Processor for performing part-of-speech tagging
 """
 
 from stanza.models.common import doc
-from stanza.models.common.pretrain import Pretrain
 from stanza.models.common.utils import get_tqdm, unsort
 from stanza.models.pos.data import DataLoader
 from stanza.models.pos.trainer import Trainer
@@ -20,9 +19,9 @@ class POSProcessor(UDProcessor):
     # set of processor requirements for this processor
     REQUIRES_DEFAULT = set([TOKENIZE])
 
-    def _set_up_model(self, config, use_gpu):
+    def _set_up_model(self, config, pipeline, use_gpu):
         # get pretrained word vectors
-        self._pretrain = Pretrain(config['pretrain_path']) if 'pretrain_path' in config else None
+        self._pretrain = pipeline.foundation_cache.load_pretrain(config['pretrain_path']) if 'pretrain_path' in config else None
         # set up trainer
         self._trainer = Trainer(pretrain=self.pretrain, model_file=config['model_path'], use_cuda=use_gpu)
         self._tqdm = 'tqdm' in config and config['tqdm']

--- a/stanza/pipeline/processor.py
+++ b/stanza/pipeline/processor.py
@@ -156,13 +156,13 @@ class UDProcessor(Processor):
         self._trainer = None
         self._vocab = None
         if not hasattr(self, '_variant'):
-            self._set_up_model(config, use_gpu)
+            self._set_up_model(config, pipeline, use_gpu)
 
         # build the final config for the processor
         self._set_up_final_config(config)
 
     @abstractmethod
-    def _set_up_model(self, config, gpu):
+    def _set_up_model(self, config, pipeline, gpu):
         pass
 
     def _set_up_final_config(self, config):

--- a/stanza/pipeline/sentiment_processor.py
+++ b/stanza/pipeline/sentiment_processor.py
@@ -13,7 +13,6 @@ import stanza.models.classifiers.cnn_classifier as cnn_classifier
 
 from stanza.models.common import doc
 from stanza.models.common.char_model import CharacterLanguageModel
-from stanza.models.common.pretrain import Pretrain
 from stanza.pipeline._constants import *
 from stanza.pipeline.processor import UDProcessor, register_processor
 
@@ -27,10 +26,10 @@ class SentimentProcessor(UDProcessor):
     # default batch size, measured in words per batch
     DEFAULT_BATCH_SIZE = 5000
 
-    def _set_up_model(self, config, use_gpu):
+    def _set_up_model(self, config, pipeline, use_gpu):
         # get pretrained word vectors
         pretrain_path = config.get('pretrain_path', None)
-        self._pretrain = Pretrain(pretrain_path) if pretrain_path else None
+        self._pretrain = pipeline.foundation_cache.load_pretrain(pretrain_path) if pretrain_path else None
         forward_charlm_path = config.get('forward_charlm_path', None)
         charmodel_forward = CharacterLanguageModel.load(forward_charlm_path, finetune=False) if forward_charlm_path else None
         backward_charlm_path = config.get('backward_charlm_path', None)

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -32,7 +32,7 @@ class TokenizeProcessor(UDProcessor):
     # default max sequence length
     MAX_SEQ_LENGTH_DEFAULT = 1000
 
-    def _set_up_model(self, config, use_gpu):
+    def _set_up_model(self, config, pipeline, use_gpu):
         # set up trainer
         if config.get('pretokenized'):
             self._trainer = None

--- a/stanza/utils/datasets/ner/prepare_ner_dataset.py
+++ b/stanza/utils/datasets/ner/prepare_ner_dataset.py
@@ -220,7 +220,11 @@ def convert_bio_to_json(base_input_path, base_output_path, short_name, suffix="b
     for shard in SHARDS:
         input_filename = os.path.join(base_input_path, '%s.%s.%s' % (short_name, shard, suffix))
         if not os.path.exists(input_filename):
-            raise FileNotFoundError('Cannot find %s component of %s in %s' % (shard, short_name, input_filename))
+            alt_filename = os.path.join(base_input_path, '%s.%s' % (shard, suffix))
+            if os.path.exists(alt_filename):
+                input_filename = alt_filename
+            else:
+                raise FileNotFoundError('Cannot find %s component of %s in %s' % (shard, short_name, input_filename))
         output_filename = os.path.join(base_output_path, '%s.%s.json' % (short_name, shard))
         print("Converting %s to %s" % (input_filename, output_filename))
         prepare_ner_file.process_dataset(input_filename, output_filename)


### PR DESCRIPTION
Update all of the processors to get the EmbeddingCache from the pipeline

Cache the pretrain as well (this doesn't seem to change much in terms of memory usage, though)
