### PR TITLE
Update utils.py

### DIFF
--- a/stanza/models/common/utils.py
+++ b/stanza/models/common/utils.py
@@ -20,6 +20,7 @@ import numpy as np
 from stanza.models.common.constant import lcode2lang
 import stanza.models.common.seq2seq_constant as constant
 import stanza.utils.conll18_ud_eval as ud_eval
+from IPython import get_ipython
 
 logger = logging.getLogger('stanza')
 


### PR DESCRIPTION
## Description
Line 398 calls `get_ipython` but this function is never imported which throws error in console hidden applications. Now the import line is added. More details [here](https://stackoverflow.com/questions/75595323/stanza-based-auto-py-to-exe-gui-app-throws-exception-windows-10).


## Fixes Issues
Error while loading a GUI app involving the import of `stanza`, like the error below:
![image](https://user-images.githubusercontent.com/46898829/221959339-719d9159-33e0-4808-999e-da5c66c78afc.png)


## Unit test coverage
None

## Known breaking changes/behaviors
Don't know.
