### PR TITLE
Networkx for enhanced dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'numpy', 
         'protobuf>=3.15.0',
         'requests', 
+        'networkx',
         'torch>=1.3.0',
         'tqdm',
     ],

--- a/stanza/models/common/doc.py
+++ b/stanza/models/common/doc.py
@@ -421,7 +421,8 @@ class Sentence(StanzaObject):
         # enhanced_dependencies represents the DEPS column
         # this is a networkx MultiDiGraph
         # with edges from the parent to the dependent
-        self._enhanced_dependencies = nx.MultiDiGraph()
+        # however, we set it to None until needed, as it is somewhat slow
+        self._enhanced_dependencies = None
         self._process_tokens(tokens)
 
     def _process_tokens(self, tokens):
@@ -462,7 +463,7 @@ class Sentence(StanzaObject):
         """
         Whether or not the enhanced dependencies are part of this sentence
         """
-        return len(self._enhanced_dependencies) > 0
+        return self._enhanced_dependencies is not None and len(self._enhanced_dependencies) > 0
 
     @property
     def index(self):
@@ -1077,7 +1078,7 @@ class Word(StanzaObject):
     def deps(self):
         """ Access the dependencies of this word. """
         graph = self._sent._enhanced_dependencies
-        if not graph.has_node(self.id):
+        if graph is None or not graph.has_node(self.id):
             return None
 
         data = []
@@ -1098,6 +1099,14 @@ class Word(StanzaObject):
     def deps(self, value):
         """ Set the word's dependencies value. """
         graph = self._sent._enhanced_dependencies
+        # if we don't have a graph, and we aren't trying to set any actual
+        # dependencies, we can save the time of doing anything else
+        if graph is None and value is None:
+            return
+
+        if graph is None:
+            graph = nx.MultiDiGraph()
+            self._sent._enhanced_dependencies = graph
         # need to make a new list: cannot iterate and delete at the same time
         if graph.has_node(self.id):
             in_edges = list(graph.in_edges(self.id))
@@ -1111,12 +1120,9 @@ class Word(StanzaObject):
         if all(isinstance(x, str) for x in value):
             value = [x.split(":", maxsplit=1) for x in value]
         for parent, dep in value:
-            if "." in parent:
-                parent = tuple(map(int, parent.split(".", maxsplit=1)))
-            else:
-                # parents which aren't empty nodes still get tuples
-                # this makes it easier to sort when writing them back out
-                parent = (int(parent),)
+            # parents which aren't empty nodes (labeled X.Y in CoNLLU format)
+            # still get tuples this makes it easier to sort when writing them back out
+            parent = tuple(map(int, parent.split(".", maxsplit=1)))
             graph.add_edge(parent, self.id, dep)
 
     @property

--- a/stanza/models/parser.py
+++ b/stanza/models/parser.py
@@ -161,7 +161,7 @@ def train(args):
 
     # load data
     logger.info("Loading data with batch size {}...".format(args['batch_size']))
-    train_data, _ = CoNLL.conll2dict(input_file=args['train_file'])
+    train_data, _, _ = CoNLL.conll2dict(input_file=args['train_file'])
     # possibly augment the training data with some amount of fake data
     # based on the options chosen
     logger.info("Original data size: {}".format(len(train_data)))

--- a/stanza/models/tagger.py
+++ b/stanza/models/tagger.py
@@ -188,7 +188,7 @@ def train(args):
         logger.info("Reading %s" % train_file)
         # train_data is now a list of sentences, where each sentence is a
         # list of words, in which each word is a dict of conll attributes
-        train_data, _ = CoNLL.conll2dict(input_file=train_file)
+        train_data, _, _ = CoNLL.conll2dict(input_file=train_file)
         # possibly augment the training data with some amount of fake data
         # based on the options chosen
         logger.info("Original data size: {}".format(len(train_data)))

--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -39,8 +39,10 @@ DICT = [[{'id': (1,), 'text': 'Nous', 'lemma': 'il', 'upos': 'PRON', 'feats': 'N
          {'id': (9,), 'text': '.', 'lemma': '.', 'upos': 'PUNCT', 'head': 3, 'deprel': 'punct', 'misc': 'start_char=36|end_char=37'}]]
 
 def test_conll_to_dict():
-    dicts = CoNLL.convert_conll(CONLL)
+    dicts, empty = CoNLL.convert_conll(CONLL)
     assert dicts == DICT
+    assert len(dicts) == len(empty)
+    assert all(len(x) == 0 for x in empty)
 
 def test_dict_to_conll():
     document = Document(DICT)
@@ -348,22 +350,48 @@ ESTONIAN_EMPTY_DEPS = """
 7	...	...	PUNCT	Z	_	3	punct	5.1:punct	_
 """.strip()
 
+ESTONIAN_EMPTY_END_DEPS = """
+# sent_id = ewtb2_000035_15
+# text = Ja paari aasta pärast rôômalt maasikatele ...
+1	Ja	ja	CCONJ	J	_	3	cc	5.1:cc	_
+2	paari	paar	NUM	N	Case=Gen|Number=Sing|NumForm=Word|NumType=Card	3	nummod	3:nummod	_
+3	aasta	aasta	NOUN	S	Case=Gen|Number=Sing	0	root	5.1:obl	_
+4	pärast	pärast	ADP	K	AdpType=Post	3	case	3:case	_
+5	rôômalt	rõõmsalt	ADV	D	Typo=Yes	3	advmod	5.1:advmod	Orphan=Yes|CorrectForm=rõõmsalt
+5.1	panna	panema	VERB	V	VerbForm=Inf	_	_	0:root	Empty=5.1
+""".strip()
+
 def test_empty_deps_conversion():
     """
-    Ideally we would be able to read & recreate the dependencies
-
-    Currently that is not possible.  Perhaps it should be fixed.
-    At the very least, we shouldn't fail horribly when reading this
+    Check that we can read and then output a sentence with empty dependencies
     """
-    doc = CoNLL.conll2doc(input_str=ESTONIAN_EMPTY_DEPS)
+    check_empty_deps_conversion(ESTONIAN_EMPTY_DEPS, 7)
+
+def test_empty_deps_at_end_conversion():
+    """
+    The empty deps conversion should also work if the empty dep is at the end
+    """
+    check_empty_deps_conversion(ESTONIAN_EMPTY_END_DEPS, 5)
+
+def check_empty_deps_conversion(input_str, expected_words):
+    doc = CoNLL.conll2doc(input_str=input_str, ignore_gapping=False)
     assert len(doc.sentences) == 1
+    assert len(doc.sentences[0].tokens) == expected_words
+    assert len(doc.sentences[0].words) == expected_words
+    assert len(doc.sentences[0].empty_words) == 1
+
     sentence = doc.sentences[0]
     conll = "{:C}".format(doc)
-    #assert len(sentence.tokens) == 10
+    assert conll == input_str
 
-    #word = doc.sentences[0].words[3]
-    #assert word.deps == "3:obj|9:nsubj"
+    sentence_dict = doc.sentences[0].to_dict()
+    assert len(sentence_dict) == expected_words + 1
+    # currently this is true for both of the examples we run
+    assert sentence_dict[5]['id'] == (5, 1)
 
-    #conll = "{:C}".format(doc)
-    #assert conll == ESTONIAN_EMPTY_DOCS
-
+    # redo the above checks to make sure
+    # there are no weird bugs in the accessors
+    assert len(doc.sentences) == 1
+    assert len(doc.sentences[0].tokens) == expected_words
+    assert len(doc.sentences[0].words) == expected_words
+    assert len(doc.sentences[0].empty_words) == 1

--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -110,6 +110,7 @@ def check_russian_doc(doc):
         assert expected_id == sentence.sent_id
         assert sent_idx == sentence.index
         assert len(sentence.comments) == 3
+        assert not sentence.has_enhanced_dependencies()
 
     sentences = "{:C}".format(doc)
     sentences = sentences.split("\n\n")
@@ -287,6 +288,7 @@ def test_mwt_ner_conversion():
     assert len(doc.sentences) == 1
     sentence = doc.sentences[0]
     assert len(sentence.tokens) == 5
+    assert not sentence.has_enhanced_dependencies()
     EXPECTED_NER = ["O", "O", "S-PERSON", "O", "O"]
     EXPECTED_WORDS = [1, 1, 2, 1, 1]
     for token, ner, expected_words in zip(sentence.tokens, EXPECTED_NER, EXPECTED_WORDS):
@@ -325,6 +327,7 @@ def test_deps_conversion():
     assert len(doc.sentences) == 1
     sentence = doc.sentences[0]
     assert len(sentence.tokens) == 10
+    assert sentence.has_enhanced_dependencies()
 
     word = doc.sentences[0].words[3]
     assert word.deps == "3:obj|9:nsubj"


### PR DESCRIPTION
Use the networkx library to represent enhanced dependencies when reading in a UD data file

Also, correctly process extra words if `ignore_gapping` is `False`.  That includes reading them, attaching them as a second list to the sentence, and then outputting them back in the conll or dict formats

The networkx graph is a little slow, so we lazy initialize it (such as when using the Pipeline, which won't create enhanced dependencies)