### PR TITLE
Process sentence ids from the corpus, if available.  Change sentence.…

### DIFF
--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -95,6 +95,7 @@ RUSSIAN_SAMPLE="""
 """.strip()
 
 RUSSIAN_TEXT = ["Как- то слишком мало цветов получают актёры после спектакля.", "В женщине важна верность, а не красота."]
+RUSSIAN_IDS = ["yandex.reviews-f-8xh5zqnmwak3t6p68y4rhwd4e0-1969-9253", "4"]
 
 def check_russian_doc(doc):
     """
@@ -105,8 +106,10 @@ def check_russian_doc(doc):
     assert lines[0] == doc.sentences[0].comments[0]
     assert lines[1] == doc.sentences[0].comments[1]
     assert lines[2] == doc.sentences[0].comments[2]
-    for expected_text, sentence in zip(RUSSIAN_TEXT, doc.sentences):
+    for sent_idx, (expected_text, expected_id, sentence) in enumerate(zip(RUSSIAN_TEXT, RUSSIAN_IDS, doc.sentences)):
         assert expected_text == sentence.text
+        assert expected_id == sentence.sent_id
+        assert sent_idx == sentence.index
         assert len(sentence.comments) == 3
 
     sentences = CoNLL.doc2conll(doc)

--- a/stanza/tests/pipeline/test_english_pipeline.py
+++ b/stanza/tests/pipeline/test_english_pipeline.py
@@ -87,6 +87,7 @@ EN_DOC_DEPENDENCY_PARSES_GOLD = """
 
 EN_DOC_CONLLU_GOLD = """
 # text = Barack Obama was born in Hawaii.
+# sent_id = 0
 1	Barack	Barack	PROPN	NNP	Number=Sing	4	nsubj:pass	_	start_char=0|end_char=6
 2	Obama	Obama	PROPN	NNP	Number=Sing	1	flat	_	start_char=7|end_char=12
 3	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux:pass	_	start_char=13|end_char=16
@@ -96,6 +97,7 @@ EN_DOC_CONLLU_GOLD = """
 7	.	.	PUNCT	.	_	4	punct	_	start_char=31|end_char=32
 
 # text = He was elected president in 2008.
+# sent_id = 1
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj:pass	_	start_char=34|end_char=36
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	start_char=37|end_char=40
 3	elected	elect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	start_char=41|end_char=48
@@ -105,6 +107,7 @@ EN_DOC_CONLLU_GOLD = """
 7	.	.	PUNCT	.	_	3	punct	_	start_char=66|end_char=67
 
 # text = Obama attended Harvard.
+# sent_id = 2
 1	Obama	Obama	PROPN	NNP	Number=Sing	2	nsubj	_	start_char=69|end_char=74
 2	attended	attend	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	start_char=75|end_char=83
 3	Harvard	Harvard	PROPN	NNP	Number=Sing	2	obj	_	start_char=84|end_char=91
@@ -114,6 +117,7 @@ EN_DOC_CONLLU_GOLD = """
 
 EN_DOC_CONLLU_GOLD_MULTIDOC = """
 # text = Barack Obama was born in Hawaii.
+# sent_id = 0
 1	Barack	Barack	PROPN	NNP	Number=Sing	4	nsubj:pass	_	start_char=0|end_char=6
 2	Obama	Obama	PROPN	NNP	Number=Sing	1	flat	_	start_char=7|end_char=12
 3	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux:pass	_	start_char=13|end_char=16
@@ -123,6 +127,7 @@ EN_DOC_CONLLU_GOLD_MULTIDOC = """
 7	.	.	PUNCT	.	_	4	punct	_	start_char=31|end_char=32
 
 # text = He was elected president in 2008.
+# sent_id = 1
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj:pass	_	start_char=0|end_char=2
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux:pass	_	start_char=3|end_char=6
 3	elected	elect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	start_char=7|end_char=14
@@ -132,6 +137,7 @@ EN_DOC_CONLLU_GOLD_MULTIDOC = """
 7	.	.	PUNCT	.	_	3	punct	_	start_char=32|end_char=33
 
 # text = Obama attended Harvard.
+# sent_id = 2
 1	Obama	Obama	PROPN	NNP	Number=Sing	2	nsubj	_	start_char=0|end_char=5
 2	attended	attend	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	_	start_char=6|end_char=14
 3	Harvard	Harvard	PROPN	NNP	Number=Sing	2	obj	_	start_char=15|end_char=22
@@ -191,6 +197,10 @@ class TestEnglishPipeline:
     def test_words_multidoc(self, processed_multidoc):
         assert "\n\n".join([sent.words_string() for processed_doc in processed_multidoc for sent in processed_doc.sentences]) == EN_DOC_WORDS_GOLD
 
+    def test_sentence_indices_multidoc(self, processed_multidoc):
+        sentences = [sent for doc in processed_multidoc for sent in doc.sentences]
+        for sent_idx, sentence in enumerate(sentences):
+            assert sent_idx == sentence.index
 
     def test_dependency_parse_multidoc(self, processed_multidoc):
         assert "\n\n".join([sent.dependencies_string() for processed_doc in processed_multidoc for sent in processed_doc.sentences]) == \


### PR DESCRIPTION
Process sentence ids from the corpus, if available.  Change sentence.id to a string (and incidentally make it match the documentation regarding being 1 indexed)

