### PR TITLE
Doc format

### DIFF
--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -47,20 +47,14 @@ def test_dict_to_conll():
 def test_dict_to_doc_and_doc_to_dict():
     """
     Test the conversion from raw dict to Document and back
+
     This code path will first turn start_char|end_char into start_char & end_char fields in the Document
     That version to a dict will have separate fields for each of those
     Finally, the conversion from that dict to a list of conll entries should convert that back to misc
     """
     doc = Document(DICT)
     dicts = doc.to_dict()
-    dicts_tupleid = []
-    for sentence in dicts:
-        items = []
-        for item in sentence:
-            item['id'] = item['id'] if isinstance(item['id'], tuple) else (item['id'], )
-            items.append(item)
-        dicts_tupleid.append(items)
-    conll = CoNLL.convert_dict(DICT)
+    conll = CoNLL.convert_dict(dicts)
     assert conll == CONLL
 
 # sample is two sentences long so that the tests check multiple sentences

--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -41,7 +41,9 @@ def test_conll_to_dict():
     assert dicts == DICT
 
 def test_dict_to_conll():
-    conll = CoNLL.convert_dict(DICT)
+    document = Document(DICT)
+    # :c = no comments
+    conll = [[sentence.split("\t") for sentence in doc.split("\n")] for doc in "{:c}".format(document).split("\n\n")]
     assert conll == CONLL
 
 def test_dict_to_doc_and_doc_to_dict():
@@ -52,9 +54,10 @@ def test_dict_to_doc_and_doc_to_dict():
     That version to a dict will have separate fields for each of those
     Finally, the conversion from that dict to a list of conll entries should convert that back to misc
     """
-    doc = Document(DICT)
-    dicts = doc.to_dict()
-    conll = CoNLL.convert_dict(dicts)
+    document = Document(DICT)
+    dicts = document.to_dict()
+    document = Document(dicts)
+    conll = [[sentence.split("\t") for sentence in doc.split("\n")] for doc in "{:c}".format(document).split("\n\n")]
     assert conll == CONLL
 
 # sample is two sentences long so that the tests check multiple sentences
@@ -106,10 +109,11 @@ def check_russian_doc(doc):
         assert sent_idx == sentence.index
         assert len(sentence.comments) == 3
 
-    sentences = CoNLL.doc2conll(doc)
+    sentences = "{:C}".format(doc)
+    sentences = sentences.split("\n\n")
     assert len(sentences) == 2
 
-    sentence = sentences[0]
+    sentence = sentences[0].split("\n")
     assert len(sentence) == 14
     assert lines[0] == sentence[0]
     assert lines[1] == sentence[1]
@@ -159,11 +163,12 @@ def test_unusual_misc():
     (the below test would fail)
     """
     doc = CoNLL.conll2doc(input_str=RUSSIAN_SAMPLE)
-    sentences = CoNLL.doc2conll(doc)
+    sentences = "{:C}".format(doc).split("\n\n")
     assert len(sentences) == 2
-    assert len(sentences[0]) == 14
+    sentence = sentences[0].split("\n")
+    assert len(sentence) == 14
 
-    for word in sentences[0]:
+    for word in sentence:
         pieces = word.split("\t")
         assert len(pieces) == 1 or len(pieces) == 10
         if len(pieces) == 10:
@@ -223,8 +228,8 @@ def test_simple_ner_conversion():
         # they should also not reach the word's misc field
         assert not token.words[0].misc
 
-    conll = CoNLL.doc2conll(doc)
-    assert "\n".join(conll[0]) == SIMPLE_NER
+    conll = "{:C}".format(doc)
+    assert conll == SIMPLE_NER
 
 MWT_NER = """
 # text = This makes John's headache worse
@@ -259,5 +264,5 @@ def test_mwt_ner_conversion():
         # they should also not reach the word's misc field
         assert not token.words[0].misc
 
-    conll = CoNLL.doc2conll(doc)
-    assert "\n".join(conll[0]) == MWT_NER
+    conll = "{:C}".format(doc)
+    assert conll == MWT_NER

--- a/stanza/tests/pipeline/test_english_pipeline.py
+++ b/stanza/tests/pipeline/test_english_pipeline.py
@@ -113,8 +113,7 @@ EN_DOC_CONLLU_GOLD = """
 2	attended	attend	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	start_char=75|end_char=83|ner=O
 3	Harvard	Harvard	PROPN	NNP	Number=Sing	2	obj	_	start_char=84|end_char=91|ner=S-ORG
 4	.	.	PUNCT	.	_	2	punct	_	start_char=91|end_char=92|ner=O
-
-""".lstrip()
+""".strip()
 
 EN_DOC_CONLLU_GOLD_MULTIDOC = """
 # text = Barack Obama was born in Hawaii.
@@ -143,8 +142,7 @@ EN_DOC_CONLLU_GOLD_MULTIDOC = """
 2	attended	attend	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	start_char=6|end_char=14|ner=O
 3	Harvard	Harvard	PROPN	NNP	Number=Sing	2	obj	_	start_char=15|end_char=22|ner=S-ORG
 4	.	.	PUNCT	.	_	2	punct	_	start_char=22|end_char=23|ner=O
-
-""".lstrip()
+""".strip()
 
 class TestEnglishPipeline:
     @pytest.fixture(scope="class")
@@ -161,7 +159,7 @@ class TestEnglishPipeline:
 
 
     def test_conllu(self, processed_doc):
-        assert CoNLL.doc2conll_text(processed_doc) == EN_DOC_CONLLU_GOLD
+        assert "{:C}".format(processed_doc) == EN_DOC_CONLLU_GOLD
 
 
     def test_tokens(self, processed_doc):
@@ -189,7 +187,7 @@ class TestEnglishPipeline:
 
 
     def test_conllu_multidoc(self, processed_multidoc):
-        assert "".join([CoNLL.doc2conll_text(doc) for doc in processed_multidoc]) == EN_DOC_CONLLU_GOLD_MULTIDOC
+        assert "\n\n".join(["{:C}".format(doc) for doc in processed_multidoc]) == EN_DOC_CONLLU_GOLD_MULTIDOC
 
     def test_tokens_multidoc(self, processed_multidoc):
         assert "\n\n".join([sent.tokens_string() for processed_doc in processed_multidoc for sent in processed_doc.sentences]) == EN_DOC_TOKENS_GOLD

--- a/stanza/utils/conll.py
+++ b/stanza/utils/conll.py
@@ -3,6 +3,7 @@ Utility functions for the loading and conversion of CoNLL-format files.
 """
 import os
 import io
+import warnings
 from zipfile import ZipFile
 
 from stanza.models.common.doc import Document
@@ -119,11 +120,12 @@ class CoNLL:
         Input: dictionary format data, which is a list of list of dictionaries for each token in each sentence in the data.
         Output: CoNLL-U format data, which is a list of list of list for each token in each sentence in the data.
 
-        TODO: deprecate this and then remove it in a future release
+        TODO: remove in the next release
         """
         doc = Document(doc_dict)
         doc_conll = CoNLL.doc2conll(doc, include_comments=False)
         doc_conll = [[x.split("\t") for x in sentence] for sentence in doc_conll]
+        warnings.warn('convert_dict is deprecated.  Please use "{:C}".format(doc) and use the text format directly', stacklevel=2)
         return doc_conll
 
     @staticmethod
@@ -131,13 +133,14 @@ class CoNLL:
         """
         Dump the loaded CoNLL-U format list data to string.
 
-        TODO: deprecate and remove
+        TODO: remove in the next release
         """
         return_string = ""
         for sent in doc:
             for ln in sent:
                 return_string += ("\t".join(ln)+"\n")
             return_string += "\n"
+        warnings.warn('conll_as_string is deprecated.  Please use "{:C}".format(doc) and use the text format directly', stacklevel=2)
         return return_string
 
     @staticmethod
@@ -145,11 +148,8 @@ class CoNLL:
         """
         Convert the dictionary format input data to the CoNLL-U format output data and write to a file.
         """
-        doc_conll = CoNLL.convert_dict(doc_dict)
-        conll_string = CoNLL.conll_as_string(doc_conll)
-        with open(filename, 'w', encoding='utf-8') as outfile:
-            outfile.write(conll_string)
-        return
+        doc = Document(doc_dict)
+        write_doc2conll(doc, filename)
 
 
     @staticmethod
@@ -159,7 +159,7 @@ class CoNLL:
 
         Each sentence is represented by a list of strings: first the comments, then the converted tokens
 
-        TODO: deprecate and remove
+        TODO: remove in the next release
         """
         doc_conll = []
         for sentence in doc.sentences:
@@ -168,6 +168,7 @@ class CoNLL:
                 sent_conll.extend(token.to_conll_text().split("\n"))
             doc_conll.append(sent_conll)
 
+        warnings.warn('doc2conll is deprecated.  Please use "{:C}".format(doc) and use the text format directly', stacklevel=2)
         return doc_conll
 
     @staticmethod
@@ -175,8 +176,9 @@ class CoNLL:
         """
         Convert a Document to a big block of text.
 
-        TODO: deprecate and remove
+        TODO: remove in the next release
         """
+        warnings.warn('doc2conll_text is deprecated.  Please use "{:C}".format(doc)', stacklevel=2)
         return "{:C}".format(doc)
 
     @staticmethod

--- a/stanza/utils/conll.py
+++ b/stanza/utils/conll.py
@@ -118,16 +118,15 @@ class CoNLL:
     def convert_dict(doc_dict):
         """ Convert the dictionary format input data to the CoNLL-U format output data. This is the reverse function of
         `convert_conll`.
+
         Input: dictionary format data, which is a list of list of dictionaries for each token in each sentence in the data.
         Output: CoNLL-U format data, which is a list of list of list for each token in each sentence in the data.
+
+        TODO: deprecate this and then remove it in a future release
         """
-        doc_conll = []
-        for sent_dict in doc_dict:
-            sent_conll = []
-            for token_dict in sent_dict:
-                token_conll = CoNLL.convert_token_dict(token_dict)
-                sent_conll.append(token_conll)
-            doc_conll.append(sent_conll)
+        doc = Document(doc_dict)
+        doc_conll = CoNLL.doc2conll(doc, include_comments=False)
+        doc_conll = [[x.split("\t") for x in sentence] for sentence in doc_conll]
         return doc_conll
 
     @staticmethod
@@ -186,14 +185,14 @@ class CoNLL:
 
 
     @staticmethod
-    def doc2conll(doc):
+    def doc2conll(doc, include_comments=True):
         """ Convert a Document object to a list of list of strings
 
         Each sentence is represented by a list of strings: first the comments, then the converted tokens
         """
         doc_conll = []
         for sentence in doc.sentences:
-            sent_conll = list(sentence.comments)
+            sent_conll = list(sentence.comments) if include_comments else []
             for token_dict in sentence.to_dict():
                 token_conll = CoNLL.convert_token_dict(token_dict)
                 sent_conll.append("\t".join(token_conll))

--- a/stanza/utils/conll.py
+++ b/stanza/utils/conll.py
@@ -5,12 +5,9 @@ import os
 import io
 from zipfile import ZipFile
 
-FIELD_NUM = 10
-
 from stanza.models.common.doc import Document
 from stanza.models.common.doc import ID, TEXT, LEMMA, UPOS, XPOS, FEATS, HEAD, DEPREL, DEPS, MISC, NER, START_CHAR, END_CHAR
-
-FIELD_TO_IDX = {ID: 0, TEXT: 1, LEMMA: 2, UPOS: 3, XPOS: 4, FEATS: 5, HEAD: 6, DEPREL: 7, DEPS: 8, MISC: 9}
+from stanza.models.common.doc import FIELD_TO_IDX, FIELD_NUM
 
 class CoNLL:
 
@@ -130,42 +127,12 @@ class CoNLL:
         return doc_conll
 
     @staticmethod
-    def convert_token_dict(token_dict):
-        """ Convert the dictionary format input token to the CoNLL-U format output token. This is the reverse function of
-        `convert_conll_token`.
-        Input: dictionary format token, which is a dictionaries for the token.
-        Output: CoNLL-U format token, which is a list for the token.
-        """
-        token_conll = ['_' for i in range(FIELD_NUM)]
-        misc = []
-        for key in token_dict:
-            if key == START_CHAR or key == END_CHAR:
-                misc.append("{}={}".format(key, token_dict[key]))
-            elif key == NER:
-                # TODO: potentially need to escape =|\ in the NER
-                misc.append("{}={}".format(key, token_dict[key]))
-            elif key == MISC:
-                # avoid appending a blank misc entry.
-                # otherwise the resulting misc field in the conll doc will wind up being blank text
-                # TODO: potentially need to escape =|\ in the MISC as well
-                if token_dict[key]:
-                    misc.append(token_dict[key])
-            elif key == ID:
-                token_conll[FIELD_TO_IDX[key]] = '-'.join([str(x) for x in token_dict[key]]) if isinstance(token_dict[key], tuple) else str(token_dict[key])
-            elif key in FIELD_TO_IDX:
-                token_conll[FIELD_TO_IDX[key]] = str(token_dict[key])
-        if misc:
-            token_conll[FIELD_TO_IDX[MISC]] = "|".join(misc)
-        else:
-            token_conll[FIELD_TO_IDX[MISC]] = '_'
-        # when a word (not mwt token) without head is found, we insert dummy head as required by the UD eval script
-        if '-' not in token_conll[FIELD_TO_IDX[ID]] and HEAD not in token_dict:
-            token_conll[FIELD_TO_IDX[HEAD]] = str(int(token_dict[ID] if isinstance(token_dict[ID], int) else token_dict[ID][0]) - 1) # evaluation script requires head: int
-        return token_conll
-
-    @staticmethod
     def conll_as_string(doc):
-        """ Dump the loaded CoNLL-U format list data to string. """
+        """
+        Dump the loaded CoNLL-U format list data to string.
+
+        TODO: deprecate and remove
+        """
         return_string = ""
         for sent in doc:
             for ln in sent:
@@ -175,7 +142,8 @@ class CoNLL:
 
     @staticmethod
     def dict2conll(doc_dict, filename):
-        """ Convert the dictionary format input data to the CoNLL-U format output data and write to a file.
+        """
+        Convert the dictionary format input data to the CoNLL-U format output data and write to a file.
         """
         doc_conll = CoNLL.convert_dict(doc_dict)
         conll_string = CoNLL.conll_as_string(doc_conll)
@@ -186,31 +154,38 @@ class CoNLL:
 
     @staticmethod
     def doc2conll(doc, include_comments=True):
-        """ Convert a Document object to a list of list of strings
+        """
+        Convert a Document object to a list of list of strings
 
         Each sentence is represented by a list of strings: first the comments, then the converted tokens
+
+        TODO: deprecate and remove
         """
         doc_conll = []
         for sentence in doc.sentences:
             sent_conll = list(sentence.comments) if include_comments else []
-            for token_dict in sentence.to_dict():
-                token_conll = CoNLL.convert_token_dict(token_dict)
-                sent_conll.append("\t".join(token_conll))
+            for token in sentence.tokens:
+                sent_conll.extend(token.to_conll_text().split("\n"))
             doc_conll.append(sent_conll)
 
         return doc_conll
 
     @staticmethod
     def doc2conll_text(doc):
-        """ Convert a Document to a big block of text.
         """
-        doc_conll = CoNLL.doc2conll(doc)
-        return "\n\n".join("\n".join(line for line in sentence)
-                           for sentence in doc_conll) + "\n\n"
+        Convert a Document to a big block of text.
+
+        TODO: deprecate and remove
+        """
+        return "{:C}".format(doc)
 
     @staticmethod
     def write_doc2conll(doc, filename):
-        """ Writes the doc as a conll file to the given filename
+        """
+        Writes the doc as a conll file to the given filename
+
+        Note that the output needs an extra \n\n at the end to be a legal output file
         """
         with open(filename, 'w', encoding='utf-8') as outfile:
-            outfile.write(CoNLL.doc2conll_text(doc))
+            outfile.write("{:C}".format(doc))
+            outfile.write("\n\n")


### PR DESCRIPTION
Add a `"{:C}"` format to `Document` and `Sentence` by rearranging some of the code from `conll`