### PR TITLE
Script to use a Stanza tokenizer to tokenize raw text files

### DIFF
--- a/stanza/models/tokenization/tokenize_files.py
+++ b/stanza/models/tokenization/tokenize_files.py
@@ -1,0 +1,78 @@
+"""Use a Stanza tokenizer to turn a text file into one tokenized paragraph per line
+
+For example, the output of this script is suitable for Glove
+
+Currently this *only* supports tokenization, no MWT splitting.
+It also would be beneficial to have an option to convert spaces into
+NBSP, underscore, or some other marker to make it easier to process
+languages such as VI which have spaces in them
+"""
+
+
+import argparse
+import io
+import os
+import re
+import zipfile
+
+import torch
+
+import stanza
+from stanza.models.common.utils import get_tqdm, open_read_text
+from stanza.models.tokenization.data import TokenizationDataset
+from stanza.models.tokenization.utils import output_predictions
+from stanza.pipeline.tokenize_processor import TokenizeProcessor
+
+tqdm = get_tqdm()
+
+NEWLINE_SPLIT_RE = re.compile(r"\n\s*\n")
+
+def tokenize_to_file(tokenizer, fin, fout):
+    # TODO: split text?  this could be kinda long
+    raw_text = fin.read()
+    documents = NEWLINE_SPLIT_RE.split(raw_text)
+    in_docs = [stanza.Document([], text=d) for d in documents]
+    out_docs = tokenizer.bulk_process(in_docs)
+    for document in out_docs:
+        for sent_idx, sentence in enumerate(document.sentences):
+            if sent_idx > 0:
+                fout.write(" ")
+            fout.write(" ".join(x.text for x in sentence.tokens))
+        fout.write("\n")
+
+def main(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lang", type=str, default="sd", help="Which language to use for tokenization")
+    parser.add_argument("--tokenize_model_path", type=str, default=None, help="Specific tokenizer model to use")
+    parser.add_argument("input_files", type=str, nargs="+", help="Which input files to tokenize")
+    parser.add_argument("--output_file", type=str, default="glove.txt", help="Where to write the tokenized output")
+    parser.add_argument("--model_dir", type=str, default=None, help="Where to get models for a Pipeline (None => default models dir)")
+    args = parser.parse_args(args=args)
+
+    if os.path.exists(args.output_file):
+        print("Cowardly refusing to overwrite existing output file %s" % args.output_file)
+        return
+
+    if args.tokenize_model_path:
+        config = { "model_path": args.tokenize_model_path,
+                   "check_requirements": False }
+        tokenizer = TokenizeProcessor(config, pipeline=None, use_gpu=torch.cuda.is_available())
+    else:
+        pipe = stanza.Pipeline(lang=args.lang, processors="tokenize", model_dir=args.model_dir)
+        tokenizer = pipe.processors["tokenize"]
+
+    with open(args.output_file, "w", encoding="utf-8") as fout:
+        for filename in tqdm(args.input_files):
+            if filename.endswith(".zip"):
+                with zipfile.ZipFile(filename) as zin:
+                    input_names = zin.namelist()
+                    for input_name in tqdm(input_names, leave=False):
+                        with zin.open(input_names[0]) as fin:
+                            fin = io.TextIOWrapper(fin, encoding='utf-8')
+                            tokenize_to_file(tokenizer, fin, fout)
+            else:
+                with open_read_text(filename, encoding="utf-8") as fin:
+                    tokenize_to_file(tokenizer, fin, fout)
+
+if __name__ == '__main__':
+    main()

--- a/stanza/pipeline/processor.py
+++ b/stanza/pipeline/processor.py
@@ -131,6 +131,8 @@ class Processor(ABC):
 
     def _check_requirements(self):
         """ Given a list of fulfilled requirements, check if all of this processor's requirements are met or not. """
+        if not self.config.get("check_requirements", True):
+            return
         provided_reqs = set.union(*[processor.provides for processor in self.pipeline.loaded_processors]+[set([])])
         if self.requires - provided_reqs:
             load_names = [item[0] for item in self.pipeline.load_list]

--- a/stanza/tests/tokenization/test_tokenize_files.py
+++ b/stanza/tests/tokenization/test_tokenize_files.py
@@ -1,0 +1,24 @@
+import pytest
+
+from stanza.models.tokenization import tokenize_files
+from stanza.tests import TEST_MODELS_DIR
+
+pytestmark = [pytest.mark.pipeline, pytest.mark.travis]
+
+EXPECTED = """
+This is a test . This is a second sentence .
+I took my daughter ice skating
+""".lstrip()
+
+def test_tokenize_files(tmp_path):
+    input_file = tmp_path / "input.txt"
+    with open(input_file, "w") as fout:
+        fout.write("This is a test.  This is a second sentence.\n\nI took my daughter ice skating")
+
+    output_file = tmp_path / "output.txt"
+    tokenize_files.main([str(input_file), "--lang", "en", "--output_file", str(output_file), "--model_dir", TEST_MODELS_DIR])
+
+    with open(output_file) as fin:
+        text = fin.read()
+
+    assert EXPECTED == text


### PR DESCRIPTION
Minor change to the pipeline to accommodate the usage of TokenizeProcessor, then add a script to process raw text files with an arbitrary tokenizer model