### PR TITLE
Tagger xpos 2

### DIFF
--- a/stanza/models/common/data.py
+++ b/stanza/models/common/data.py
@@ -87,14 +87,14 @@ def get_augment_ratio(train_data, should_augment_predicate, can_augment_predicat
 
 def should_augment_nopunct_predicate(sentence):
     last_word = sentence[-1]
-    return last_word[UPOS] == 'PUNCT'
+    return last_word.get(UPOS, None) == 'PUNCT'
 
 def can_augment_nopunct_predicate(sentence):
     """
     Check that the sentence ends with PUNCT and also doesn't have any words which depend on the last word
     """
     last_word = sentence[-1]
-    if last_word[UPOS] != 'PUNCT':
+    if last_word.get(UPOS, None) != 'PUNCT':
         return False
     # don't cut off MWT
     if len(last_word[ID]) > 1:

--- a/stanza/models/pos/data.py
+++ b/stanza/models/pos/data.py
@@ -11,14 +11,18 @@ from stanza.models.common.doc import *
 logger = logging.getLogger('stanza')
 
 class DataLoader:
-    def __init__(self, doc, batch_size, args, pretrain, vocab, evaluation=False, sort_during_eval=False):
+    def __init__(self, doc, batch_size, args, pretrain, vocab=None, evaluation=False, sort_during_eval=False):
         self.batch_size = batch_size
         self.args = args
         self.eval = evaluation
         self.shuffled = not self.eval
         self.sort_during_eval = sort_during_eval
         self.doc = doc
-        self.vocab = vocab
+
+        if vocab is None:
+            self.vocab = DataLoader.init_vocab([doc], args)
+        else:
+            self.vocab = vocab
 
         data = self.load_doc(self.doc)
 

--- a/stanza/models/pos/data.py
+++ b/stanza/models/pos/data.py
@@ -24,6 +24,10 @@ class DataLoader:
         else:
             self.vocab = vocab
 
+        self.has_upos = not all(x is None or x == '_' for x in doc.get(UPOS, as_sentences=False))
+        self.has_xpos = not all(x is None or x == '_' for x in doc.get(XPOS, as_sentences=False))
+        self.has_feats = not all(x is None or x == '_' for x in doc.get(FEATS, as_sentences=False))
+
         data = self.load_doc(self.doc)
 
         # handle pretrain; pretrain vocab is used when args['pretrain'] == True and pretrain is not None
@@ -111,9 +115,9 @@ class DataLoader:
         wordchars = get_long_tensor(batch_words, len(word_lens))
         wordchars_mask = torch.eq(wordchars, PAD_ID)
 
-        upos = get_long_tensor(batch[2], batch_size)
-        xpos = get_long_tensor(batch[3], batch_size)
-        ufeats = get_long_tensor(batch[4], batch_size)
+        upos = get_long_tensor(batch[2], batch_size) if self.has_upos else None
+        xpos = get_long_tensor(batch[3], batch_size) if self.has_xpos else None
+        ufeats = get_long_tensor(batch[4], batch_size) if self.has_feats else None
         pretrained = get_long_tensor(batch[5], batch_size)
         text = batch[6]
         sentlens = [len(x) for x in batch[0]]

--- a/stanza/models/pos/data.py
+++ b/stanza/models/pos/data.py
@@ -44,8 +44,8 @@ class DataLoader:
         logger.debug("{} batches created.".format(len(self.data)))
 
     @staticmethod
-    def init_vocab(doc, args):
-        data = DataLoader.load_doc(doc)
+    def init_vocab(docs, args):
+        data = [x for doc in docs for x in DataLoader.load_doc(doc)]
         charvocab = CharVocab(data, args['shorthand'])
         wordvocab = WordVocab(data, args['shorthand'], cutoff=args['word_cutoff'], lower=True)
         uposvocab = WordVocab(data, args['shorthand'], idx=1)

--- a/stanza/models/pos/model.py
+++ b/stanza/models/pos/model.py
@@ -198,6 +198,8 @@ class Tagger(nn.Module):
         if upos is not None:
             upos = pack(upos).data
             loss = self.crit(upos_pred.view(-1, upos_pred.size(-1)), upos.view(-1))
+        else:
+            loss = 0.0
 
         if self.share_hid:
             xpos_hid = upos_hid

--- a/stanza/models/pos/scorer.py
+++ b/stanza/models/pos/scorer.py
@@ -7,10 +7,10 @@ from stanza.models.common.utils import ud_scores
 
 logger = logging.getLogger('stanza')
 
-def score(system_conllu_file, gold_conllu_file, verbose=True):
+def score(system_conllu_file, gold_conllu_file, verbose=True, eval_type='AllTags'):
     """ Wrapper for tagger scorer. """
     evaluation = ud_scores(gold_conllu_file, system_conllu_file)
-    el = evaluation['AllTags']
+    el = evaluation[eval_type]
     p = el.precision
     r = el.recall
     f = el.f1

--- a/stanza/models/tagger.py
+++ b/stanza/models/tagger.py
@@ -199,6 +199,16 @@ def train(args):
     vocab = DataLoader.init_vocab(train_docs, args)
     train_batches = [DataLoader(train_doc, args['batch_size'], args, pretrain, vocab=vocab, evaluation=False)
                      for train_doc in train_docs]
+    # here we make sure the model will learn to output _ for empty columns
+    if not any(train_batch.has_upos for train_batch in train_batches):
+        for train_batch in train_batches:
+            train_batch.has_upos = True
+    if not any(train_batch.has_xpos for train_batch in train_batches):
+        for train_batch in train_batches:
+            train_batch.has_xpos = True
+    if not any(train_batch.has_feats for train_batch in train_batches):
+        for train_batch in train_batches:
+            train_batch.has_feats = True
     dev_doc = CoNLL.conll2doc(input_file=args['eval_file'])
     dev_batch = DataLoader(dev_doc, args['batch_size'], args, pretrain, vocab=vocab, evaluation=True, sort_during_eval=True)
 

--- a/stanza/tests/pos/test_data.py
+++ b/stanza/tests/pos/test_data.py
@@ -1,0 +1,58 @@
+"""
+A few tests of specific operations from the DataLoader
+"""
+
+import os
+import pytest
+
+from stanza.models.common.doc import *
+from stanza.models import tagger
+from stanza.models.pos.data import DataLoader
+from stanza.utils.conll import CoNLL
+
+from stanza.tests.pos.test_tagger import TRAIN_DATA_NO_XPOS, TRAIN_DATA_NO_UPOS, TRAIN_DATA_NO_FEATS
+
+def test_no_xpos():
+    """
+    Test that a dataset with no xpos is detected by the DataLoader
+    """
+    # empty args for building the data object
+    args = tagger.parse_args(args=[])
+
+    train_data, _ = CoNLL.conll2dict(input_str=TRAIN_DATA_NO_XPOS)
+    train_doc = Document(train_data)
+
+    data = DataLoader(train_doc, args['batch_size'], args, None)
+    assert data.has_upos
+    assert not data.has_xpos
+    assert data.has_feats
+
+def test_no_upos():
+    """
+    Test that a dataset with no upos is detected by the DataLoader
+    """
+    # empty args for building the data object
+    args = tagger.parse_args(args=[])
+
+    train_data, _ = CoNLL.conll2dict(input_str=TRAIN_DATA_NO_UPOS)
+    train_doc = Document(train_data)
+
+    data = DataLoader(train_doc, args['batch_size'], args, None)
+    assert not data.has_upos
+    assert data.has_xpos
+    assert data.has_feats
+
+def test_no_feats():
+    """
+    Test that a dataset with no feats is detected by the DataLoader
+    """
+    # empty args for building the data object
+    args = tagger.parse_args(args=[])
+
+    train_data, _ = CoNLL.conll2dict(input_str=TRAIN_DATA_NO_FEATS)
+    train_doc = Document(train_data)
+
+    data = DataLoader(train_doc, args['batch_size'], args, None)
+    assert data.has_upos
+    assert data.has_xpos
+    assert not data.has_feats

--- a/stanza/tests/pos/test_tagger.py
+++ b/stanza/tests/pos/test_tagger.py
@@ -69,6 +69,45 @@ TRAIN_DATA_2 = """
 
 """.lstrip()
 
+TRAIN_DATA_NO_UPOS = """
+# sent_id = 11
+# text = It's all hers!
+# previous = Which person owns this?
+# comment = predeterminer modifier
+1	It	it	_	PRP	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
+2	's	be	_	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
+3	all	all	_	DT	Case=Nom	4	det:predet	_	_
+4	hers	hers	_	PRP	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	!	!	_	.	_	4	punct	_	_
+
+""".lstrip()
+
+TRAIN_DATA_NO_XPOS = """
+# sent_id = 11
+# text = It's all hers!
+# previous = Which person owns this?
+# comment = predeterminer modifier
+1	It	it	PRON	_	Number=Sing|Person=3|PronType=Prs	4	nsubj	_	SpaceAfter=No
+2	's	be	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
+3	all	all	DET	_	Case=Nom	4	det:predet	_	_
+4	hers	hers	PRON	_	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	0	root	_	SpaceAfter=No
+5	!	!	PUNCT	_	_	4	punct	_	_
+
+""".lstrip()
+
+TRAIN_DATA_NO_FEATS = """
+# sent_id = 11
+# text = It's all hers!
+# previous = Which person owns this?
+# comment = predeterminer modifier
+1	It	it	PRON	PRP	_	4	nsubj	_	SpaceAfter=No
+2	's	be	AUX	VBZ	_	4	cop	_	_
+3	all	all	DET	DT	_	4	det:predet	_	_
+4	hers	hers	PRON	PRP	_	0	root	_	SpaceAfter=No
+5	!	!	PUNCT	.	_	4	punct	_	_
+
+""".lstrip()
+
 DEV_DATA = """
 1	From	from	ADP	IN	_	3	case	3:case	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
@@ -162,3 +201,12 @@ class TestTagger:
         assert '	hers	' not in TRAIN_DATA
         assert '	hers	' in TRAIN_DATA_2
         assert 'hers' in word_vocab
+
+
+    def test_missing_column(self, tmp_path, wordvec_pretrain_file):
+        """
+        Test that using train files with missing columns works
+
+        TODO: we should find some evidence that it is successfully training the upos & xpos
+        """
+        trainer = self.run_training(tmp_path, wordvec_pretrain_file, [TRAIN_DATA_NO_UPOS, TRAIN_DATA_NO_XPOS, TRAIN_DATA_NO_FEATS], DEV_DATA)

--- a/stanza/tests/pos/test_xpos_vocab_factory.py
+++ b/stanza/tests/pos/test_xpos_vocab_factory.py
@@ -146,8 +146,8 @@ class TestXPOSVocabFactory:
         with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as tmpdirname:
             args = tagger.parse_args(["--batch_size", "1", "--shorthand", shorthand])
             train_doc = build_doc(iterations, suffix)
-            vocab = DataLoader.init_vocab([train_doc], args)
-            train_batch = DataLoader(train_doc, args["batch_size"], args, pt, vocab=vocab, evaluation=False)
+            train_batch = DataLoader(train_doc, args["batch_size"], args, pt, evaluation=False)
+            vocab = train_batch.vocab
             assert isinstance(vocab['xpos'], expected_vocab)
 
             trainer = Trainer(args=args, vocab=vocab, pretrain=pt, device="cpu")

--- a/stanza/tests/pos/test_xpos_vocab_factory.py
+++ b/stanza/tests/pos/test_xpos_vocab_factory.py
@@ -146,7 +146,7 @@ class TestXPOSVocabFactory:
         with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as tmpdirname:
             args = tagger.parse_args(["--batch_size", "1", "--shorthand", shorthand])
             train_doc = build_doc(iterations, suffix)
-            vocab = DataLoader.init_vocab(train_doc, args)
+            vocab = DataLoader.init_vocab([train_doc], args)
             train_batch = DataLoader(train_doc, args["batch_size"], args, pt, vocab=vocab, evaluation=False)
             assert isinstance(vocab['xpos'], expected_vocab)
 

--- a/stanza/utils/datasets/pos/convert_trees_to_pos.py
+++ b/stanza/utils/datasets/pos/convert_trees_to_pos.py
@@ -61,7 +61,7 @@ def convert_file(in_file, out_file, upos):
                 fout.write("\t_\t_\n")
             fout.write("\n")
 
-def convert_treebank(short_name, upos, paths):
+def convert_treebank(short_name, upos, output_name, paths):
     in_dir = paths["CONSTITUENCY_DATA_DIR"]
     in_files = [os.path.join(in_dir, "%s_%s.mrg" % (short_name, shard)) for shard in SHARDS]
     for in_file in in_files:
@@ -71,8 +71,10 @@ def convert_treebank(short_name, upos, paths):
     out_dir = paths["POS_DATA_DIR"]
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
-    out_files = [os.path.join(out_dir, "%s.%s.in.conllu" % (short_name, shard)) for shard in SHARDS]
-    gold_files = [os.path.join(out_dir, "%s.%s.gold.conllu" % (short_name, shard)) for shard in SHARDS]
+    if output_name is None:
+        output_name = short_name
+    out_files = [os.path.join(out_dir, "%s.%s.in.conllu" % (output_name, shard)) for shard in SHARDS]
+    gold_files = [os.path.join(out_dir, "%s.%s.gold.conllu" % (output_name, shard)) for shard in SHARDS]
 
     for in_file, out_file in zip(in_files, out_files):
         convert_file(in_file, out_file, upos)
@@ -84,8 +86,9 @@ if __name__ == '__main__':
     parser.add_argument("dataset", help="Which dataset to process from trees to POS")
     parser.add_argument("--upos", action="store_true", default=False, help="Store tags on the UPOS")
     parser.add_argument("--xpos", dest="upos", action="store_false", help="Store tags on the XPOS")
+    parser.add_argument("--output_name", default=None, help="What name to give the output dataset.  If blank, will use the dataset arg")
     args = parser.parse_args()
 
     paths = default_paths.get_default_paths()
 
-    convert_treebank(args.dataset, args.upos, paths)
+    convert_treebank(args.dataset, args.upos, args.output_name, paths)

--- a/stanza/utils/training/run_pos.py
+++ b/stanza/utils/training/run_pos.py
@@ -49,6 +49,8 @@ def run_treebank(mode, paths, treebank, short_name,
 
     pos_dir        = paths["POS_DATA_DIR"]
     train_file     = f"{pos_dir}/{short_name}.train.in.conllu"
+    if short_name == 'vi_vlsp22':
+        train_file += f";{pos_dir}/vi_vtb.train.in.conllu"
     dev_in_file    = f"{pos_dir}/{short_name}.dev.in.conllu"
     dev_gold_file  = f"{pos_dir}/{short_name}.dev.gold.conllu"
     dev_pred_file  = temp_output_file if temp_output_file else f"{pos_dir}/{short_name}.dev.pred.conllu"
@@ -60,9 +62,10 @@ def run_treebank(mode, paths, treebank, short_name,
     charlm_args = build_charlm_args(short_language, charlm)
 
     if mode == Mode.TRAIN:
-        if not os.path.exists(train_file):
-            logger.error("TRAIN FILE NOT FOUND: %s ... skipping" % train_file)
-            return
+        for train_piece in train_file.split(";"):
+            if not os.path.exists(train_piece):
+                logger.error("TRAIN FILE NOT FOUND: %s ... skipping" % train_piece)
+                return
 
         # some languages need reduced batch size
         batch_size = pos_batch_size(short_name)


### PR DESCRIPTION
Add functionality to only backprop from batches if the batch actually has xpos, upos, or feats in it.  The missing elements are not included in the loss.  Allows for POS datasets with a mix of xpos tags, or allows adding constituency trees with only xpos as a data source, etc