### PR TITLE
Try to generalize wikiner reading - currently the download format is a

### DIFF
--- a/stanza/utils/datasets/ner/preprocess_wikiner.py
+++ b/stanza/utils/datasets/ner/preprocess_wikiner.py
@@ -6,9 +6,9 @@ python preprocess_wikiner input output
 
 import sys
 
-def preprocess_wikiner(input_file, output_file):
-    with open(input_file) as fin:
-        with open(output_file, "w") as fout:
+def preprocess_wikiner(input_file, output_file, encoding="utf-8"):
+    with open(input_file, encoding=encoding) as fin:
+        with open(output_file, "w", encoding="utf-8") as fout:
             for line in fin:
                 line = line.strip()
                 if not line:


### PR DESCRIPTION
Try to generalize wikiner reading - currently the download format is a
bz2 file with one thing in it, but an older layout I have had the text
itself in a "raw" subdirectory

ignore leftover bz2 files

Some of the input files are Windows encoded ffs
