### PR TITLE
Refactor dataloader

### DIFF
--- a/stanza/models/tokenization/data.py
+++ b/stanza/models/tokenization/data.py
@@ -187,9 +187,9 @@ class TokenizationDataset:
         lens = (ounits != padid).sum(1).tolist()
         pad_len = max(l-i for i, l in zip(eval_offsets, lens))
 
-        units = np.full((len(ounits), pad_len), padid, dtype=np.int64)
-        labels = np.full((len(ounits), pad_len), -1, dtype=np.int64)
-        features = np.zeros((len(ounits), pad_len, feat_size), dtype=np.float32)
+        units = torch.full((len(ounits), pad_len), padid, dtype=torch.int32)
+        labels = torch.full((len(ounits), pad_len), -1, dtype=torch.int32)
+        features = torch.zeros((len(ounits), pad_len, feat_size), dtype=torch.float32)
         raw_units = []
 
         for i in range(len(ounits)):
@@ -198,10 +198,6 @@ class TokenizationDataset:
             labels[i, :(lens[i] - eval_offsets[i])] = olabels[i, eval_offsets[i]:lens[i]]
             features[i, :(lens[i] - eval_offsets[i])] = ofeatures[i, eval_offsets[i]:lens[i]]
             raw_units.append(oraw[i][eval_offsets[i]:lens[i]] + ['<PAD>'] * (pad_len - lens[i] + eval_offsets[i]))
-
-        units = torch.from_numpy(units)
-        labels = torch.from_numpy(labels)
-        features = torch.from_numpy(features)
 
         return units, labels, features, raw_units
 

--- a/stanza/models/tokenizer.py
+++ b/stanza/models/tokenizer.py
@@ -25,7 +25,7 @@ import torch
 import json
 from stanza.models.common import utils
 from stanza.models.tokenization.trainer import Trainer
-from stanza.models.tokenization.data import DataLoader
+from stanza.models.tokenization.data import DataLoader, TokenizationDataset
 from stanza.models.tokenization.utils import load_mwt_dict, eval_model, output_predictions, load_lexicon, create_dictionary
 from stanza.models import _training_logging
 
@@ -141,7 +141,7 @@ def train(args):
             'txt': args['dev_txt_file'],
             'label': args['dev_label_file']
             }
-    dev_batches = DataLoader(args, input_files=dev_input_files, vocab=vocab, evaluation=True,  dictionary=dictionary)
+    dev_batches = TokenizationDataset(args, input_files=dev_input_files, vocab=vocab, evaluation=True, dictionary=dictionary)
 
     if args['use_mwt'] is None:
         args['use_mwt'] = train_batches.has_mwt()
@@ -216,7 +216,7 @@ def evaluate(args):
             }
 
 
-    batches = DataLoader(args, input_files=eval_input_files, vocab=vocab, evaluation=True,  dictionary=trainer.dictionary)
+    batches = TokenizationDataset(args, input_files=eval_input_files, vocab=vocab, evaluation=True, dictionary=trainer.dictionary)
 
     oov_count, N, _, _ = output_predictions(args['conll_file'], trainer, batches, vocab, mwt_dict, args['max_seqlen'])
 

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -5,7 +5,7 @@ Processor for performing tokenization
 import io
 import logging
 
-from stanza.models.tokenization.data import DataLoader
+from stanza.models.tokenization.data import TokenizationDataset
 from stanza.models.tokenization.trainer import Trainer
 from stanza.models.tokenization.utils import output_predictions
 from stanza.pipeline._constants import *
@@ -82,12 +82,13 @@ class TokenizeProcessor(UDProcessor):
 
         raw_text = '\n\n'.join(document) if isinstance(document, list) else document
         # set up batches
-        batches = DataLoader(self.config, input_text=raw_text, vocab=self.vocab, evaluation=True, dictionary=self.trainer.dictionary)
+        batches = TokenizationDataset(self.config, input_text=raw_text, vocab=self.vocab, evaluation=True, dictionary=self.trainer.dictionary)
         # get dict data
         _, _, _, document = output_predictions(None, self.trainer, batches, self.vocab, None,
                                                self.config.get('max_seqlen', TokenizeProcessor.MAX_SEQ_LENGTH_DEFAULT),
                                                orig_text=raw_text,
-                                               no_ssplit=self.config.get('no_ssplit', False))
+                                               no_ssplit=self.config.get('no_ssplit', False),
+                                               num_workers = self.config.get('num_workers', 0))
         return doc.Document(document, raw_text)
 
     def bulk_process(self, docs):


### PR DESCRIPTION
Refactor the tokenizer data module to use a torch DataLoader at eval time.  Train time is not changed at all.

Between version 1.4.0 and dev branch as of this pull request, some optimizations were added to pass around numpy or torch items sooner.  This improved the runtime some already.  Switching to a pytorch dataloader further improves the runtime.  Timing on a 2080ti and a CPU that was top of the line a couple years ago:

```
main branch:
real    0m53.964s
user    0m51.178s
sys     0m4.205s

dev branch:
real    0m46.744s
user    0m44.220s
sys     0m4.028s

refactor_dataloader branch:
real    0m38.706s
user    0m46.471s
sys     0m6.985s
```

Most of the timing improvements wound up being portable to the dev branch without the Dataloader.  However, there are a few circumstances where lots of docs of mixed sizes can be faster by spawning multiple workers.  Also, in general it's basically the same speed if you go with num_workers=0, which is the default.  At least merging this in will make it easier to optimize the multiple worker case in the future...