### PR TITLE
Fix an error in augment_comma_separations

### DIFF
--- a/stanza/tests/tokenization/test_prepare_tokenizer_treebank.py
+++ b/stanza/tests/tokenization/test_prepare_tokenizer_treebank.py
@@ -366,3 +366,29 @@ def test_augment_space_final_punct():
     doc2 = prepare_tokenizer_treebank.augment_move_comma(doc, ratio=1.0)
     expected = read_test_doc(ENGLISH_COMMA_SWAP_RESULT)
     assert doc2 == expected
+
+COMMA_SEP_TEST_CASE = """
+# text = Fuzzy people, floating people
+1	Fuzzy	fuzzy	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
+2	people	people	NOUN	NNS	Number=Plur	0	root	0:root	SpaceAfter=No
+3	,	,	PUNCT	,	_	2	punct	2:punct	_
+4	floating	float	VERB	VBG	VerbForm=Ger	5	amod	5:amod	_
+5	people	people	NOUN	NNS	Number=Plur	2	appos	2:appos	_
+"""
+
+COMMA_SEP_TEST_EXPECTED = """
+# text = Fuzzy people,floating people
+1	Fuzzy	fuzzy	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
+2	people	people	NOUN	NNS	Number=Plur	0	root	0:root	SpaceAfter=No
+3	,	,	PUNCT	,	_	2	punct	2:punct	SpaceAfter=No
+4	floating	float	VERB	VBG	VerbForm=Ger	5	amod	5:amod	_
+5	people	people	NOUN	NNS	Number=Plur	2	appos	2:appos	_
+"""
+
+def test_augment_comma_separations():
+    doc = read_test_doc(COMMA_SEP_TEST_CASE)
+    doc2 = prepare_tokenizer_treebank.augment_comma_separations(doc, ratio=1.0)
+
+    assert len(doc2) == 2
+    expected = read_test_doc(COMMA_SEP_TEST_EXPECTED)
+    assert doc2[1] == expected[0]

--- a/stanza/utils/datasets/prepare_tokenizer_treebank.py
+++ b/stanza/utils/datasets/prepare_tokenizer_treebank.py
@@ -247,7 +247,7 @@ def augment_telugu(sents):
     return sents + new_sents
 
 COMMA_SEPARATED_RE = re.compile(" ([a-zA-Z]+)[,] ([a-zA-Z]+) ")
-def augment_comma_separations(sents):
+def augment_comma_separations(sents, ratio=0.03):
     """Find some fraction of the sentences which match "asdf, zzzz" and squish them to "asdf,zzzz"
 
     This leaves the tokens and all of the other data the same.  The
@@ -283,7 +283,7 @@ def augment_comma_separations(sents):
             continue
 
         match = COMMA_SEPARATED_RE.search(sentence[text_idx])
-        if match and random.random() < 0.03:
+        if match and random.random() < ratio:
             for idx, word in enumerate(sentence):
                 if word.startswith("#"):
                     continue
@@ -292,7 +292,7 @@ def augment_comma_separations(sents):
                     continue
                 if sentence[idx+1].split("\t")[1] != ',':
                     continue
-                if sentence[idx+2].split("\t")[2] != match.group(2):
+                if sentence[idx+2].split("\t")[1] != match.group(2):
                     continue
                 break
             if idx == len(sentence) - 1:


### PR DESCRIPTION
## Description
When using `stanza.utils.datasets.prepare_tokenizer_treebank` on custom treebank, I stumbled on an error

```
Traceback (most recent call last):
  File "/nix/store/9srs642k875z3qdk8glapjycncf2pa51-python3-3.10.7/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/nix/store/9srs642k875z3qdk8glapjycncf2pa51-python3-3.10.7/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/dvzubarev/installed_thirdparty/stanza/stanza/utils/datasets/prepare_tokenizer_treebank.py", line 1140, in <module>
    main()
  File "/home/dvzubarev/installed_thirdparty/stanza/stanza/utils/datasets/prepare_tokenizer_treebank.py", line 1137, in main
    common.main(process_treebank, add_specific_args)
  File "/home/dvzubarev/installed_thirdparty/stanza/stanza/utils/datasets/common.py", line 257, in main
    process_treebank(treebank, paths, args)
  File "/home/dvzubarev/installed_thirdparty/stanza/stanza/utils/datasets/prepare_tokenizer_treebank.py", line 1127, in process_treebank
    process_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name, short_language, args.augment)
  File "/home/dvzubarev/installed_thirdparty/stanza/stanza/utils/datasets/prepare_tokenizer_treebank.py", line 1023, in process_ud_treebank
    prepare_ud_dataset(treebank, udbase_dir, tokenizer_dir, short_name, short_language, "train", augment)
  File "/home/dvzubarev/installed_thirdparty/stanza/stanza/utils/datasets/prepare_tokenizer_treebank.py", line 1012, in prepare_ud_dataset
    write_augmented_dataset(input_conllu, output_conllu, augment_punct)
  File "/home/dvzubarev/installed_thirdparty/stanza/stanza/utils/datasets/prepare_tokenizer_treebank.py", line 674, in write_augmented_dataset
    new_sents = augment_function(sents)
  File "/home/dvzubarev/installed_thirdparty/stanza/stanza/utils/datasets/prepare_tokenizer_treebank.py", line 657, in augment_punct
    new_sents = augment_comma_separations(new_sents)
  File "/home/dvzubarev/installed_thirdparty/stanza/stanza/utils/datasets/prepare_tokenizer_treebank.py", line 293, in augment_comma_separations
    if sentence[idx+1].split("\t")[1] != ',':
IndexError: list index out of range

``` 
## Fixes Issues
This PR fixes this issue

## Unit test coverage
I added a test for the sentence that caused this issue.


