### PR TITLE
manual MWT control in tokenization

### DIFF
--- a/stanza/tests/pipeline/test_tokenizer.py
+++ b/stanza/tests/pipeline/test_tokenizer.py
@@ -154,6 +154,23 @@ EN_DOC_PRETOKENIZED_LIST_GOLD_TOKENS = """
 EN_DOC_NO_SSPLIT = ["This is a sentence. This is another.", "This is a third."]
 EN_DOC_NO_SSPLIT_SENTENCES = [['This', 'is', 'a', 'sentence', '.', 'This', 'is', 'another', '.'], ['This', 'is', 'a', 'third', '.']]
 
+FR_DOC = "Le prince va manger du poulet aux les magasins aujourd'hui."
+FR_DOC_POSTPROCESSOR_TOKENS_LIST = [['Le', 'prince', 'va', 'manger', ('du', True), 'poulet', ('aux', True), 'les', 'magasins', "aujourd'hui", '.']]
+FR_DOC_POSTPROCESSOR_COMBINED_MWT_LIST = [['Le', 'prince', 'va', 'manger', ('du', True), 'poulet', ('aux', True), 'les', 'magasins', ("aujourd'hui", ["aujourd'", "hui"]), '.']]
+FR_DOC_PRETOKENIZED_LIST_GOLD_TOKENS = """
+<Token id=1;words=[<Word id=1;text=Le>]>
+<Token id=2;words=[<Word id=2;text=prince>]>
+<Token id=3;words=[<Word id=3;text=va>]>
+<Token id=4;words=[<Word id=4;text=manger>]>
+<Token id=5-6;words=[<Word id=5;text=de>, <Word id=6;text=le>]>
+<Token id=7;words=[<Word id=7;text=poulet>]>
+<Token id=8-9;words=[<Word id=8;text=à>, <Word id=9;text=les>]>
+<Token id=10;words=[<Word id=10;text=les>]>
+<Token id=11;words=[<Word id=11;text=magasins>]>
+<Token id=12-13;words=[<Word id=12;text=aujourd'>, <Word id=13;text=hui>]>
+<Token id=14;words=[<Word id=14;text=.>]>
+"""
+
 JA_DOC = "北京は中国の首都です。 北京の人口は2152万人です。\n" # add some random whitespaces that need to be skipped
 JA_DOC_GOLD_TOKENS = """
 <Token id=1;words=[<Word id=1;text=北京>]>
@@ -339,6 +356,22 @@ def test_postprocessor():
                              'tokenize_postprocessor': dummy_postprocessor})
     doc = nlp(EN_DOC)
     assert EN_DOC_POSTPROCESSOR_COMBINED_TOKENS.strip() == '\n\n'.join([sent.tokens_string() for sent in doc.sentences]).strip()
+
+def test_postprocessor_mwt():
+
+    def dummy_postprocessor(input):
+        # Importantly, EN_DOC_POSTPROCESSOR_COMBINED_LIST returns a few tokens joinde
+        # with space. As some languages (such as VN) contains tokens with space in between
+        # its important to have joined space tested as one of the tokens
+        assert input == FR_DOC_POSTPROCESSOR_TOKENS_LIST
+        return FR_DOC_POSTPROCESSOR_COMBINED_MWT_LIST
+
+    nlp = stanza.Pipeline(**{'processors': 'tokenize', 'dir': TEST_MODELS_DIR,
+                             'lang': 'fr',
+                             'tokenize_postprocessor': dummy_postprocessor})
+    doc = nlp(FR_DOC)
+    assert FR_DOC_PRETOKENIZED_LIST_GOLD_TOKENS.strip() == '\n\n'.join([sent.tokens_string() for sent in doc.sentences]).strip()
+
 
 def test_postprocessor_typeerror():
     with pytest.raises(ValueError):

--- a/stanza/tests/tokenization/test_tokenize_utils.py
+++ b/stanza/tests/tokenization/test_tokenize_utils.py
@@ -102,7 +102,7 @@ def test_postprocessor_application():
     good_tokenization = [['I', 'am', 'Joe.', '⭆⊱⇞', 'Hi', '.'], ["I'm", 'a', 'chicken', '.']]
     text = "I am Joe. ⭆⊱⇞ Hi. I'm a chicken."
 
-    target_doc = [[{'id': (1,), 'text': 'I', 'start_char': 0, 'end_char': 1}, {'id': (2,), 'text': 'am', 'start_char': 2, 'end_char': 4}, {'id': (3,), 'text': 'Joe.', 'start_char': 5, 'end_char': 9}, {'id': (4,), 'text': '⭆⊱⇞', 'start_char': 10, 'end_char': 13}, {'id': (5,), 'text': 'Hi', 'start_char': 14, 'end_char': 16}, {'id': (6,), 'text': '.', 'start_char': 16, 'end_char': 17}], [{'id': (1,), 'text': "I'm", 'start_char': 18, 'end_char': 21}, {'id': (2,), 'text': 'a', 'start_char': 22, 'end_char': 23}, {'id': (3,), 'text': 'chicken', 'start_char': 24, 'end_char': 31}, {'id': (4,), 'text': '.', 'start_char': 31, 'end_char': 32}]]
+    target_doc = [[{'id': 1, 'text': 'I', 'start_char': 0, 'end_char': 1}, {'id': 2, 'text': 'am', 'start_char': 2, 'end_char': 4}, {'id': 3, 'text': 'Joe.', 'start_char': 5, 'end_char': 9}, {'id': 4, 'text': '⭆⊱⇞', 'start_char': 10, 'end_char': 13}, {'id': 5, 'text': 'Hi', 'start_char': 14, 'end_char': 16}, {'id': 6, 'text': '.', 'start_char': 16, 'end_char': 17}], [{'id': 1, 'text': "I'm", 'start_char': 18, 'end_char': 21}, {'id': 2, 'text': 'a', 'start_char': 22, 'end_char': 23}, {'id': 3, 'text': 'chicken', 'start_char': 24, 'end_char': 31}, {'id': 4, 'text': '.', 'start_char': 31, 'end_char': 32}]]
 
     def postprocesor(_):
         return good_tokenization
@@ -118,12 +118,13 @@ def test_reassembly_indexing():
 
     good_tokenization = [['I', 'am', 'Joe.', '⭆⊱⇞', 'Hi', '.'], ["I'm", 'a', 'chicken', '.']]
     good_mwts = [[False for _ in range(len(i))] for i in good_tokenization]
+    good_expansions = [[None for _ in range(len(i))] for i in good_tokenization]
 
     text = "I am Joe. ⭆⊱⇞ Hi. I'm a chicken."
 
-    target_doc = [[{'id': (1,), 'text': 'I', 'start_char': 0, 'end_char': 1}, {'id': (2,), 'text': 'am', 'start_char': 2, 'end_char': 4}, {'id': (3,), 'text': 'Joe.', 'start_char': 5, 'end_char': 9}, {'id': (4,), 'text': '⭆⊱⇞', 'start_char': 10, 'end_char': 13}, {'id': (5,), 'text': 'Hi', 'start_char': 14, 'end_char': 16}, {'id': (6,), 'text': '.', 'start_char': 16, 'end_char': 17}], [{'id': (1,), 'text': "I'm", 'start_char': 18, 'end_char': 21}, {'id': (2,), 'text': 'a', 'start_char': 22, 'end_char': 23}, {'id': (3,), 'text': 'chicken', 'start_char': 24, 'end_char': 31}, {'id': (4,), 'text': '.', 'start_char': 31, 'end_char': 32}]]
+    target_doc = [[{'id': 1, 'text': 'I', 'start_char': 0, 'end_char': 1}, {'id': 2, 'text': 'am', 'start_char': 2, 'end_char': 4}, {'id': 3, 'text': 'Joe.', 'start_char': 5, 'end_char': 9}, {'id': 4, 'text': '⭆⊱⇞', 'start_char': 10, 'end_char': 13}, {'id': 5, 'text': 'Hi', 'start_char': 14, 'end_char': 16}, {'id': 6, 'text': '.', 'start_char': 16, 'end_char': 17}], [{'id': 1, 'text': "I'm", 'start_char': 18, 'end_char': 21}, {'id': 2, 'text': 'a', 'start_char': 22, 'end_char': 23}, {'id': 3, 'text': 'chicken', 'start_char': 24, 'end_char': 31}, {'id': 4, 'text': '.', 'start_char': 31, 'end_char': 32}]]
 
-    res = utils.reassemble_doc_from_tokens(good_tokenization, good_mwts, text)
+    res = utils.reassemble_doc_from_tokens(good_tokenization, good_mwts, good_expansions, text)
 
     assert res == target_doc
 
@@ -134,22 +135,25 @@ def test_reassembly_reference_failures():
 
     bad_addition_tokenization = [['Joe', 'Smith', 'lives', 'in', 'Southern', 'California', '.']]
     bad_addition_mwts = [[False for _ in range(len(bad_addition_tokenization[0]))]]
+    bad_addition_expansions = [[None for _ in range(len(bad_addition_tokenization[0]))]]
 
     bad_inline_tokenization = [['Joe', 'Smith', 'lives', 'in', 'Californiaa', '.']]
     bad_inline_mwts = [[False for _ in range(len(bad_inline_tokenization[0]))]]
+    bad_inline_expansions = [[None for _ in range(len(bad_inline_tokenization[0]))]]
 
     good_tokenization = [['Joe', 'Smith', 'lives', 'in', 'California', '.']]
     good_mwts = [[False for _ in range(len(good_tokenization[0]))]]
+    good_expansions = [[None for _ in range(len(good_tokenization[0]))]]
 
     text = "Joe Smith lives in California."
 
     with pytest.raises(ValueError):
-        utils.reassemble_doc_from_tokens(bad_addition_tokenization, bad_addition_mwts, text)
+        utils.reassemble_doc_from_tokens(bad_addition_tokenization, bad_addition_mwts, bad_addition_expansions, text)
 
     with pytest.raises(ValueError):
-        utils.reassemble_doc_from_tokens(bad_inline_tokenization, bad_inline_mwts, text)
+        utils.reassemble_doc_from_tokens(bad_inline_tokenization, bad_inline_mwts, bad_inline_mwts, text)
 
-    utils.reassemble_doc_from_tokens(good_tokenization, good_mwts, text)
+    utils.reassemble_doc_from_tokens(good_tokenization, good_mwts, good_expansions, text)
 
 
 


### PR DESCRIPTION
## Description
This is a followup to #1290 which allows manual control of MWT splitting via the `tokenize_postprocessor`. We implement this via a new attribute `MEXP=Yes` to denote pre-deliniated MWT that the MWT processor shouldn't touch.

For instance:

```python
nlp = stanza.Pipeline(lang="fr", processors="tokenize",
                                    tokenize_postprocessor=lambda draft: do_stuff_to_draft(draft))
```

whereby, the single argument passed to `tokenize_postprocessor` is a list of lists containing string sentence and word tokenizations

```
[['Le', 'prince', 'va', 'manger', ('du', True), 'poulet', ('aux', True), 'les', 
   'magasins', ("aujourd'hui", ["aujourd'", "hui"]), '.']]
```

With this postprocessor return, `du`, `aux` are requested to be split via the traditional MWT splitter, whereas a user-defined split is provided for `aujourd'hui`.

## Unit Test Coverage
`test_postprocessor_mwt` is created to check for this functionality, and `pipeline/test_tokenizer.py` contains updates to support MWT override.
