### PR TITLE
Refactor lstm

### DIFF
--- a/stanza/models/constituency/lstm_tree_stack.py
+++ b/stanza/models/constituency/lstm_tree_stack.py
@@ -1,0 +1,73 @@
+"""
+Keeps an LSTM in TreeStack form.
+
+The TreeStack nodes keep the hx and cx for the LSTM, along with a
+"value" which represents whatever the user needs to store.
+
+The TreeStacks can be ppped to get back to the previous LSTM state.
+
+The module itself implements two methods: initial_state and push_states
+"""
+
+from collections import namedtuple
+
+import torch
+import torch.nn as nn
+
+from stanza.models.constituency.tree_stack import TreeStack
+
+Node = namedtuple("Node", ['value', 'lstm_hx', 'lstm_cx'])
+
+class LSTMTreeStack(nn.Module):
+    def __init__(self, input_size, hidden_size, num_lstm_layers, dropout, uses_boundary_vector, input_dropout):
+        super().__init__()
+
+        self.uses_boundary_vector = uses_boundary_vector
+
+        # The start embedding needs to be input_size as we put it through the LSTM
+        # A zeros vector needs to be *hidden_size* as we do not put that through the LSTM
+        if uses_boundary_vector:
+            self.register_parameter('start_embedding', torch.nn.Parameter(0.2 * torch.randn(input_size, requires_grad=True)))
+        else:
+            self.register_buffer('zeros', torch.zeros(num_lstm_layers, 1, hidden_size))
+
+        self.lstm = nn.LSTM(input_size=input_size, hidden_size=hidden_size, num_layers=num_lstm_layers, dropout=dropout)
+        self.input_dropout = input_dropout
+
+
+    def initial_state(self):
+        """
+        Return an initial state, either based on zeros or based on the initial embedding and LSTM
+
+        Note that LSTM start operation is already batched, in a sense
+        The subsequent batch built this way will be used for batch_size trees
+
+        Returns a stack with None value, hx & cx either based on the
+        start_embedding or zeros, and no parent.
+        """
+        if self.uses_boundary_vector:
+            start = self.start_embedding.unsqueeze(0).unsqueeze(0)
+            output, (hx, cx) = self.lstm(start)
+            start = output[0, 0, :]
+        else:
+            hx = self.zeros
+            cx = self.zeros
+        return TreeStack(value=Node(None, hx, cx), parent=None, length=1)
+
+    def push_states(self, stacks, values, inputs):
+        """
+        Starting from a list of current stacks, put the inputs through the LSTM and build new stack nodes.
+
+        N = stacks.len() = values.len()
+
+        inputs must be of shape 1 x N x input_size
+        """
+        inputs = self.input_dropout(inputs)
+
+        hx = torch.cat([t.value.lstm_hx for t in stacks], axis=1)
+        cx = torch.cat([t.value.lstm_cx for t in stacks], axis=1)
+        output, (hx, cx) = self.lstm(inputs, (hx, cx))
+        new_stacks = [stack.push(Node(transition, hx[:, i:i+1, :], cx[:, i:i+1, :]))
+                      for i, (stack, transition) in enumerate(zip(stacks, values))]
+        return new_stacks
+

--- a/stanza/models/constituency/trainer.py
+++ b/stanza/models/constituency/trainer.py
@@ -96,6 +96,17 @@ class Trainer:
         saved_args.update(args)
         params = checkpoint['params']
 
+        if 'transition_start_embedding' in params['model']:
+            params['model']['transition_lstm_stack.start_embedding']   = params['model']['transition_start_embedding']
+            params['model']['transition_lstm_stack.lstm.weight_ih_l0'] = params['model']['transition_lstm.weight_ih_l0']
+            params['model']['transition_lstm_stack.lstm.weight_hh_l0'] = params['model']['transition_lstm.weight_hh_l0']
+            params['model']['transition_lstm_stack.lstm.bias_ih_l0']   = params['model']['transition_lstm.bias_ih_l0']
+            params['model']['transition_lstm_stack.lstm.bias_hh_l0']   = params['model']['transition_lstm.bias_hh_l0']
+            params['model']['transition_lstm_stack.lstm.weight_ih_l1'] = params['model']['transition_lstm.weight_ih_l1']
+            params['model']['transition_lstm_stack.lstm.weight_hh_l1'] = params['model']['transition_lstm.weight_hh_l1']
+            params['model']['transition_lstm_stack.lstm.bias_ih_l1']   = params['model']['transition_lstm.bias_ih_l1']
+            params['model']['transition_lstm_stack.lstm.bias_hh_l1']   = params['model']['transition_lstm.bias_hh_l1']
+
         model_type = checkpoint['model_type']
         if model_type == 'LSTM':
             pt = load_pretrain(saved_args.get('wordvec_pretrain_file', None), foundation_cache)

--- a/stanza/models/constituency/trainer.py
+++ b/stanza/models/constituency/trainer.py
@@ -107,6 +107,17 @@ class Trainer:
             params['model']['transition_lstm_stack.lstm.bias_ih_l1']   = params['model']['transition_lstm.bias_ih_l1']
             params['model']['transition_lstm_stack.lstm.bias_hh_l1']   = params['model']['transition_lstm.bias_hh_l1']
 
+        if 'constituent_start_embedding' in params['model']:
+            params['model']['constituent_lstm_stack.start_embedding']   = params['model']['constituent_start_embedding']
+            params['model']['constituent_lstm_stack.lstm.weight_ih_l0'] = params['model']['constituent_lstm.weight_ih_l0']
+            params['model']['constituent_lstm_stack.lstm.weight_hh_l0'] = params['model']['constituent_lstm.weight_hh_l0']
+            params['model']['constituent_lstm_stack.lstm.bias_ih_l0']   = params['model']['constituent_lstm.bias_ih_l0']
+            params['model']['constituent_lstm_stack.lstm.bias_hh_l0']   = params['model']['constituent_lstm.bias_hh_l0']
+            params['model']['constituent_lstm_stack.lstm.weight_ih_l1'] = params['model']['constituent_lstm.weight_ih_l1']
+            params['model']['constituent_lstm_stack.lstm.weight_hh_l1'] = params['model']['constituent_lstm.weight_hh_l1']
+            params['model']['constituent_lstm_stack.lstm.bias_ih_l1']   = params['model']['constituent_lstm.bias_ih_l1']
+            params['model']['constituent_lstm_stack.lstm.bias_hh_l1']   = params['model']['constituent_lstm.bias_hh_l1']
+
         model_type = checkpoint['model_type']
         if model_type == 'LSTM':
             pt = load_pretrain(saved_args.get('wordvec_pretrain_file', None), foundation_cache)

--- a/stanza/tests/constituency/test_lstm_model.py
+++ b/stanza/tests/constituency/test_lstm_model.py
@@ -350,7 +350,6 @@ def check_structure_test(pretrain_file, args1, args2):
     for i, j in zip(other_states[0].word_queue, model_states[0].word_queue):
         assert torch.allclose(i.hx, j.hx)
     for i, j in zip(other_states[0].transitions, model_states[0].transitions):
-        assert torch.allclose(i.output, j.output)
         assert torch.allclose(i.lstm_hx, j.lstm_hx)
         assert torch.allclose(i.lstm_cx, j.lstm_cx)
     for i, j in zip(other_states[0].constituents, model_states[0].constituents):

--- a/stanza/tests/constituency/test_lstm_model.py
+++ b/stanza/tests/constituency/test_lstm_model.py
@@ -353,7 +353,9 @@ def check_structure_test(pretrain_file, args1, args2):
         assert torch.allclose(i.lstm_hx, j.lstm_hx)
         assert torch.allclose(i.lstm_cx, j.lstm_cx)
     for i, j in zip(other_states[0].constituents, model_states[0].constituents):
-        assert torch.allclose(i.tree_hx, j.tree_hx)
+        assert (i.value is None) == (j.value is None)
+        if i.value is not None:
+            assert torch.allclose(i.value.tree_hx, j.value.tree_hx)
         assert torch.allclose(i.lstm_hx, j.lstm_hx)
         assert torch.allclose(i.lstm_cx, j.lstm_cx)
 


### PR DESCRIPTION
Refactor the LSTM for transitions and constituents into a separate class.  The intention is to make it easier to build a Transformer Stack and then replace the existing LSTMs with one, as long as we make the Transformer use the same interface.