### PR TITLE
Add Extremaduran language

### DIFF
--- a/stanza/models/common/constant.py
+++ b/stanza/models/common/constant.py
@@ -78,6 +78,7 @@ lcode2lang_raw = [
     ("eo",  "Esperanto"),
     ("et",  "Estonian"),
     ("ee",  "Ewe"),
+    ("ext", "Extremaduran")
     ("fo",  "Faroese"),
     ("fj",  "Fijian"),
     ("fi",  "Finnish"),


### PR DESCRIPTION

## Description
Add language Code for extremaduran language https://iso639-3.sil.org/code/ext
