### PR TITLE
Mixing inputs that has/doesn't have `upos`, `xpos`, `feats`

### DIFF
--- a/stanza/models/pos/data.py
+++ b/stanza/models/pos/data.py
@@ -71,9 +71,9 @@ class _ShadowDataset(DS):
 
         # sort sentences by lens for easy RNN operations
         lens = [torch.sum(x != PAD_ID) for x in words]
-        (words, wordchars, upos, xpos,
-        ufeats, pretrained, text), orig_idx = sort_all((words, wordchars, upos, xpos,
-                                                        ufeats, pretrained, text), lens)
+        (words, wordchars, upos, xpos, ufeats, pretrained,
+         has_upos, has_xpos, has_feats, text), orig_idx = sort_all((words, wordchars, upos, xpos, ufeats, pretrained,
+                                                                    has_upos, has_xpos, has_feats, text), lens)
         lens = [torch.sum(x != PAD_ID) for x in words] # we need to reinterpret lengths for the RNN
 
         # combine all words into one large list, and sort for easy charRNN ops

--- a/stanza/models/pos/model.py
+++ b/stanza/models/pos/model.py
@@ -12,7 +12,7 @@ from stanza.models.common.biaffine import BiaffineScorer
 from stanza.models.common.foundation_cache import load_bert, load_charlm
 from stanza.models.common.hlstm import HighwayLSTM
 from stanza.models.common.dropout import WordDropout
-from stanza.models.common.vocab import CompositeVocab
+from stanza.models.common.vocab import CompositeVocab, PAD_ID
 from stanza.models.common.char_model import CharacterModel
 
 logger = logging.getLogger('stanza')
@@ -218,15 +218,11 @@ class Tagger(nn.Module):
 
         preds = [pad(upos_pred).max(2)[1]]
 
+        loss = 0.0
         if upos is not None:
             upos = pack(upos).data
-
-            if torch.any(upos):
+            if not torch.all(upos.eq(PAD_ID)):
                 loss = self.crit(upos_pred.view(-1, upos_pred.size(-1)), upos.view(-1))
-            else:
-                loss = 0.0
-        else:
-            loss = 0.0
 
         if self.share_hid:
             xpos_hid = upos_hid
@@ -249,13 +245,13 @@ class Tagger(nn.Module):
             xpos_preds = []
             for i in range(len(self.vocab['xpos'])):
                 xpos_pred = clffunc(self.xpos_clf[i], xpos_hid)
-                if xpos is not None and torch.any(xpos):
+                if xpos is not None and not torch.all(xpos[:, i].eq(PAD_ID)):
                     loss += self.crit(xpos_pred.view(-1, xpos_pred.size(-1)), xpos[:, i].view(-1))
                 xpos_preds.append(pad(xpos_pred).max(2, keepdim=True)[1])
             preds.append(torch.cat(xpos_preds, 2))
         else:
             xpos_pred = clffunc(self.xpos_clf, xpos_hid)
-            if xpos is not None and torch.any(xpos):
+            if xpos is not None and not torch.all(xpos.eq(PAD_ID)):
                 loss += self.crit(xpos_pred.view(-1, xpos_pred.size(-1)), xpos.view(-1))
             preds.append(pad(xpos_pred).max(2)[1])
 
@@ -263,7 +259,7 @@ class Tagger(nn.Module):
         if ufeats is not None: ufeats = pack(ufeats).data
         for i in range(len(self.vocab['feats'])):
             ufeats_pred = clffunc(self.ufeats_clf[i], ufeats_hid)
-            if ufeats is not None and torch.any(ufeats):
+            if ufeats is not None and not torch.all(ufeats[:, i].eq(PAD_ID)):
                 loss += self.crit(ufeats_pred.view(-1, ufeats_pred.size(-1)), ufeats[:, i].view(-1))
             ufeats_preds.append(pad(ufeats_pred).max(2, keepdim=True)[1])
         preds.append(torch.cat(ufeats_preds, 2))

--- a/stanza/models/pos/model.py
+++ b/stanza/models/pos/model.py
@@ -220,7 +220,11 @@ class Tagger(nn.Module):
 
         if upos is not None:
             upos = pack(upos).data
-            loss = self.crit(upos_pred.view(-1, upos_pred.size(-1)), upos.view(-1))
+
+            if torch.any(upos):
+                loss = self.crit(upos_pred.view(-1, upos_pred.size(-1)), upos.view(-1))
+            else:
+                loss = 0.0
         else:
             loss = 0.0
 
@@ -245,13 +249,13 @@ class Tagger(nn.Module):
             xpos_preds = []
             for i in range(len(self.vocab['xpos'])):
                 xpos_pred = clffunc(self.xpos_clf[i], xpos_hid)
-                if xpos is not None:
+                if xpos is not None and torch.any(xpos):
                     loss += self.crit(xpos_pred.view(-1, xpos_pred.size(-1)), xpos[:, i].view(-1))
                 xpos_preds.append(pad(xpos_pred).max(2, keepdim=True)[1])
             preds.append(torch.cat(xpos_preds, 2))
         else:
             xpos_pred = clffunc(self.xpos_clf, xpos_hid)
-            if xpos is not None:
+            if xpos is not None and torch.any(xpos):
                 loss += self.crit(xpos_pred.view(-1, xpos_pred.size(-1)), xpos.view(-1))
             preds.append(pad(xpos_pred).max(2)[1])
 
@@ -259,7 +263,7 @@ class Tagger(nn.Module):
         if ufeats is not None: ufeats = pack(ufeats).data
         for i in range(len(self.vocab['feats'])):
             ufeats_pred = clffunc(self.ufeats_clf[i], ufeats_hid)
-            if ufeats is not None:
+            if ufeats is not None and torch.any(ufeats):
                 loss += self.crit(ufeats_pred.view(-1, ufeats_pred.size(-1)), ufeats[:, i].view(-1))
             ufeats_preds.append(pad(ufeats_pred).max(2, keepdim=True)[1])
         preds.append(torch.cat(ufeats_preds, 2))

--- a/stanza/models/tagger.py
+++ b/stanza/models/tagger.py
@@ -193,6 +193,19 @@ def load_training_data(args, pretrain):
     train_data = [Dataset(i, args, pretrain, vocab=vocab, evaluation=False)
                   for i in train_docs]
 
+    # if *any* dataset has data for the upos, xpos, or feature column,
+    # we consider that data enough to train the model on that column
+    # otherwise, we want to train the model to always output blanks
+    if not any(td.has_upos for td in train_data):
+        for td in train_data:
+            td.has_upos = True
+    if not any(td.has_xpos for td in train_data):
+        for td in train_data:
+            td.has_xpos = True
+    if not any(td.has_feats for td in train_data):
+        for td in train_data:
+            td.has_feats = True
+
     # calculate the batches
     train_batches = merge_datasets(train_data).to_loader(batch_size=args["batch_size"], shuffle=True)
     return vocab, train_data, train_batches

--- a/stanza/tests/pos/test_data.py
+++ b/stanza/tests/pos/test_data.py
@@ -93,12 +93,12 @@ def test_merge_some_xpos():
             if batch.text[-1][0] == 'It':
                 if batch_idx == 0:
                     it_first += 1
-                # TODO: I would expect this to always be False, unless
-                # I have misinterpreted the process for the masking,
-                # but there are times it comes back True instead.  I
-                # think that is an effect of the has_xpos not being
-                # sorted with everything else by length
-                print(torch.any(batch.xpos[-1]))
+                    # in a batch of size 2, the other item has to be
+                    # one of the with-xpos items
+                    assert any(batch.xpos[0])
+                # this should always be false to represent that this
+                # item in the batch has been masked
+                assert not any(batch.xpos[-1])
 
     # check that the sentence w/o xpos is sometimes but not always in the first batch
     assert it_first > 5


### PR DESCRIPTION
## Description
Some languages, like German, OOM when training with the new PyTorch `Dataset` scheme as the overhead loading multiple datasets into separate `DataLoader` and then mixing them didn't work well. We did this because some entire input files wouldn't have upos/xpos/ufeats, and we don't want to calculate loss. 
Instead, this PR elects to create a `_ShadowDataset` object between them, and masks out loss (by turning the upos/xpos/etc. into padding tokens at *batch time*) with the exact *sentences* which came from datasets that doesn't have upos/xpos/ufeats masked out only.

## Unit test coverage
Passes all tests in `stanza.tests.pos.test_tagger`