### PR TITLE
Add getting all possible values for each feat

### DIFF
--- a/stanza/pipeline/pos_processor.py
+++ b/stanza/pipeline/pos_processor.py
@@ -48,8 +48,8 @@ class POSProcessor(UDProcessor):
         """
         Returns the features known by this model
         """
-        keys = [k for k in self.vocab['feats']._unit2id.keys() if k not in VOCAB_PREFIX]
-        return keys
+        values = {k: v.keys() - VOCAB_PREFIX for k, v in self.vocab['feats']._unit2id.items()}
+        return values
 
     def process(self, document):
         batch = DataLoader(

--- a/stanza/tests/pipeline/test_pipeline_pos_processor.py
+++ b/stanza/tests/pipeline/test_pipeline_pos_processor.py
@@ -48,3 +48,4 @@ def test_get_known_feats(pos_pipeline):
     feats = pos_pipeline.processors['pos'].get_known_feats()
     # I appreciate how self-referential the Abbr feat is
     assert 'Abbr' in feats
+    assert 'Yes' in feats['Abbr']


### PR DESCRIPTION
## Description
It's my proposal for the returned value of `get_known_feats` - returning all values as a dictionary instead of only feats types as a list (omitting possible values).

## Fixes Issues
#1066 

## Unit test coverage
I extended the test of the method to test also the feat value - `Yes`.

## Known breaking changes/behaviors
The feature has not been added to main yet, so I think it's fine.
