### PR TITLE
Refactor tok

### DIFF
--- a/stanza/models/tokenization/data.py
+++ b/stanza/models/tokenization/data.py
@@ -45,16 +45,22 @@ class DataLoader:
             else:
                 text = input_text
 
+            text_chunks = NEWLINE_WHITESPACE_RE.split(text)
+            text_chunks = [pt.rstrip() for pt in text_chunks]
+            text_chunks = [pt for pt in text_chunks if pt]
             if label_file is not None:
                 with open(label_file) as f:
                     labels = ''.join(f.readlines()).rstrip()
+                    labels = NEWLINE_WHITESPACE_RE.split(labels)
+                    labels = [pt.rstrip() for pt in labels]
+                    labels = [map(int, pt) for pt in labels if pt]
             else:
-                labels = '\n\n'.join(['0' * len(pt.rstrip()) for pt in NEWLINE_WHITESPACE_RE.split(text)])
+                labels = [[0 for _ in pt] for pt in text_chunks]
 
             skip_newline = args.get('skip_newline', False)
-            self.data = [[(WHITESPACE_RE.sub(' ', char), int(label)) # substitute special whitespaces
-                          for char, label in zip(pt.rstrip(), pc) if not (skip_newline and char == '\n')] # check if newline needs to be eaten
-                         for pt, pc in zip(NEWLINE_WHITESPACE_RE.split(text), NEWLINE_WHITESPACE_RE.split(labels)) if len(pt.rstrip()) > 0]
+            self.data = [[(WHITESPACE_RE.sub(' ', char), label) # substitute special whitespaces
+                          for char, label in zip(pt, pc) if not (skip_newline and char == '\n')] # check if newline needs to be eaten
+                         for pt, pc in zip(text_chunks, labels)]
 
         # remove consecutive whitespaces
         self.data = [filter_consecutive_whitespaces(x) for x in self.data]

--- a/stanza/models/tokenization/trainer.py
+++ b/stanza/models/tokenization/trainer.py
@@ -73,11 +73,11 @@ class Trainer(BaseTrainer):
 
     def save(self, filename):
         params = {
-                'model': self.model.state_dict() if self.model is not None else None,
-                'vocab': self.vocab.state_dict(),
-                'lexicon': self.lexicon,
-                'config': self.args
-                }
+            'model': self.model.state_dict() if self.model is not None else None,
+            'vocab': self.vocab.state_dict(),
+            'lexicon': self.lexicon,
+            'config': self.args
+        }
         try:
             torch.save(params, filename, _use_new_zipfile_serialization=False)
             logger.info("Model saved to {}".format(filename))

--- a/stanza/models/tokenization/utils.py
+++ b/stanza/models/tokenization/utils.py
@@ -297,7 +297,7 @@ def output_predictions(output_file, trainer, data_generator, vocab, mwt_dict, ma
                     break
                 # once we've made predictions on a certain number of characters for each paragraph (recorded in `adv`),
                 # we skip the first `adv` characters to make the updated batch
-                batch = data_generator.next(eval_offsets=adv, old_batch=batch)
+                batch = data_generator.advance_old_batch(adv, batch)
 
             pred = [np.concatenate(p, 0) for p in pred]
 

--- a/stanza/models/tokenization/utils.py
+++ b/stanza/models/tokenization/utils.py
@@ -45,6 +45,7 @@ def create_dictionary(lexicon=None):
             add_word(word)
 
     return dictionary
+
 def create_lexicon(shorthand=None, train_path=None, external_path=None):
     """
     This function is to create a lexicon to store all the words from the training set and external dictionary.

--- a/stanza/tests/tokenization/test_tokenize_data.py
+++ b/stanza/tests/tokenization/test_tokenize_data.py
@@ -6,8 +6,10 @@ the data from a temp file, for example
 """
 
 import pytest
+import tempfile
 import stanza
 
+from stanza import Pipeline
 from stanza.tests import *
 from stanza.models.tokenization.data import DataLoader
 
@@ -35,4 +37,70 @@ def test_has_mwt():
 
     data = DataLoader(args=FAKE_PROPERTIES, input_data=MWT_DATA)
     assert data.has_mwt()
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    pipeline = Pipeline("en", dir=TEST_MODELS_DIR, download_method=None, processors="tokenize")
+    tokenizer = pipeline.processors['tokenize']
+    return tokenizer
+
+EXPECTED_TWO_NL_RAW = [[('T', 0), ('h', 0), ('i', 0), ('s', 0), (' ', 0), ('i', 0), ('s', 0), (' ', 0), ('a', 0), (' ', 0), ('t', 0), ('e', 0), ('s', 0), ('t', 0)], [('f', 0), ('o', 0), ('o', 0)]]
+# in this test, the newline after test becomes a space labeled 0
+EXPECTED_ONE_NL_RAW = [[('T', 0), ('h', 0), ('i', 0), ('s', 0), (' ', 0), ('i', 0), ('s', 0), (' ', 0), ('a', 0), (' ', 0), ('t', 0), ('e', 0), ('s', 0), ('t', 0), (' ', 0), ('f', 0), ('o', 0), ('o', 0)]]
+EXPECTED_SKIP_NL_RAW = [[('T', 0), ('h', 0), ('i', 0), ('s', 0), (' ', 0), ('i', 0), ('s', 0), (' ', 0), ('a', 0), (' ', 0), ('t', 0), ('e', 0), ('s', 0), ('t', 0), ('f', 0), ('o', 0), ('o', 0)]]
+
+def test_convert_units_raw_text(tokenizer):
+    """
+    Tests converting a couple small segments to units
+    """
+    raw_text = "This is a      test\n\nfoo"
+    batches = DataLoader(tokenizer.config, input_text=raw_text, vocab=tokenizer.vocab, evaluation=True, dictionary=tokenizer.trainer.dictionary)
+    assert batches.data == EXPECTED_TWO_NL_RAW
+
+    raw_text = "This is a      test\nfoo"
+    batches = DataLoader(tokenizer.config, input_text=raw_text, vocab=tokenizer.vocab, evaluation=True, dictionary=tokenizer.trainer.dictionary)
+    assert batches.data == EXPECTED_ONE_NL_RAW
+
+    skip_newline_config = dict(tokenizer.config)
+    skip_newline_config['skip_newline'] = True
+    batches = DataLoader(skip_newline_config, input_text=raw_text, vocab=tokenizer.vocab, evaluation=True, dictionary=tokenizer.trainer.dictionary)
+    assert batches.data == EXPECTED_SKIP_NL_RAW
+
+
+EXPECTED_TWO_NL_FILE = [[('T', 0), ('h', 0), ('i', 0), ('s', 0), (' ', 0), ('i', 0), ('s', 0), (' ', 0), ('a', 0), (' ', 0), ('t', 0), ('e', 0), ('s', 0), ('t', 0), ('.', 1)], [('f', 0), ('o', 0), ('o', 0)]]
+# in this test, the newline after test becomes a space labeled 0
+EXPECTED_ONE_NL_FILE = [[('T', 0), ('h', 0), ('i', 0), ('s', 0), (' ', 0), ('i', 0), ('s', 0), (' ', 0), ('a', 0), (' ', 0), ('t', 0), ('e', 0), ('s', 0), ('t', 0), ('.', 1), (' ', 0), ('f', 0), ('o', 0), ('o', 0)]]
+
+def test_convert_units_file(tokenizer):
+    """
+    Tests reading some text from a file and converting that to units
+    """
+    with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+        # two nl test case, read from file
+        labels   = "00000000000000000001\n\n000\n\n"
+        raw_text = "This is a      test.\n\nfoo\n\n"
+
+        txt_file = os.path.join(test_dir, "testfile.txt")
+        label_file = os.path.join(test_dir, "labelfile.txt")
+        with open(txt_file, "w") as fout:
+            fout.write(raw_text)
+        with open(label_file, "w") as fout:
+            fout.write(labels)
+
+        batches = DataLoader(tokenizer.config, input_files={'txt': txt_file, 'label': label_file}, vocab=tokenizer.vocab, evaluation=True, dictionary=tokenizer.trainer.dictionary)
+        assert batches.data == EXPECTED_TWO_NL_FILE
+
+        # one nl test case, read from file
+        labels   = "000000000000000000010000\n\n"
+        raw_text = "This is a      test.\nfoo\n\n"
+
+        txt_file = os.path.join(test_dir, "testfile.txt")
+        label_file = os.path.join(test_dir, "labelfile.txt")
+        with open(txt_file, "w") as fout:
+            fout.write(raw_text)
+        with open(label_file, "w") as fout:
+            fout.write(labels)
+
+        batches = DataLoader(tokenizer.config, input_files={'txt': txt_file, 'label': label_file}, vocab=tokenizer.vocab, evaluation=True, dictionary=tokenizer.trainer.dictionary)
+        assert batches.data == EXPECTED_ONE_NL_FILE
 


### PR DESCRIPTION
Refactor some pieces of the tokenizer and make some optimizations on the way.  In particular, passing around numpy or torch arrays is faster than making lists of numbers.

Add some tests of the data object as well.

When parsing one large data file, this makes the tokenizer about 10% faster by simplifying some of the logic to go from raw letters -> numbers