### PR TITLE
When a comment is added to a sentence with a constituency tree, parse…

### DIFF
--- a/stanza/models/common/stanza_object.py
+++ b/stanza/models/common/stanza_object.py
@@ -1,0 +1,31 @@
+def _readonly_setter(self, name):
+    full_classname = self.__class__.__module__
+    if full_classname is None:
+        full_classname = self.__class__.__qualname__
+    else:
+        full_classname += '.' + self.__class__.__qualname__
+    raise ValueError(f'Property "{name}" of "{full_classname}" is read-only.')
+
+class StanzaObject(object):
+    """
+    Base class for all Stanza data objects that allows for some flexibility handling annotations
+    """
+
+    @classmethod
+    def add_property(cls, name, default=None, getter=None, setter=None):
+        """
+        Add a property accessible through self.{name} with underlying variable self._{name}.
+        Optionally setup a setter as well.
+        """
+
+        if hasattr(cls, name):
+            raise ValueError(f'Property by the name of {name} already exists in {cls}. Maybe you want to find another name?')
+
+        setattr(cls, f'_{name}', default)
+        if getter is None:
+            getter = lambda self: getattr(self, f'_{name}')
+        if setter is None:
+            setter = lambda self, value: _readonly_setter(self, name)
+
+        setattr(cls, name, property(getter, setter))
+

--- a/stanza/models/constituency/parse_tree.py
+++ b/stanza/models/constituency/parse_tree.py
@@ -9,7 +9,7 @@ import itertools
 import re
 import warnings
 
-from stanza.models.common.doc import StanzaObject
+from stanza.models.common.stanza_object import StanzaObject
 
 # useful more for the "is" functionality than the time savings
 CLOSE_PAREN = ')'

--- a/stanza/tests/common/test_doc.py
+++ b/stanza/tests/common/test_doc.py
@@ -102,4 +102,4 @@ def test_serialized(pipeline):
     doc2 = Document.from_serialized(serialized)
     assert len(doc2.sentences) == 1
     assert len(doc2.ents) == 2
-    assert doc2.text == text
+    assert doc.sentences[0].constituency == doc2.sentences[0].constituency


### PR DESCRIPTION
When a comment is added to a sentence with a constituency tree, parse that comment into the tree object

This involves refactoring the StanzaObject, since it is used in both doc and parse_tree
