### PR TITLE
Load the pretrained charlm, adds it as inputs to the POS model

### DIFF
--- a/stanza/models/pos/data.py
+++ b/stanza/models/pos/data.py
@@ -75,6 +75,7 @@ class DataLoader:
                 processed_sent += [pretrain_vocab.map([w[0].lower() for w in sent])]
             else:
                 processed_sent += [[PAD_ID] * len(sent)]
+            processed_sent.append([w[0] for w in sent])
             processed.append(processed_sent)
         return processed
 
@@ -90,7 +91,7 @@ class DataLoader:
         batch = self.data[key]
         batch_size = len(batch)
         batch = list(zip(*batch))
-        assert len(batch) == 6
+        assert len(batch) == 7
 
         # sort sentences by lens for easy RNN operations
         lens = [len(x) for x in batch[0]]
@@ -114,8 +115,9 @@ class DataLoader:
         xpos = get_long_tensor(batch[3], batch_size)
         ufeats = get_long_tensor(batch[4], batch_size)
         pretrained = get_long_tensor(batch[5], batch_size)
+        text = batch[6]
         sentlens = [len(x) for x in batch[0]]
-        return words, words_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, orig_idx, word_orig_idx, sentlens, word_lens
+        return words, words_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, orig_idx, word_orig_idx, sentlens, word_lens, text
 
     def __iter__(self):
         for i in range(self.__len__()):

--- a/stanza/models/pos/trainer.py
+++ b/stanza/models/pos/trainer.py
@@ -24,7 +24,8 @@ def unpack_batch(batch, use_cuda):
     word_orig_idx = batch[9]
     sentlens = batch[10]
     wordlens = batch[11]
-    return inputs, orig_idx, word_orig_idx, sentlens, wordlens
+    text = batch[12]
+    return inputs, orig_idx, word_orig_idx, sentlens, wordlens, text
 
 class Trainer(BaseTrainer):
     """ A trainer for training models. """
@@ -32,7 +33,7 @@ class Trainer(BaseTrainer):
         self.use_cuda = use_cuda
         if model_file is not None:
             # load everything from file
-            self.load(model_file, pretrain)
+            self.load(model_file, pretrain, args=args)
         else:
             # build model from scratch
             self.args = args
@@ -46,7 +47,7 @@ class Trainer(BaseTrainer):
         self.optimizer = utils.get_optimizer(self.args['optim'], self.parameters, self.args['lr'], betas=(0.9, self.args['beta2']), eps=1e-6)
 
     def update(self, batch, eval=False):
-        inputs, orig_idx, word_orig_idx, sentlens, wordlens = unpack_batch(batch, self.use_cuda)
+        inputs, orig_idx, word_orig_idx, sentlens, wordlens, text = unpack_batch(batch, self.use_cuda)
         word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained = inputs
 
         if eval:
@@ -54,7 +55,7 @@ class Trainer(BaseTrainer):
         else:
             self.model.train()
             self.optimizer.zero_grad()
-        loss, _ = self.model(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, word_orig_idx, sentlens, wordlens)
+        loss, _ = self.model(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, word_orig_idx, sentlens, wordlens, text)
         loss_val = loss.data.item()
         if eval:
             return loss_val
@@ -65,12 +66,12 @@ class Trainer(BaseTrainer):
         return loss_val
 
     def predict(self, batch, unsort=True):
-        inputs, orig_idx, word_orig_idx, sentlens, wordlens = unpack_batch(batch, self.use_cuda)
+        inputs, orig_idx, word_orig_idx, sentlens, wordlens, text = unpack_batch(batch, self.use_cuda)
         word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained = inputs
 
         self.model.eval()
         batch_size = word.size(0)
-        _, preds = self.model(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, word_orig_idx, sentlens, wordlens)
+        _, preds = self.model(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, word_orig_idx, sentlens, wordlens, text)
         upos_seqs = [self.vocab['upos'].unmap(sent) for sent in preds[0].tolist()]
         xpos_seqs = [self.vocab['xpos'].unmap(sent) for sent in preds[1].tolist()]
         feats_seqs = [self.vocab['feats'].unmap(sent) for sent in preds[2].tolist()]
@@ -100,7 +101,7 @@ class Trainer(BaseTrainer):
         except Exception as e:
             logger.warning(f"Saving failed... {e} continuing anyway.")
 
-    def load(self, filename, pretrain):
+    def load(self, filename, pretrain, args=None):
         """
         Load a model from file, with preloaded pretrain embeddings. Here we allow the pretrain to be None or a dummy input,
         and the actual use of pretrain embeddings will depend on the boolean config "pretrain" in the loaded args.
@@ -111,6 +112,7 @@ class Trainer(BaseTrainer):
             logger.error("Cannot load model from {}".format(filename))
             raise
         self.args = checkpoint['config']
+        if args is not None: self.args.update(args)
         self.vocab = MultiVocab.load_state_dict(checkpoint['vocab'])
         # load model
         emb_matrix = None

--- a/stanza/models/tagger.py
+++ b/stanza/models/tagger.py
@@ -61,8 +61,17 @@ def parse_args(args=None):
     parser.add_argument('--dropout', type=float, default=0.5)
     parser.add_argument('--rec_dropout', type=float, default=0, help="Recurrent dropout")
     parser.add_argument('--char_rec_dropout', type=float, default=0, help="Recurrent dropout")
+
+    # TODO: refactor charlm arguments for models which use it?
     parser.add_argument('--no_char', dest='char', action='store_false', help="Turn off character model.")
-    parser.add_argument('--char_bidirectional', dest='char_bidirectional', action='store_true', help="Use a bidirectional version of the charlm.  Doesn't help much, makes the models larger")
+    parser.add_argument('--char_bidirectional', dest='char_bidirectional', action='store_true', help="Use a bidirectional version of the non-pretrained charlm.  Doesn't help much, makes the models larger")
+    parser.add_argument('--char_lowercase', dest='char_lowercase', action='store_true', help="Use lowercased characters in character model.")
+    parser.add_argument('--charlm', action='store_true', help="Turn on contextualized char embedding using pretrained character-level language model.")
+    parser.add_argument('--charlm_save_dir', type=str, default='saved_models/charlm', help="Root dir for pretrained character-level language model.")
+    parser.add_argument('--charlm_shorthand', type=str, default=None, help="Shorthand for character-level language model training corpus.")
+    parser.add_argument('--charlm_forward_file', type=str, default=None, help="Exact path to use for forward charlm")
+    parser.add_argument('--charlm_backward_file', type=str, default=None, help="Exact path to use for backward charlm")
+
     parser.add_argument('--no_pretrain', dest='pretrain', action='store_false', help="Turn off pretrained embeddings.")
     parser.add_argument('--share_hid', action='store_true', help="Share hidden representations for UPOS, XPOS and UFeats.")
     parser.set_defaults(share_hid=False)
@@ -139,6 +148,15 @@ def train(args):
 
     # load pretrained vectors if needed
     pretrain = load_pretrain(args)
+
+    if args['charlm']:
+        if args['charlm_shorthand'] is None:
+            raise ValueError("CharLM Shorthand is required for loading pretrained CharLM model...")
+        logger.info('Using pretrained contextualized char embedding')
+        if not args['charlm_forward_file']:
+            args['charlm_forward_file'] = '{}/{}_forward_charlm.pt'.format(args['charlm_save_dir'], args['charlm_shorthand'])
+        if not args['charlm_backward_file']:
+            args['charlm_backward_file'] = '{}/{}_backward_charlm.pt'.format(args['charlm_save_dir'], args['charlm_shorthand'])
 
     # load data
     logger.info("Loading data with batch size {}...".format(args['batch_size']))

--- a/stanza/pipeline/pos_processor.py
+++ b/stanza/pipeline/pos_processor.py
@@ -23,8 +23,10 @@ class POSProcessor(UDProcessor):
     def _set_up_model(self, config, pipeline, use_gpu):
         # get pretrained word vectors
         self._pretrain = pipeline.foundation_cache.load_pretrain(config['pretrain_path']) if 'pretrain_path' in config else None
+        args = {'charlm_forward_file': config.get('forward_charlm_path', None),
+                'charlm_backward_file': config.get('backward_charlm_path', None)}
         # set up trainer
-        self._trainer = Trainer(pretrain=self.pretrain, model_file=config['model_path'], use_cuda=use_gpu)
+        self._trainer = Trainer(pretrain=self.pretrain, model_file=config['model_path'], use_cuda=use_gpu, args=args)
         self._tqdm = 'tqdm' in config and config['tqdm']
 
     def __str__(self):

--- a/stanza/utils/training/common.py
+++ b/stanza/utils/training/common.py
@@ -133,6 +133,10 @@ def build_argparse():
     parser.add_argument('--force', dest='force', action='store_true', default=False, help='Retrain existing models')
     return parser
 
+def add_charlm_args(parser):
+    parser.add_argument('--charlm', default="default", type=str, help='Which charlm to run on.  Will use the default charlm for this language/model if not set.  Set to None to turn off charlm for languages with a default charlm')
+    parser.add_argument('--no_charlm', dest='charlm', action="store_const", const=None, help="Don't use a charlm, even if one is used by default for this package")
+
 def main(run_treebank, model_dir, model_name, add_specific_args=None):
     """
     A main program for each of the run_xyz scripts
@@ -332,7 +336,9 @@ def choose_charlm(language, dataset, charlm, language_charlms, dataset_charlms):
         return None
     elif charlm != "default":
         return charlm
-    elif specific_charlm:
+    elif dataset in dataset_charlms.get(language, {}):
+        # this way, a "" or None result gets honored
+        # thus treating "not in the map" as a way for dataset_charlms to signal to use the default
         return specific_charlm
     elif default_charlm:
         return default_charlm

--- a/stanza/utils/training/run_ner.py
+++ b/stanza/utils/training/run_ner.py
@@ -25,7 +25,7 @@ import os
 from stanza.models import ner_tagger
 from stanza.utils.datasets.ner import prepare_ner_dataset
 from stanza.utils.training import common
-from stanza.utils.training.common import Mode, build_charlm_args, choose_charlm, find_wordvec_pretrain
+from stanza.utils.training.common import Mode, add_charlm_args, build_charlm_args, choose_charlm, find_wordvec_pretrain
 
 from stanza.resources.prepare_resources import default_charlms, default_pretrains, ner_charlms, ner_pretrains
 
@@ -40,10 +40,6 @@ DATASET_EXTRA_ARGS = {
 }
 
 logger = logging.getLogger('stanza')
-
-def add_ner_args(parser):
-    parser.add_argument('--charlm', default="default", type=str, help='Which charlm to run on.  Will use the default charlm for this language/model if not set.  Set to None to turn off charlm for languages with a default charlm')
-    parser.add_argument('--no_charlm', dest='charlm', action="store_const", const=None, help="Don't use a charlm, even if one is used by default for this package")
 
 # Technically NER datasets are not necessarily treebanks
 # (usually not, in fact)
@@ -121,7 +117,7 @@ def run_treebank(mode, paths, treebank, short_name,
 
 
 def main():
-    common.main(run_treebank, "ner", "nertagger", add_ner_args)
+    common.main(run_treebank, "ner", "nertagger", add_charlm_args)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Load the pretrained charlm, adds it as inputs to the POS model

This improves accuracy on almost all POS models

Doing the same thing for depparse would also make sense, but is
currently not done.  However, the downstream scores of depparse don't
seem to be negatively affected by using the different (better) POS
tags produced by models using the pretrained charlm

Add a pos-specific charlm map for the medical EN datasets and the one dataset which appears to be hurt by the charlm (tr_boun)

craft, genia -> None

Produces resources.json with pos charlms

Make the Pipeline pass in charlm paths if present in resources.json
TODO: use the foundation_cache to load them
