### PR TITLE
Speed up prepare_tokenizer_data on large treebanks

### DIFF
--- a/stanza/utils/datasets/prepare_tokenizer_data.py
+++ b/stanza/utils/datasets/prepare_tokenizer_data.py
@@ -22,7 +22,7 @@ PARAGRAPH_BREAK = re.compile(r'\n\s*\n')
 def is_para_break(index, text):
     """ Detect if a paragraph break can be found, and return the length of the paragraph break sequence. """
     if text[index] == '\n':
-        para_break = PARAGRAPH_BREAK.match(text[index:])
+        para_break = PARAGRAPH_BREAK.match(text, index)
         if para_break:
             break_len = len(para_break.group(0))
             return True, break_len


### PR DESCRIPTION

Avoid excessive copying of the full-text on each paragraph check.

`stanza.utils.datasets.prepare_tokenizer_treebank` took around 2 hours on my custom treebank (~60 MiB .txt file). 
After this fix it finished in 2 minutes.  

Results for other large UD treebanks:
|                      | before | after |
|----------------------|--------|---------|
| UD_Russian-SynTagRus | 46s    | 23s     |
| UD_German-HDT        | 6m 12s | 50s     |



