### PR TITLE
Packages

### DIFF
--- a/stanza/pipeline/core.py
+++ b/stanza/pipeline/core.py
@@ -185,6 +185,7 @@ class Pipeline:
                  resources_url=DEFAULT_RESOURCES_URL,
                  resources_branch=None,
                  resources_version=DEFAULT_RESOURCES_VERSION,
+                 resources_filepath=None,
                  proxies=None,
                  foundation_cache=None,
                  device=None,
@@ -212,6 +213,7 @@ class Pipeline:
                                     resources_url=resources_url,
                                     resources_branch=resources_branch,
                                     resources_version=resources_version,
+                                    resources_filepath=resources_filepath,
                                     proxies=proxies)
 
         # process different pipeline parameters
@@ -219,7 +221,7 @@ class Pipeline:
 
         # Load resources.json to obtain latest packages.
         logger.debug('Loading resource file...')
-        resources = load_resources_json(self.dir)
+        resources = load_resources_json(self.dir, resources_filepath)
         if lang in resources:
             if 'alias' in resources[lang]:
                 logger.info(f'"{lang}" is an alias for "{resources[lang]["alias"]}"')

--- a/stanza/resources/common.py
+++ b/stanza/resources/common.py
@@ -428,6 +428,7 @@ def download_resources_json(model_dir=DEFAULT_MODEL_DIR,
                             resources_url=DEFAULT_RESOURCES_URL,
                             resources_branch=None,
                             resources_version=DEFAULT_RESOURCES_VERSION,
+                            resources_filepath=None,
                             proxies=None):
     """
     Downloads resources.json to obtain latest packages.
@@ -439,20 +440,23 @@ def download_resources_json(model_dir=DEFAULT_MODEL_DIR,
         resources_url = STANFORDNLP_RESOURCES_URL
     resources_url = f'{resources_url}/resources_{resources_version}.json'
     logger.debug('Downloading resource file from %s', resources_url)
+    if resources_filepath is None:
+        resources_filepath = os.path.join(model_dir, 'resources.json')
     # make request
     request_file(
         resources_url,
-        os.path.join(model_dir, 'resources.json'),
+        resources_filepath,
         proxies,
         raise_for_status=True
     )
 
 
-def load_resources_json(model_dir=DEFAULT_MODEL_DIR):
+def load_resources_json(model_dir=DEFAULT_MODEL_DIR, resources_filepath=None):
     """
     Unpack the resources json file from the given model_dir
     """
-    resources_filepath = os.path.join(model_dir, 'resources.json')
+    if resources_filepath is None:
+        resources_filepath = os.path.join(model_dir, 'resources.json')
     if not os.path.exists(resources_filepath):
         raise ResourcesFileNotFoundError(resources_filepath)
     with open(resources_filepath) as fin:

--- a/stanza/resources/default_packages.py
+++ b/stanza/resources/default_packages.py
@@ -8,6 +8,9 @@ causing a circular import
 
 import copy
 
+# all languages will have a map which represents the available packages
+PACKAGES = "packages"
+
 # default treebank for languages
 default_treebanks = {
     "af":      "afribooms",

--- a/stanza/resources/default_packages.py
+++ b/stanza/resources/default_packages.py
@@ -33,7 +33,7 @@ default_treebanks = {
     "fa":      "perdt",
     "fi":      "tdt",
     "fo":      "farpahc",
-    "fr":      "gsd",
+    "fr":      "combined",
     "fro":     "srcmf",
     "ga":      "idt",
     "gd":      "arcosg",

--- a/stanza/resources/prepare_resources.py
+++ b/stanza/resources/prepare_resources.py
@@ -108,21 +108,25 @@ allowed_empty_languages = [
 ]
 
 # map processor name to file ending
+# the order of this dict determines the order in which default.zip files are built
+# changing it will necessitate rebuilding all of the default.zip files
+# not a disaster, but it would involve a bunch of uploading
 processor_to_ending = {
     "tokenize": "tokenizer",
     "mwt": "mwt_expander",
-    "pos": "tagger",
     "lemma": "lemmatizer",
+    "pos": "tagger",
     "depparse": "parser",
-    "ner": "nertagger",
-    "sentiment": "sentiment",
-    "constituency": "constituency",
     "pretrain": "pretrain",
+    "ner": "nertagger",
     "forward_charlm": "forward_charlm",
     "backward_charlm": "backward_charlm",
+    "sentiment": "sentiment",
+    "constituency": "constituency",
     "langid": "langid"
 }
 ending_to_processor = {j: i for i, j in processor_to_ending.items()}
+PROCESSORS = list(processor_to_ending.keys())
 
 def ensure_dir(dir):
     Path(dir).mkdir(parents=True, exist_ok=True)
@@ -394,8 +398,7 @@ def process_default_zips(args):
                 models_needed[dependency['model']].add(dependency['package'])
 
         model_files = []
-        processors = ['tokenize', 'mwt', 'lemma', 'pos', 'depparse', 'pretrain', 'ner', 'forward_charlm', 'backward_charlm', 'sentiment', 'constituency', 'langid']
-        for processor in processors:
+        for processor in PROCESSORS:
             if processor in models_needed:
                 for package in sorted(models_needed[processor]):
                     filename = os.path.join(args.output_dir, lang, "models", processor, package + '.pt')

--- a/stanza/resources/prepare_resources.py
+++ b/stanza/resources/prepare_resources.py
@@ -19,6 +19,7 @@ import zipfile
 
 from stanza import __resources_version__
 from stanza.models.common.constant import lcode2lang, two_to_three_letters, three_to_two_letters
+from stanza.resources.default_packages import PACKAGES
 from stanza.resources.default_packages import default_treebanks, no_pretrain_languages, default_pretrains, pos_pretrains, depparse_pretrains, ner_pretrains, default_charlms, pos_charlms, depparse_charlms, ner_charlms, lemma_charlms, known_nicknames
 from stanza.utils.get_tqdm import get_tqdm
 
@@ -462,7 +463,12 @@ def process_defaults(args):
                     raise FileNotFoundError(f"Could not find an expected model file for {lang} {processor} {package} : {filename}")
 
         default_md5 = get_md5(os.path.join(args.output_dir, lang, 'models', 'default.zip'))
+        # TODO: eventually we can remove default_processors
+        # For now, we want to keep this so that v1.5.1 is compatible
+        # with the next iteration of resources files
         resources[lang]['default_processors'] = default_processors
+        resources[lang][PACKAGES] = {}
+        resources[lang][PACKAGES]['default'] = default_processors
         resources[lang]['default_md5'] = default_md5
 
     print("Processed default model dependencies.  Writing resources.json")

--- a/stanza/resources/prepare_resources.py
+++ b/stanza/resources/prepare_resources.py
@@ -300,6 +300,26 @@ def get_sentiment_dependencies(lang, package):
 
     return dependencies
 
+def get_dependencies(processor, lang, package):
+    """
+    Get the dependencies for a particular lang/package based on the package name
+
+    The package can include descriptors such as _nopretrain, _nocharlm, _charlm
+    which inform whether or not this particular model uses charlm or pretrain
+    """
+    if processor == 'depparse':
+        return get_depparse_dependencies(lang, package)
+    elif processor == 'lemma':
+        return get_lemma_dependencies(lang, package)
+    elif processor == 'pos':
+        return get_pos_dependencies(lang, package)
+    elif processor == 'ner':
+        return get_ner_dependencies(lang, package)
+    elif processor == 'sentiment':
+        return get_sentiment_dependencies(lang, package)
+    elif processor == 'constituency':
+        return get_con_dependencies(lang, package)
+    return {}
 
 def process_dirs(args):
     dirs = sorted(os.listdir(args.input_dir))
@@ -319,19 +339,7 @@ def process_dirs(args):
             # maintain md5
             md5 = get_md5(output_path)
             # maintain dependencies
-            dependencies = None
-            if processor == 'depparse':
-                dependencies = get_depparse_dependencies(lang, package)
-            elif processor == 'lemma':
-                dependencies = get_lemma_dependencies(lang, package)
-            elif processor == 'pos':
-                dependencies = get_pos_dependencies(lang, package)
-            elif processor == 'ner':
-                dependencies = get_ner_dependencies(lang, package)
-            elif processor == 'sentiment':
-                dependencies = get_sentiment_dependencies(lang, package)
-            elif processor == 'constituency':
-                dependencies = get_con_dependencies(lang, package)
+            dependencies = get_dependencies(processor, lang, package)
             # maintain resources
             if lang not in resources: resources[lang] = {}
             if processor not in resources[lang]: resources[lang][processor] = {}

--- a/stanza/resources/prepare_resources.py
+++ b/stanza/resources/prepare_resources.py
@@ -632,8 +632,8 @@ def main():
     args = parse_args()
     print("Converting models from %s to %s" % (args.input_dir, args.output_dir))
     process_dirs(args)
-    process_default_zips(args)
     process_packages(args)
+    process_default_zips(args)
     process_lcode(args)
     process_misc(args)
 

--- a/stanza/resources/prepare_resources.py
+++ b/stanza/resources/prepare_resources.py
@@ -565,6 +565,8 @@ def process_misc(args):
     resources = json.load(open(os.path.join(args.output_dir, 'resources.json')))
     resources['no'] = {'alias': 'nb'}
     resources['zh'] = {'alias': 'zh-hans'}
+    # This is intended to be unformatted.  expand_model_url in common.py will fill in the raw string
+    # with the appropriate values in order to find the needed model file on huggingface
     resources['url'] = 'https://huggingface.co/stanfordnlp/stanza-{lang}/resolve/v{resources_version}/models/{filename}'
     print("Finalized misc attributes.  Writing resources.json")
     json.dump(resources, open(os.path.join(args.output_dir, 'resources.json'), 'w'), indent=2)

--- a/stanza/resources/prepare_resources.py
+++ b/stanza/resources/prepare_resources.py
@@ -541,6 +541,8 @@ def process_lcode(args):
     for lang in resources:
         if lang == 'multilingual':
             continue
+        if 'alias' in resources[lang]:
+            continue
         if lang not in lcode2lang:
             print(lang + ' not found in lcode2lang!')
             continue

--- a/stanza/tests/pipeline/test_french_pipeline.py
+++ b/stanza/tests/pipeline/test_french_pipeline.py
@@ -36,8 +36,8 @@ EXPECTED_RESULT = """
       "text": "encore",
       "lemma": "encore",
       "upos": "ADV",
-      "head": 1,
-      "deprel": "fixed",
+      "head": 3,
+      "deprel": "advmod",
       "start_char": 6,
       "end_char": 12
     },
@@ -96,7 +96,7 @@ EXPECTED_RESULT = """
       "upos": "NOUN",
       "feats": "Gender=Masc|Number=Sing",
       "head": 3,
-      "deprel": "obl:arg",
+      "deprel": "obl:mod",
       "start_char": 30,
       "end_char": 36
     },
@@ -287,7 +287,7 @@ EXPECTED_RESULT = """
       "id": 25,
       "text": "Numérique",
       "lemma": "numérique",
-      "upos": "NOUN",
+      "upos": "PROPN",
       "feats": "Gender=Masc|Number=Sing",
       "head": 17,
       "deprel": "conj",


### PR DESCRIPTION
Add a `packages` map to the `resources.json` wherein `default` is what we recommend people use on a day to day basis, but there is also `default_fast` where no charlms are used for any model (good for CPU) and `default_best` for any language where we use transformers.  We also add packages for each of the UD datasets, which is useful since previous versions allowed `package="gsd"` for French, for example, but that is actually not possible in version 1.5.1.  Some might even call that a bug...

https://github.com/stanfordnlp/stanza/issues/1259

https://github.com/stanfordnlp/stanza/issues/1284
