### PR TITLE
Multilayer ner

### DIFF
--- a/stanza/models/common/utils.py
+++ b/stanza/models/common/utils.py
@@ -396,18 +396,6 @@ def set_random_seed(seed):
         torch.cuda.manual_seed(seed)
     return seed
 
-def get_known_tags(known_tags):
-    """
-    Turns either a list or a list of lists into a single sorted list
-
-    Actually this is not at all necessarily about tags
-    """
-    if isinstance(known_tags, list) and isinstance(known_tags[0], list):
-        known_tags = sorted(set(x for y in known_tags for x in y))
-    else:
-        known_tags = sorted(known_tags)
-    return known_tags
-
 def find_missing_tags(known_tags, test_tags):
     if isinstance(known_tags, list) and isinstance(known_tags[0], list):
         known_tags = set(x for y in known_tags for x in y)

--- a/stanza/models/common/vocab.py
+++ b/stanza/models/common/vocab.py
@@ -13,6 +13,7 @@ EMPTY_ID = 2
 ROOT = '<ROOT>'
 ROOT_ID = 3
 VOCAB_PREFIX = [PAD, UNK, EMPTY, ROOT]
+VOCAB_PREFIX_SIZE = len(VOCAB_PREFIX)
 
 class BaseVocab:
     """ A base class for common vocabulary operations. Each subclass should at least 

--- a/stanza/models/common/vocab.py
+++ b/stanza/models/common/vocab.py
@@ -1,5 +1,6 @@
 from copy import copy
 from collections import Counter, OrderedDict
+from collections.abc import Iterable
 import os
 import pickle
 
@@ -111,7 +112,7 @@ class CompositeVocab(BaseVocab):
 
     def unit2parts(self, unit):
         # unpack parts of a unit
-        if self.sep == "":
+        if not self.sep:
             parts = [x for x in unit]
         else:
             parts = unit.split(self.sep)
@@ -137,6 +138,9 @@ class CompositeVocab(BaseVocab):
             return [self._unit2id[i].get(parts[i], UNK_ID) if i < len(parts) else EMPTY_ID for i in range(len(self._unit2id))]
 
     def id2unit(self, id):
+        # special case: allow single ids for vocabs with length 1
+        if len(self._id2unit) == 1 and not isinstance(id, Iterable):
+            id = (id,)
         items = []
         for v, k in zip(id, self._id2unit.keys()):
             if v == EMPTY_ID: continue
@@ -144,10 +148,13 @@ class CompositeVocab(BaseVocab):
                 items.append("{}={}".format(k, self._id2unit[k][v]))
             else:
                 items.append(self._id2unit[k][v])
-        res = self.sep.join(items)
-        if res == "":
-            res = "_"
-        return res
+        if self.sep:
+            res = self.sep.join(items)
+            if res == "":
+                res = "_"
+            return res
+        else:
+            return items
 
     def build_vocab(self):
         allunits = [w[self.idx] for sent in self.data for w in sent]
@@ -190,6 +197,9 @@ class CompositeVocab(BaseVocab):
 
     def lens(self):
         return [len(self._unit2id[k]) for k in self._unit2id]
+
+    def items(self, idx):
+        return self._id2unit[idx]
 
 class BaseMultiVocab:
     """ A convenient vocab container that can store multiple BaseVocab instances, and support 

--- a/stanza/models/ner/data.py
+++ b/stanza/models/ner/data.py
@@ -68,11 +68,7 @@ class DataLoader:
         else:
             charvocab = CharVocab(data, self.args['shorthand'])
         wordvocab = self.pretrain.vocab
-        # TODO: even when reading the multi_ner, we are converting that
-        # to single tag entries.  those should be entire lists.
-        # then it will not be necessary to convert the tag_data
-        # could simply use idx=1
-        tag_data = [[((x[1],),) for x in sentence] for sentence in data]
+        tag_data = [[(x[1],) for x in sentence] for sentence in data]
         tagvocab = CompositeVocab(tag_data, self.args['shorthand'], idx=0, sep=None)
         ignore = None
         if self.args['emb_finetune_known_only']:
@@ -95,11 +91,10 @@ class DataLoader:
             char_case = lambda x: x.lower()
         else:
             char_case = lambda x: x
-        for sent in data:
+        for sent_idx, sent in enumerate(data):
             processed_sent = [[w[0] for w in sent]]
             processed_sent += [[vocab['char'].map([char_case(x) for x in w[0]]) for w in sent]]
-            # TODO: this is where we would pass in multiple tags and/or empty fields
-            processed_sent += [vocab['tag'].map([(w[1],) for w in sent])]
+            processed_sent += [vocab['tag'].map([w[1] for w in sent])]
             processed.append(processed_sent)
         return processed
 
@@ -159,10 +154,6 @@ class DataLoader:
         if self.preprocess_tags: # preprocess tags
             data = process_tags(data, self.args.get('scheme', 'bio'))
             data = normalize_empty_tags(data)
-        # TODO: downstream stuff like the scoring evaluation should handle multi_ner
-        # the missing tag function in ner_tagger.py will also need to work with
-        # multiple dimensions of tags
-        data = [[[token[0], token[1][0]] for token in sentence] for sentence in data]
         return data
 
     def process_chars(self, sents):

--- a/stanza/models/ner/data.py
+++ b/stanza/models/ner/data.py
@@ -8,7 +8,7 @@ from stanza.models.common.vocab import PAD_ID, VOCAB_PREFIX
 from stanza.models.pos.vocab import CharVocab, CompositeVocab, WordVocab
 from stanza.models.ner.vocab import MultiVocab
 from stanza.models.common.doc import *
-from stanza.models.ner.utils import process_tags
+from stanza.models.ner.utils import process_tags, normalize_empty_tags
 
 logger = logging.getLogger('stanza')
 
@@ -158,6 +158,7 @@ class DataLoader:
         data = [[[token[0], token[2]] if token[2] else [token[0], (token[1],)] for token in sentence] for sentence in data]
         if self.preprocess_tags: # preprocess tags
             data = process_tags(data, self.args.get('scheme', 'bio'))
+            data = normalize_empty_tags(data)
         # TODO: downstream stuff like the scoring evaluation should handle multi_ner
         # the missing tag function in ner_tagger.py will also need to work with
         # multiple dimensions of tags

--- a/stanza/models/ner/data.py
+++ b/stanza/models/ner/data.py
@@ -157,11 +157,7 @@ class DataLoader:
         data = doc.get([TEXT, NER, MULTI_NER], as_sentences=True, from_token=True)
         data = [[[token[0], token[2]] if token[2] else [token[0], (token[1],)] for token in sentence] for sentence in data]
         if self.preprocess_tags: # preprocess tags
-            # TODO: instead, process_tags should expect multiple columns of tags
-            # and properly process each of them
-            data = [[[token[0], token[1][0]] for token in sentence] for sentence in data]
             data = process_tags(data, self.args.get('scheme', 'bio'))
-            data = [[[token[0], (token[1],)] for token in sentence] for sentence in data]
         # TODO: downstream stuff like the scoring evaluation should handle multi_ner
         # the missing tag function in ner_tagger.py will also need to work with
         # multiple dimensions of tags

--- a/stanza/models/ner/data.py
+++ b/stanza/models/ner/data.py
@@ -68,7 +68,10 @@ class DataLoader:
         else:
             charvocab = CharVocab(data, self.args['shorthand'])
         wordvocab = self.pretrain.vocab
-        # TODO: this should just read off the multi_ner instead of needing to do this
+        # TODO: even when reading the multi_ner, we are converting that
+        # to single tag entries.  those should be entire lists.
+        # then it will not be necessary to convert the tag_data
+        # could simply use idx=1
         tag_data = [[((x[1],),) for x in sentence] for sentence in data]
         tagvocab = CompositeVocab(tag_data, self.args['shorthand'], idx=0, sep=None)
         ignore = None
@@ -149,9 +152,20 @@ class DataLoader:
             yield self.__getitem__(i)
 
     def load_doc(self, doc):
-        data = doc.get([TEXT, NER], as_sentences=True, from_token=True)
+        # preferentially load the MULTI_NER in case we are training /
+        # testing a model with multiple layers of tags
+        data = doc.get([TEXT, NER, MULTI_NER], as_sentences=True, from_token=True)
+        data = [[[token[0], token[2]] if token[2] else [token[0], (token[1],)] for token in sentence] for sentence in data]
         if self.preprocess_tags: # preprocess tags
+            # TODO: instead, process_tags should expect multiple columns of tags
+            # and properly process each of them
+            data = [[[token[0], token[1][0]] for token in sentence] for sentence in data]
             data = process_tags(data, self.args.get('scheme', 'bio'))
+            data = [[[token[0], (token[1],)] for token in sentence] for sentence in data]
+        # TODO: downstream stuff like the scoring evaluation should handle multi_ner
+        # the missing tag function in ner_tagger.py will also need to work with
+        # multiple dimensions of tags
+        data = [[[token[0], token[1][0]] for token in sentence] for sentence in data]
         return data
 
     def process_chars(self, sents):

--- a/stanza/models/ner/model.py
+++ b/stanza/models/ner/model.py
@@ -13,7 +13,7 @@ from stanza.models.common.dropout import WordDropout, LockedDropout
 from stanza.models.common.char_model import CharacterModel, CharacterLanguageModel
 from stanza.models.common.crf import CRFLoss
 from stanza.models.common.foundation_cache import load_bert
-from stanza.models.common.vocab import PAD_ID, UNK_ID
+from stanza.models.common.vocab import PAD_ID, UNK_ID, EMPTY_ID
 from stanza.models.common.bert_embedding import extract_bert_embeddings
 
 logger = logging.getLogger('stanza')
@@ -120,12 +120,13 @@ class NERTagger(nn.Module):
         self.taggerlstm_c_init = nn.Parameter(torch.zeros(2 * self.args['num_layers'], 1, self.args['hidden_dim']), requires_grad=False)
 
         # tag classifier
-        num_tag = self.vocab['tag'].lens()[0]
-        self.tag_clf = nn.Linear(self.args['hidden_dim']*2, num_tag)
-        self.tag_clf.bias.data.zero_()
-
-        # criterion
-        self.crit = CRFLoss(num_tag)
+        tag_lengths = self.vocab['tag'].lens()
+        self.num_output_layers = len(tag_lengths)
+        # TODO: add an option to connect the output of one layer to the input of the next layer
+        self.tag_clfs = nn.ModuleList([nn.Linear(self.args['hidden_dim']*2, num_tag) for num_tag in tag_lengths])
+        for tag_clf in self.tag_clfs:
+            tag_clf.bias.data.zero_()
+        self.crits = nn.ModuleList([CRFLoss(num_tag) for num_tag in tag_lengths])
 
         self.drop = nn.Dropout(args['dropout'])
         self.worddrop = WordDropout(args['word_dropout'])
@@ -233,10 +234,18 @@ class NERTagger(nn.Module):
         lstm_outputs = pad(lstm_outputs)
         lstm_outputs = self.lockeddrop(lstm_outputs)
         lstm_outputs = pack(lstm_outputs).data
-        logits = pad(self.tag_clf(lstm_outputs)).contiguous()
-        # TODO: this will have to update in order to use multiple layers
-        tags = tags[:, :, 0]
-        loss, trans = self.crit(logits, word_mask, tags)
+
+        loss = 0
+        logits = []
+        trans = []
+        for idx, (tag_clf, crit) in enumerate(zip(self.tag_clfs, self.crits)):
+            next_logits = pad(tag_clf(lstm_outputs)).contiguous()
+            # the tag_mask lets us avoid backprop on a blank tag
+            tag_mask = torch.eq(tags[:, :, idx], EMPTY_ID)
+            next_loss, next_trans = crit(next_logits, torch.bitwise_or(tag_mask, word_mask), tags[:, :, idx])
+            loss = loss + next_loss
+            logits.append(next_logits)
+            trans.append(next_trans)
 
         return loss, logits, trans
 

--- a/stanza/models/ner/model.py
+++ b/stanza/models/ner/model.py
@@ -120,7 +120,7 @@ class NERTagger(nn.Module):
         self.taggerlstm_c_init = nn.Parameter(torch.zeros(2 * self.args['num_layers'], 1, self.args['hidden_dim']), requires_grad=False)
 
         # tag classifier
-        num_tag = len(self.vocab['tag'])
+        num_tag = self.vocab['tag'].lens()[0]
         self.tag_clf = nn.Linear(self.args['hidden_dim']*2, num_tag)
         self.tag_clf.bias.data.zero_()
 
@@ -234,6 +234,8 @@ class NERTagger(nn.Module):
         lstm_outputs = self.lockeddrop(lstm_outputs)
         lstm_outputs = pack(lstm_outputs).data
         logits = pad(self.tag_clf(lstm_outputs)).contiguous()
+        # TODO: this will have to update in order to use multiple layers
+        tags = tags[:, :, 0]
         loss, trans = self.crit(logits, word_mask, tags)
 
         return loss, logits, trans

--- a/stanza/models/ner/trainer.py
+++ b/stanza/models/ner/trainer.py
@@ -118,6 +118,8 @@ class Trainer(BaseTrainer):
         for i in range(bs):
             tags, _ = viterbi_decode(scores[i, :sentlens[i]], trans)
             tags = self.vocab['tag'].unmap(tags)
+            # for now, allow either TagVocab or CompositeVocab
+            tags = [x[0] if isinstance(x, list) else x for x in tags]
             tags = fix_singleton_tags(tags)
             tag_seqs += [tags]
 
@@ -185,7 +187,7 @@ class Trainer(BaseTrainer):
         Removes the S-, B-, etc, and does not include O
         """
         tags = set()
-        for tag in self.vocab['tag']:
+        for tag in self.vocab['tag'].items(0):
             if tag in VOCAB_PREFIX:
                 continue
             if tag == 'O':

--- a/stanza/models/ner/trainer.py
+++ b/stanza/models/ner/trainer.py
@@ -9,7 +9,7 @@ from torch import nn
 
 from stanza.models.common.foundation_cache import NoTransformerFoundationCache
 from stanza.models.common.trainer import Trainer as BaseTrainer
-from stanza.models.common.vocab import VOCAB_PREFIX
+from stanza.models.common.vocab import VOCAB_PREFIX, VOCAB_PREFIX_SIZE
 from stanza.models.common import utils, loss
 from stanza.models.ner.model import NERTagger
 from stanza.models.ner.vocab import MultiVocab
@@ -129,6 +129,8 @@ class Trainer(BaseTrainer):
         for i in range(batch_size):
             # for each tag column in the output, decode the tag assignments
             tags = [viterbi_decode(x[i, :sentlens[i]], y)[0] for x, y in zip(logits, trans)]
+            # TODO: this is to patch that the model can sometimes predict < "O"
+            tags = [[x if x >= VOCAB_PREFIX_SIZE else VOCAB_PREFIX_SIZE for x in y] for y in tags]
             # that gives us N lists of |sent| tags, whereas we want |sent| lists of N tags
             tags = list(zip(*tags))
             # now unmap that to the tags in the vocab

--- a/stanza/models/ner/utils.py
+++ b/stanza/models/ner/utils.py
@@ -120,35 +120,79 @@ def bio2_to_bioes(tags):
     return new_tags
 
 def process_tags(sentences, scheme):
-    res = []
-    # check if tag conversion is needed
-    convert_bio_to_bioes = False
-    convert_basic_to_bioes = False
-    is_bio = is_bio_scheme([x[1] for sent in sentences for x in sent])
-    is_basic = not is_bio and is_basic_scheme([x[1] for sent in sentences for x in sent])
-    if is_bio and scheme.lower() == 'bioes':
-        convert_bio_to_bioes = True
-        logger.debug("BIO tagging scheme found in input; converting into BIOES scheme...")
-    elif is_basic and scheme.lower() == 'bioes':
-        convert_basic_to_bioes = True
-        logger.debug("Basic tagging scheme found in input; converting into BIOES scheme...")
-    # process tags
-    for sent in sentences:
+    all_words = []
+    all_tags = []
+    converted_tuples = False
+    for sent_idx, sent in enumerate(sentences):
         words, tags = zip(*sent)
-        # NER field sanity checking
-        if any([x is None or x == '_' for x in tags]):
-            raise ValueError("NER tag not found for some input data.")
-        if convert_basic_to_bioes:
-            # if basic, convert tags -> bio -> bioes
-            tags = bio2_to_bioes(basic_to_bio(tags))
-        else:
-            # first ensure BIO2 scheme
-            tags = to_bio2(tags)
-            # then convert to BIOES
-            if convert_bio_to_bioes:
-                tags = bio2_to_bioes(tags)
-        res.append([(w,t) for w,t in zip(words, tags)])
-    return res
+        all_words.append(words)
+        # if we got one dimension tags w/o tuples or lists, make them tuples
+        # but we also check that the format is consistent,
+        # as otherwise the result being converted might be confusing
+        if not converted_tuples and any(tag is None or isinstance(tag, str) for tag in tags):
+            if sent_idx > 0:
+                raise ValueError("Got a mix of tags and lists of tags.  First non-list was in sentence %d" % sent_idx)
+            converted_tuples = True
+        if converted_tuples:
+            if not all(tag is None or isinstance(tag, str) for tag in tags):
+                raise ValueError("Got a mix of tags and lists of tags.  First tag as a list was in sentence %d" % sent_idx)
+            tags = [(tag,) for tag in tags]
+        all_tags.append(tags)
+
+    max_columns = max(len(x) for tags in all_tags for x in tags)
+    for sent_idx, tags in enumerate(all_tags):
+        if any(len(x) < max_columns for x in tags):
+            raise ValueError("NER tags not uniform in length at sentence %d.  TODO: extend those columns with O" % sent_idx)
+
+    all_convert_bio_to_bioes = []
+    all_convert_basic_to_bioes = []
+
+    for column_idx in range(max_columns):
+        # check if tag conversion is needed for each column
+        # we treat each column separately, although practically
+        # speaking it would be pretty weird for a dataset to have BIO
+        # in one column and basic in another, for example
+        convert_bio_to_bioes = False
+        convert_basic_to_bioes = False
+        tag_column = [x[column_idx] for sent in all_tags for x in sent]
+        is_bio = is_bio_scheme(tag_column)
+        is_basic = not is_bio and is_basic_scheme(tag_column)
+        if is_bio and scheme.lower() == 'bioes':
+            convert_bio_to_bioes = True
+            logger.debug("BIO tagging scheme found in input at column %d; converting into BIOES scheme..." % column_idx)
+        elif is_basic and scheme.lower() == 'bioes':
+            convert_basic_to_bioes = True
+            logger.debug("Basic tagging scheme found in input at column %d; converting into BIOES scheme..." % column_idx)
+        all_convert_bio_to_bioes.append(convert_bio_to_bioes)
+        all_convert_basic_to_bioes.append(convert_basic_to_bioes)
+
+    result = []
+    for words, tags in zip(all_words, all_tags):
+        # process tags
+        # tags is a list of each column of tags for each word in this sentence
+        # first, NER field sanity checking
+        if any(x is None or x == '_' for sentence_tags in tags for x in sentence_tags):
+            raise ValueError("Got blank tags for some of the words - cannot handle that yet!  TODO")
+        # copy the tags to a list so we can edit them
+        tags = [[x for x in sentence_tags] for sentence_tags in tags]
+        for column_idx, (convert_bio_to_bioes, convert_basic_to_bioes) in enumerate(zip(all_convert_bio_to_bioes, all_convert_basic_to_bioes)):
+            tag_column = [x[column_idx] for x in tags]
+            if convert_basic_to_bioes:
+                # if basic, convert tags -> bio -> bioes
+                tag_column = bio2_to_bioes(basic_to_bio(tag_column))
+            else:
+                # first ensure BIO2 scheme
+                tag_column = to_bio2(tag_column)
+                # then convert to BIOES
+                if convert_bio_to_bioes:
+                    tag_column = bio2_to_bioes(tag_column)
+            for tag_idx, tag in enumerate(tag_column):
+                tags[tag_idx][column_idx] = tag
+        result.append([(w,tuple(t)) for w,t in zip(words, tags)])
+
+    if converted_tuples:
+        result = [[(word[0], word[1][0]) for word in sentence] for sentence in result]
+    return result
 
 
 def decode_from_bioes(tags):

--- a/stanza/models/ner/vocab.py
+++ b/stanza/models/ner/vocab.py
@@ -1,6 +1,6 @@
 from collections import Counter, OrderedDict
 
-from stanza.models.common.vocab import BaseVocab, BaseMultiVocab, CharVocab
+from stanza.models.common.vocab import BaseVocab, BaseMultiVocab, CharVocab, CompositeVocab
 from stanza.models.common.vocab import VOCAB_PREFIX
 from stanza.models.common.pretrain import PretrainedWordVocab
 from stanza.models.pos.vocab import WordVocab
@@ -12,6 +12,21 @@ class TagVocab(BaseVocab):
 
         self._id2unit = VOCAB_PREFIX + list(sorted(list(counter.keys()), key=lambda k: counter[k], reverse=True))
         self._unit2id = {w:i for i, w in enumerate(self._id2unit)}
+
+def convert_tag_vocab(state_dict):
+    if state_dict['lower']:
+        raise AssertionError("Did not expect an NER vocab with 'lower' set to True")
+    items = state_dict['_id2unit'][len(VOCAB_PREFIX):]
+    # this looks silly, but the vocab builder treats this as words with multiple fields
+    # (we set it to look for field 0 with idx=0)
+    # and then the label field is expected to be a list or tuple of items
+    items = [[[[x]]] for x in items]
+    vocab = CompositeVocab(data=items, lang=state_dict['lang'], idx=0, sep=None)
+    if len(vocab._id2unit[0]) != len(state_dict['_id2unit']):
+        raise AssertionError("Failed to construct a new vocab of the same length as the original")
+    if vocab._id2unit[0] != state_dict['_id2unit']:
+        raise AssertionError("Failed to construct a new vocab in the same order as the original")
+    return vocab
 
 class MultiVocab(BaseMultiVocab):
     def state_dict(self):
@@ -26,15 +41,16 @@ class MultiVocab(BaseMultiVocab):
 
     @classmethod
     def load_state_dict(cls, state_dict):
-        class_dict = {'CharVocab': CharVocab,
-                      'PretrainedWordVocab': PretrainedWordVocab,
-                      'TagVocab': TagVocab,
-                      'WordVocab': WordVocab}
+        class_dict = {'CharVocab': CharVocab.load_state_dict,
+                      'PretrainedWordVocab': PretrainedWordVocab.load_state_dict,
+                      'TagVocab': convert_tag_vocab,
+                      'CompositeVocab': CompositeVocab.load_state_dict,
+                      'WordVocab': WordVocab.load_state_dict}
         new = cls()
         assert '_key2class' in state_dict, "Cannot find class name mapping in state dict!"
         key2class = state_dict.pop('_key2class')
         for k,v in state_dict.items():
             classname = key2class[k]
-            new[k] = class_dict[classname].load_state_dict(v)
+            new[k] = class_dict[classname](v)
         return new
 

--- a/stanza/models/ner_tagger.py
+++ b/stanza/models/ner_tagger.py
@@ -224,6 +224,7 @@ def train(args):
     dev_gold_tags = [[x[0] for x in tags] for tags in dev_gold_tags]
 
     train_tags = get_known_tags(train_batch.tags)
+    logger.info("Training data has %d columns of tags", len(train_tags))
     for tag_idx, tags in enumerate(train_tags):
         logger.info("Tags present in training set at column %d:\n  Tags without BIES markers: %s\n  Tags with B-, I-, E-, or S-: %s",
                     tag_idx,

--- a/stanza/models/ner_tagger.py
+++ b/stanza/models/ner_tagger.py
@@ -212,7 +212,7 @@ def train(args):
                 " ".join(sorted(set(i[2:] for i in train_tags if i[:2] in ('B-', 'I-', 'E-', 'S-')))))
 
     if args['finetune']:
-        utils.warn_missing_tags([i for i in trainer.vocab['tag']], train_batch.tags, "training set")
+        utils.warn_missing_tags([i for i in trainer.vocab['tag'].items(0)], train_batch.tags, "training set")
     utils.warn_missing_tags(train_batch.tags, dev_batch.tags, "dev set")
 
     # skip training if the language does not have training or dev data
@@ -349,7 +349,7 @@ def evaluate(args):
     with open(args['eval_file']) as fin:
         doc = Document(json.load(fin))
     batch = DataLoader(doc, args['batch_size'], loaded_args, vocab=vocab, evaluation=True, bert_tokenizer=trainer.model.bert_tokenizer)
-    utils.warn_missing_tags([i for i in trainer.vocab['tag']], batch.tags, "eval_file")
+    utils.warn_missing_tags([i for i in trainer.vocab['tag'].items(0)], batch.tags, "eval_file")
 
     logger.info("Start evaluation...")
     preds = []

--- a/stanza/models/ner_tagger.py
+++ b/stanza/models/ner_tagger.py
@@ -89,6 +89,8 @@ def build_argparse():
     parser.add_argument('--lr_decay', type=float, default=0.5, help="LR decay rate.")
     parser.add_argument('--patience', type=int, default=3, help="Patience for LR decay.")
 
+    parser.add_argument('--connect_output_layers', action='store_true', default=False, help='Connect one output layer to the input of the next output layer.  By default, those layers are all separate')
+
     parser.add_argument('--ignore_tag_scores', type=str, default=None, help="Which tags to ignore, if any, when scoring dev & test sets")
 
     parser.add_argument('--max_steps', type=int, default=200000)

--- a/stanza/models/ner_tagger.py
+++ b/stanza/models/ner_tagger.py
@@ -231,6 +231,7 @@ def train(args):
                     " ".join(sorted(set(i[2:] for i in tags if i[:2] in ('B-', 'I-', 'E-', 'S-')))))
 
     if args['finetune']:
+        # TODO: here we need to check if the dataset has more tags than already in the model
         utils.warn_missing_tags([i for i in trainer.vocab['tag'].items(0)], train_batch.tags, "training set")
     utils.warn_missing_tags(train_batch.tags, dev_batch.tags, "dev set")
 

--- a/stanza/tests/ner/test_ner_training.py
+++ b/stanza/tests/ner/test_ner_training.py
@@ -179,6 +179,17 @@ def test_two_tag_training_c2_backprop(pretrain_file, tmp_path):
     assert not torch.allclose(trainer.model.tag_clfs[0].weight, new_trainer.model.tag_clfs[0].weight)
     assert torch.allclose(trainer.model.tag_clfs[1].weight, new_trainer.model.tag_clfs[1].weight)
 
+def test_connected_two_tag_training(pretrain_file, tmp_path):
+    trainer = run_two_tag_training(pretrain_file, tmp_path, "--connect_output_layers")
+    assert len(trainer.model.tag_clfs) == 2
+    assert len(trainer.model.crits) == 2
+    assert len(trainer.vocab['tag'].lens()) == 2
+
+    # this checks that with the connected output layers,
+    # the second output layer has its size increased
+    # by the number of tags known to the first output layer
+    assert trainer.model.tag_clfs[1].weight.shape[1] == trainer.vocab['tag'].lens()[0] + trainer.model.tag_clfs[0].weight.shape[1]
+
 def run_training(pretrain_file, tmp_path, *extra_args):
     train_json = tmp_path / "en_test.train.json"
     write_temp_file(train_json, EN_TRAIN_BIO)

--- a/stanza/tests/ner/test_ner_training.py
+++ b/stanza/tests/ner/test_ner_training.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import warnings
@@ -41,6 +42,50 @@ Computer B-ORG
 Science E-ORG
 """.lstrip().replace(" ", "\t")
 
+EN_TRAIN_2TAG = """
+Chris B-PERSON B-PER
+Manning E-PERSON E-PER
+is O O
+a O O
+good O O
+man O O
+. O O
+
+He O O
+works O O
+in O O
+Stanford B-ORG B-ORG
+University E-ORG B-ORG
+. O O
+""".strip().replace(" ", "\t")
+
+EN_TRAIN_2TAG_EMPTY2 = """
+Chris B-PERSON -
+Manning E-PERSON -
+is O -
+a O -
+good O -
+man O -
+. O -
+
+He O -
+works O -
+in O -
+Stanford B-ORG -
+University E-ORG -
+. O -
+""".strip().replace(" ", "\t")
+
+EN_DEV_2TAG = """
+Chris B-PERSON B-PER
+Manning E-PERSON E-PER
+is O O
+part O O
+of O O
+Computer B-ORG B-ORG
+Science E-ORG E-ORG
+""".strip().replace(" ", "\t")
+
 @pytest.fixture(scope="module")
 def pretrain_file():
     return f'{TEST_WORKING_DIR}/in/tiny_emb.pt'
@@ -51,15 +96,23 @@ def write_temp_file(filename, bio_data):
         fout.write(bio_data)
     process_dataset(bio_filename, filename)
 
-def run_training(pretrain_file, tmp_path, *extra_args):
-    train_json = tmp_path / "en_test.train.json"
-    write_temp_file(train_json, EN_TRAIN_BIO)
+def write_temp_2tag(filename, bio_data):
+    doc = []
+    sentences = bio_data.split("\n\n")
+    for sentence in sentences:
+        doc.append([])
+        for word in sentence.split("\n"):
+            text, tags = word.split("\t", maxsplit=1)
+            doc[-1].append({
+                "text": text,
+                "multi_ner": tags.split()
+            })
 
-    dev_json = tmp_path / "en_test.dev.json"
-    write_temp_file(dev_json, EN_DEV_BIO)
+    with open(filename, "w", encoding="utf-8") as fout:
+        json.dump(doc, fout)
 
+def get_args(tmp_path, pretrain_file, train_json, dev_json, *extra_args):
     save_dir = tmp_path / "models"
-
     args = ["--data_dir", str(tmp_path),
             "--wordvec_pretrain_file", pretrain_file,
             "--train_file", str(train_json),
@@ -68,8 +121,72 @@ def run_training(pretrain_file, tmp_path, *extra_args):
             "--max_steps", "100",
             "--eval_interval", "40",
             "--save_dir", str(save_dir)]
-    args = args + list(extra_args)
 
+    args = args + list(extra_args)
+    return args
+
+def run_two_tag_training(pretrain_file, tmp_path, *extra_args, train_data=EN_TRAIN_2TAG):
+    train_json = tmp_path / "en_test.train.json"
+    write_temp_2tag(train_json, train_data)
+
+    dev_json = tmp_path / "en_test.dev.json"
+    write_temp_2tag(dev_json, EN_DEV_2TAG)
+
+    args = get_args(tmp_path, pretrain_file, train_json, dev_json, *extra_args)
+    return ner_tagger.main(args)
+
+def test_basic_two_tag_training(pretrain_file, tmp_path):
+    trainer = run_two_tag_training(pretrain_file, tmp_path)
+    assert len(trainer.model.tag_clfs) == 2
+    assert len(trainer.model.crits) == 2
+    assert len(trainer.vocab['tag'].lens()) == 2
+
+def test_two_tag_training_backprop(pretrain_file, tmp_path):
+    """
+    Test that the training is backproping both tags
+
+    We can do this by using the "finetune" mechanism and verifying
+    that the output tensors are different
+    """
+    trainer = run_two_tag_training(pretrain_file, tmp_path)
+
+    # first, need to save the final model before restarting
+    # (alternatively, could reload the final checkpoint)
+    trainer.save(os.path.join(trainer.args['save_dir'], trainer.args['save_name']))
+    new_trainer = run_two_tag_training(pretrain_file, tmp_path, "--finetune")
+
+    assert len(trainer.model.tag_clfs) == 2
+    assert len(new_trainer.model.tag_clfs) == 2
+    for old_clf, new_clf in zip(trainer.model.tag_clfs, new_trainer.model.tag_clfs):
+        assert not torch.allclose(old_clf.weight, new_clf.weight)
+
+def test_two_tag_training_c2_backprop(pretrain_file, tmp_path):
+    """
+    Test that the training is backproping only one tag if one column is blank
+
+    We can do this by using the "finetune" mechanism and verifying
+    that the output tensors are different in just the first column
+    """
+    trainer = run_two_tag_training(pretrain_file, tmp_path)
+
+    # first, need to save the final model before restarting
+    # (alternatively, could reload the final checkpoint)
+    trainer.save(os.path.join(trainer.args['save_dir'], trainer.args['save_name']))
+    new_trainer = run_two_tag_training(pretrain_file, tmp_path, "--finetune", train_data=EN_TRAIN_2TAG_EMPTY2)
+
+    assert len(trainer.model.tag_clfs) == 2
+    assert len(new_trainer.model.tag_clfs) == 2
+    assert not torch.allclose(trainer.model.tag_clfs[0].weight, new_trainer.model.tag_clfs[0].weight)
+    assert torch.allclose(trainer.model.tag_clfs[1].weight, new_trainer.model.tag_clfs[1].weight)
+
+def run_training(pretrain_file, tmp_path, *extra_args):
+    train_json = tmp_path / "en_test.train.json"
+    write_temp_file(train_json, EN_TRAIN_BIO)
+
+    dev_json = tmp_path / "en_test.dev.json"
+    write_temp_file(dev_json, EN_DEV_BIO)
+
+    args = get_args(tmp_path, pretrain_file, train_json, dev_json, *extra_args)
     return ner_tagger.main(args)
 
 


### PR DESCRIPTION
Add an ability to label text with multiple types of NER tags using one classifier.  The idea is that a model can be trained to do both at the same time, and the information from both datasets should work together to make the overall model better.  The learning from the second dataset can help the model generalize, even if it isn't the same tagset as the first dataset.

This will let us do something like cross-train the same model on different datasets, such as OntoNotes and CoNLL at the same time, or OntoNotes and the 8 class WorldWide dataset.

In the training data for a mixed dataset, each word now has an entry for "multi_ner" which can support more than one NER tag.  Tags which aren't present for a sentence can be blank.  In the case of the OntoNotes & WorldWide mixed dataset, for example, text from the WorldWide dataset has its 8 class tag and a blank tag, and text from the OntoNotes dataset has the original 18 class tag and a downscaled version of the 8 class tag.  

There are two options for implementing this: one in which there is the original LSTM encoder, followed by a unique Linear for each tag class and a corresponding CRFLoss, and one in which the output of one of the Linears goes back into the input of the next output layer.

Old models are maintained by converting the original version of the tensors to the new tensors.  Old datasets with one NER tagset are converted when loaded at training time.  Therefore, no need to do anything to the existing models or datasets.


Results of running the OntoNotes model, with charlm but not transformer, on the OntoNotes and WorldWide test sets:

```
original ontonotes on worldwide:   88.71  69.29
simplify-separate                  88.24  75.75
simplify-connected                 88.32  75.47
```

Here, "simplify" means the 18 class OntoNotes model is converted to 8 classes, then that data is combined with the WorldWide data as the training data for the second output layer
