### PR TITLE
Fix an issue with prepare_depparse_treebank

### DIFF
--- a/stanza/utils/datasets/prepare_depparse_treebank.py
+++ b/stanza/utils/datasets/prepare_depparse_treebank.py
@@ -85,7 +85,11 @@ def process_treebank(treebank, paths, args) -> None:
         base_args = base_args + ['--save_dir', tagger_dir, '--save_name', tagger_name]
 
         # word vector file for POS
-        base_args = base_args + wordvec_args(short_language, dataset, args)
+        if args.wordvec_pretrain_file:
+            base_args += ["--wordvec_pretrain_file", args.wordvec_pretrain_file]
+        else:
+            base_args = base_args + wordvec_args(short_language, dataset, [])
+
 
         # charlm for POS
         charlm = choose_charlm(short_language, dataset, args.charlm, default_charlms, pos_charlms)


### PR DESCRIPTION

## Description
`prepare_depparse_treebank` does not use the pretrained file passed via `wordvec_pretrain_file` option.
`wordvec_args` expects the list of options as the last argument, but `args` is a namespace object.
Now if `wordvec_pretrain_file` is set we add it to the `base_args`, otherwise invoke `wordvec_args` function


