### PR TITLE
Adds a tokenization postprocessor for manual token cleanup

### DIFF
--- a/stanza/models/tokenization/utils.py
+++ b/stanza/models/tokenization/utils.py
@@ -316,7 +316,7 @@ def predict(trainer, data_generator, batch_size, max_seqlen, use_regex_tokens, n
 
     return all_preds, all_raw
 
-def output_predictions(output_file, trainer, data_generator, vocab, mwt_dict, max_seqlen=1000, orig_text=None, no_ssplit=False, use_regex_tokens=True, num_workers=0):
+def output_predictions(output_file, trainer, data_generator, vocab, mwt_dict, max_seqlen=1000, orig_text=None, no_ssplit=False, use_regex_tokens=True, num_workers=0, postprocessor=None):
     batch_size = trainer.args['batch_size']
     max_seqlen = max(1000, max_seqlen)
 
@@ -326,9 +326,108 @@ def output_predictions(output_file, trainer, data_generator, vocab, mwt_dict, ma
     skip_newline = trainer.args['skip_newline']
     oov_count, offset, doc = decode_predictions(vocab, mwt_dict, orig_text, all_raw, all_preds, no_ssplit, skip_newline, use_la_ittb_shorthand)
 
+    # If we are provided a postprocessor, we prepare a list of pre-tokenized words and mwt flags and
+    # call the postprocessor for analysis. 
+    if postprocessor:
+        # get a list of all the words in the "draft" document to pass to the postprocessor
+        # the words array looks like [["words, "words", "words"], ["words, ("i_am_a_mwt", True), "I_am_not"]]
+        # and the postprocessor is expected to return in the same format
+        words = [[((word["text"], True)
+                   if word.get("misc") == "MWT=Yes"
+                   else word["text"]) for word in sentence]
+                for sentence in doc]
+        if not orig_text:
+            raw_text = "".join("".join(i) for i in all_raw) # template to compare the stitched text against
+        else:
+            raw_text = orig_text
+
+        # perform correction with the postprocessor
+        postprocessor_return = postprocessor(words)
+
+        # collect the words and MWTs seperately
+        corrected_words = []
+        corrected_mwts = []
+
+        # for each word, if its just a string (without the ("word", mwt_bool) format)
+        # we default that the word is not a MWT. 
+        for sent in postprocessor_return:
+            sent_words = []
+            sent_mwts = []
+            for word in sent:
+                if type(word) == str:
+                    sent_words.append(word)
+                    sent_mwts.append(False)
+                else:
+                    sent_words.append(word[0])
+                    sent_mwts.append(word[1])
+            corrected_words.append(sent_words)
+            corrected_mwts.append(sent_mwts)
+        
+        # check postprocessor output
+        token_lens = [len(i) for i in corrected_words]
+        mwt_lens = [len(i) for i in corrected_mwts]
+        assert token_lens == mwt_lens, "Postprocessor returned token and MWT lists of different length! Token list lengths %s, MWT list lengths %s" % (token_lens, mwt_lens)
+
+        # recassemble document. offsets and oov shouldn't change
+        doc = reassemble_doc_from_tokens(corrected_words, corrected_mwts, raw_text)
+
     if output_file: CoNLL.dict2conll(doc, output_file)
     return oov_count, offset, all_preds, doc
 
+def reassemble_doc_from_tokens(tokens, mwts, raw_text):
+    """Assemble a Stanza document list format from a list of string tokens, calculating offsets as needed.
+
+    Parameters
+    ----------
+    tokens : List[List[str]]
+        A list of sentences, which includes string tokens.
+    mwts : List[List[bool]]
+        Whether or not each of the tokens are MWTs to be analyzed by
+        the MWT raw.
+    parser_text : str
+        The raw text off of which we can compare offsets.
+
+    Returns
+    -------
+    List[List[Dict]]
+        List of words and their offsets, used as `doc`.
+    """
+
+    # oov count and offset stays the same; doc gets regenerated
+    new_offset = 0
+    corrected_doc = []
+
+    for sent_words, sent_mwts in zip(tokens, mwts):
+        sentence_doc = []
+
+        for indx, (word, mwt) in enumerate(zip(sent_words, sent_mwts)):
+            try:
+                offset_index = raw_text.index(word) 
+            except ValueError as e:
+                sub_start = max(0, new_offset - 20)
+                sub_end = min(len(raw_text), new_offset + 20)
+                sub = raw_text[sub_start:sub_end]
+                raise ValueError("Could not find word |%s| starting from char_offset %d.  Surrounding text: |%s|. \n Hint: did you accidentally add/subtract a symbol/character such as a space when combining tokens?" % (word, new_offset, sub)) from e
+
+            wd = {
+                "id": (indx+1,), "text": word,
+                "start_char":  new_offset+offset_index,
+                "end_char":  new_offset+offset_index+len(word)
+            }
+            if mwt:
+                wd["misc"] = "MWT=Yes"
+
+            sentence_doc.append(wd)
+
+            # we crop the raw_text variable to prevent .index() from double-indexing an
+            # earlier token. essentially, for each word, we are only interested in its *offset*
+            # from the start of string
+            raw_text = raw_text[offset_index+len(word):]
+            new_offset += offset_index+len(word)
+
+        corrected_doc.append(sentence_doc)
+
+    return corrected_doc
 
 def decode_predictions(vocab, mwt_dict, orig_text, all_raw, all_preds, no_ssplit, skip_newline, use_la_ittb_shorthand):
     """

--- a/stanza/tests/pipeline/test_tokenizer.py
+++ b/stanza/tests/pipeline/test_tokenizer.py
@@ -60,6 +60,8 @@ EN_DOC_POSTPROCESSOR_COMBINED_TOKENS = """
 <Token id=5;words=[<Word id=5;text=.>]>
 """
 
+# ensure that the entry above has spaces somewhere to test that spaces work in between tokens
+
 EN_DOC_GOLD_NOSSPLIT_TOKENS = """
 <Token id=1;words=[<Word id=1;text=Joe>]>
 <Token id=2;words=[<Word id=2;text=Smith>]>
@@ -300,6 +302,9 @@ def test_pretokenized_multidoc():
 def test_postprocessor():
 
     def dummy_postprocessor(input):
+        # Importantly, EN_DOC_POSTPROCESSOR_COMBINED_LIST returns a few tokens joinde
+        # with space. As some languages (such as VN) contains tokens with space in between
+        # its important to have joined space tested as one of the tokens
         assert input == EN_DOC_POSTPROCESSOR_TOKENS_LIST
         return EN_DOC_POSTPROCESSOR_COMBINED_LIST
 

--- a/stanza/tests/pipeline/test_tokenizer.py
+++ b/stanza/tests/pipeline/test_tokenizer.py
@@ -35,6 +35,30 @@ EN_DOC_GOLD_TOKENS = """
 <Token id=6;words=[<Word id=6;text=beach>]>
 <Token id=7;words=[<Word id=7;text=.>]>
 """.strip()
+EN_DOC_POSTPROCESSOR_TOKENS_LIST = [['Joe', 'Smith', 'lives', 'in', 'California', '.'], ['Joe', "'s", 'favorite', 'food', 'is', 'pizza', '.'], ['He', 'enjoys', 'going', 'to', 'the', 'beach', '.']]
+EN_DOC_POSTPROCESSOR_COMBINED_LIST = [['Joe', 'Smith', 'lives', 'in', 'California', '.'], ['Joe\'s', 'favorite', 'food', 'is', 'pizza', '.'], ['He', 'enjoys', 'going', "to the beach", '.']]
+
+EN_DOC_POSTPROCESSOR_COMBINED_TOKENS = """
+<Token id=1;words=[<Word id=1;text=Joe>]>
+<Token id=2;words=[<Word id=2;text=Smith>]>
+<Token id=3;words=[<Word id=3;text=lives>]>
+<Token id=4;words=[<Word id=4;text=in>]>
+<Token id=5;words=[<Word id=5;text=California>]>
+<Token id=6;words=[<Word id=6;text=.>]>
+
+<Token id=1;words=[<Word id=1;text=Joe's>]>
+<Token id=2;words=[<Word id=2;text=favorite>]>
+<Token id=3;words=[<Word id=3;text=food>]>
+<Token id=4;words=[<Word id=4;text=is>]>
+<Token id=5;words=[<Word id=5;text=pizza>]>
+<Token id=6;words=[<Word id=6;text=.>]>
+
+<Token id=1;words=[<Word id=1;text=He>]>
+<Token id=2;words=[<Word id=2;text=enjoys>]>
+<Token id=3;words=[<Word id=3;text=going>]>
+<Token id=4;words=[<Word id=4;text=to the beach>]>
+<Token id=5;words=[<Word id=5;text=.>]>
+"""
 
 EN_DOC_GOLD_NOSSPLIT_TOKENS = """
 <Token id=1;words=[<Word id=1;text=Joe>]>
@@ -272,6 +296,23 @@ def test_pretokenized_multidoc():
     doc = nlp([stanza.Document([], text=EN_DOC_PRETOKENIZED_LIST)])[0]
     assert EN_DOC_PRETOKENIZED_LIST_GOLD_TOKENS == '\n\n'.join([sent.tokens_string() for sent in doc.sentences])
     assert all([doc.text[token._start_char: token._end_char] == token.text for sent in doc.sentences for token in sent.tokens])
+
+def test_postprocessor():
+
+    def dummy_postprocessor(input):
+        assert input == EN_DOC_POSTPROCESSOR_TOKENS_LIST
+        return EN_DOC_POSTPROCESSOR_COMBINED_LIST
+
+    nlp = stanza.Pipeline(**{'processors': 'tokenize', 'dir': TEST_MODELS_DIR,
+                             'lang': 'en',
+                             'tokenize_postprocessor': dummy_postprocessor})
+    doc = nlp(EN_DOC)
+    assert EN_DOC_POSTPROCESSOR_COMBINED_TOKENS.strip() == '\n\n'.join([sent.tokens_string() for sent in doc.sentences]).strip()
+
+def test_postprocessor_typeerror():
+    with pytest.raises(ValueError):
+        nlp = stanza.Pipeline(**{'processors': 'tokenize', 'dir': TEST_MODELS_DIR, 'lang': 'en',
+                                'tokenize_postprocessor': "iamachicken"})
 
 def test_no_ssplit():
     nlp = stanza.Pipeline(**{'processors': 'tokenize', 'dir': TEST_MODELS_DIR, 'lang': 'en',

--- a/stanza/tests/tokenization/test_tokenize_utils.py
+++ b/stanza/tests/tokenization/test_tokenize_utils.py
@@ -94,6 +94,23 @@ def test_long_paragraph():
     document = doc.Document(document, raw_text)
     assert len(document.sentences) == 100
 
+def test_postprocessor_application():
+    """
+    Check that the postprocessor behaves correctly by applying the identity postprocessor and hoping that it does indeed return correctly.
+    """
+
+    good_tokenization = [['I', 'am', 'Joe.', '⭆⊱⇞', 'Hi', '.'], ["I'm", 'a', 'chicken', '.']]
+    text = "I am Joe. ⭆⊱⇞ Hi. I'm a chicken."
+    
+    target_doc = [[{'id': (1,), 'text': 'I', 'start_char': 0, 'end_char': 1}, {'id': (2,), 'text': 'am', 'start_char': 2, 'end_char': 4}, {'id': (3,), 'text': 'Joe.', 'start_char': 5, 'end_char': 9}, {'id': (4,), 'text': '⭆⊱⇞', 'start_char': 10, 'end_char': 13}, {'id': (5,), 'text': 'Hi', 'start_char': 14, 'end_char': 16}, {'id': (6,), 'text': '.', 'start_char': 16, 'end_char': 17}], [{'id': (1,), 'text': "I'm", 'start_char': 18, 'end_char': 21}, {'id': (2,), 'text': 'a', 'start_char': 22, 'end_char': 23}, {'id': (3,), 'text': 'chicken', 'start_char': 24, 'end_char': 31}, {'id': (4,), 'text': '.', 'start_char': 31, 'end_char': 32}]]
+
+    def postprocesor(_):
+        return good_tokenization
+
+    res = utils.postprocess_doc(target_doc, postprocesor, text)
+
+    assert res == target_doc
+
 def test_reassembly_indexing():
     """
     Check that the reassembly code counts the indicies correctly, and including OOV chars.

--- a/stanza/tests/tokenization/test_tokenize_utils.py
+++ b/stanza/tests/tokenization/test_tokenize_utils.py
@@ -93,3 +93,45 @@ def test_long_paragraph():
 
     document = doc.Document(document, raw_text)
     assert len(document.sentences) == 100
+
+def test_reassembly_indexing():
+    """
+    Check that the reassembly code counts the indicies correctly, and including OOV chars.
+    """
+
+    good_tokenization = [['I', 'am', 'Joe.', '⭆⊱⇞', 'Hi', '.'], ["I'm", 'a', 'chicken', '.']]
+    good_mwts = [[False for _ in range(len(i))] for i in good_tokenization]
+
+    text = "I am Joe. ⭆⊱⇞ Hi. I'm a chicken."
+    
+    target_doc = [[{'id': (1,), 'text': 'I', 'start_char': 0, 'end_char': 1}, {'id': (2,), 'text': 'am', 'start_char': 2, 'end_char': 4}, {'id': (3,), 'text': 'Joe.', 'start_char': 5, 'end_char': 9}, {'id': (4,), 'text': '⭆⊱⇞', 'start_char': 10, 'end_char': 13}, {'id': (5,), 'text': 'Hi', 'start_char': 14, 'end_char': 16}, {'id': (6,), 'text': '.', 'start_char': 16, 'end_char': 17}], [{'id': (1,), 'text': "I'm", 'start_char': 18, 'end_char': 21}, {'id': (2,), 'text': 'a', 'start_char': 22, 'end_char': 23}, {'id': (3,), 'text': 'chicken', 'start_char': 24, 'end_char': 31}, {'id': (4,), 'text': '.', 'start_char': 31, 'end_char': 32}]]
+
+    res = utils.reassemble_doc_from_tokens(good_tokenization, good_mwts, text)
+
+    assert res == target_doc
+
+def test_reassembly_reference_failures():
+    """
+    Check that the reassembly code complains correctly when the user adds tokens that doesn't exist
+    """
+
+    bad_addition_tokenization = [['Joe', 'Smith', 'lives', 'in', 'Southern', 'California', '.']]
+    bad_addition_mwts = [[False for _ in range(len(bad_addition_tokenization[0]))]]
+
+    bad_inline_tokenization = [['Joe', 'Smith', 'lives', 'in', 'Californiaa', '.']]
+    bad_inline_mwts = [[False for _ in range(len(bad_inline_tokenization[0]))]]
+
+    good_tokenization = [['Joe', 'Smith', 'lives', 'in', 'California', '.']]
+    good_mwts = [[False for _ in range(len(good_tokenization[0]))]]
+
+    text = "Joe Smith lives in California."
+
+    with pytest.raises(ValueError):
+        utils.reassemble_doc_from_tokens(bad_addition_tokenization, bad_addition_mwts, text)
+
+    with pytest.raises(ValueError):
+        utils.reassemble_doc_from_tokens(bad_inline_tokenization, bad_inline_mwts, text)
+
+    utils.reassemble_doc_from_tokens(good_tokenization, good_mwts, text)
+
+


### PR DESCRIPTION
## Description
- creates a `tokenize_postprocessor` config element to `stanza.Pipeline` which allows a callable to be passed which can override default tokenization
- creates `stanza.models.tokenization.utils.reassemble_doc_from_tokens` which allows for reassemblage of a document from re-adjusted tokenizations

For instance:

```python
nlp = stanza.Pipeline(lang="en", processors="tokenize",
                                    tokenize_postprocessor=lambda draft: do_stuff_to_draft(draft))
```

whereby, the single argument passed to `tokenize_postprocessor` is a list of lists containing string sentence and word tokenizations

```
[['Joe', 'Smith', 'lives', 'in', 'California', '.'], 
 ['Joe', "'s", 'favorite', 'food', 'is', 'pizza', '.'], 
 ['He', 'enjoys', 'going', 'to', 'the', 'beach', '.']]
```

to mark a MWT, each element can optionally be a tuple with a Bool second element. If the word `dai` in the following sentence as an `MWT`, for instance, we will be passed

```
[['Diglielo', ('dai', True), 'venire', 'a', 'mangiare', 'un', "po'", 'di', 'margarina']]
```

The callable passed to `tokenize_postprocessor` must return a list of lists in the same format: adjusting word, sentence tokenizations and MWT designations as needed. 

## Unit test coverage
- integration test of postprocessor, and type check of the argument passed
- unit test of the `reassemble_doc_from_tokens` function against normal & OOV characters