### PR TITLE
fix: move pe to the appropriate device

### DIFF
--- a/stanza/models/constituency/positional_encoding.py
+++ b/stanza/models/constituency/positional_encoding.py
@@ -21,7 +21,7 @@ class SinusoidalEncoding(nn.Module):
         pe[:, 0::2] = torch.sin(position * div_term)
         pe[:, 1::2] = torch.cos(position * div_term)
         if device is not None:
-            pe.to(device=device)
+            pe = pe.to(device=device)
         return pe
 
     def forward(self, x):


### PR DESCRIPTION
## Description
Moving a tensor to a particular device is not an in-place operation. To move `pe` to another device, it needs to be re-assigned with the returned tensor. 

## Fixes Issues
#989 

## Unit test coverage
```
nlp = stanza.Pipeline(lang=model, logging_level="DEBUG")
sent = "Over and over again Dorian used to read this fantastic chapter, and the two chapters immediately following, in which, as in some curious tapestries or cunningly-wrought enamels, were pictured the awful and beautiful forms of those whom Vice and Blood and Weariness had made monstrous or mad: Filippo, Duke of Milan, who slew his wife, and painted her lips with a scarlet poison that her lover might suck death from the dead thing he fondled; Pietro Barbi, the Venetian, known as Paul the Second, who sought in his vanity to assume the title of Formosus, and whose tiara, valued at two hundred thousand florins, was bought at the price of a terrible sin; Gian Maria Visconti, who used hounds to chase living men, and whose murdered body was covered with roses by a harlot who had loved him; the Borgia on his white horse, with Fratricide riding beside him, and his mantle stained with the blood of Perotto; Pietro Riario, the young Cardinal Archbishop of Florence, child and minion of Sixtus IV., whose beauty was equalled only by his debauchery, and who received Leonora of Aragon in a pavilion of white and crimson silk, filled with nymphs and centaurs, and gilded a boy that he might serve at the feast as Ganymede or Hylas; Ezzelin, whose melancholy could be cured only by the spectacle of death, and who had a passion for red blood, as other men have for red wine--the son of the Fiend, as was reported, and one who had cheated his father at dice when gambling with him for his own soul; Giambattista Cibo, who in mockery took the name of Innocent, and into whose torpid veins the blood of three lads was infused by a Jewish doctor; Sigismondo Malatesta, the lover of Isotta, and the lord of Rimini, whose effigy was burned at Rome as the enemy of God and man, who strangled Polyssena with a napkin, and gave poison to Ginevra d'Este in a cup of emerald, and in honour of a shameful passion built a pagan church for Christian worship; Charles VI., who had so wildly adored his brother's wife that a leper had warned him of the insanity that was coming on him, and who, when his brain had sickened and grown strange, could only be soothed by Saracen cards painted with the images of Love and Death and Madness; and, in his trimmed jerkin and jewelled cap and acanthus-like curls, Grifonetto Baglioni, who slew Astorre with his bride, and Simonetto with his page, and whose comeliness was such that, as he lay dying in the yellow piazza of Perugia, those who had hated him could not choose but weep, and Atalanta, who had cursed him, blessed him."
nlp(sent)
```

## Known breaking changes/behaviors
No
