### PR TITLE
Splitting out the optimizer utility + LR scheduler for PoS

### DIFF
--- a/stanza/tests/pos/test_tagger.py
+++ b/stanza/tests/pos/test_tagger.py
@@ -287,3 +287,6 @@ class TestTagger:
     def test_with_bert_nlayers(self, tmp_path, wordvec_pretrain_file):
         self.run_training(tmp_path, wordvec_pretrain_file, TRAIN_DATA, DEV_DATA, extra_args=['--bert_model', 'hf-internal-testing/tiny-bert', '--bert_hidden_layers', '2'])
 
+    def test_with_bert_finetune(self, tmp_path, wordvec_pretrain_file):
+        self.run_training(tmp_path, wordvec_pretrain_file, TRAIN_DATA, DEV_DATA, extra_args=['--bert_model', 'hf-internal-testing/tiny-bert', '--bert_finetune', '--bert_learning_rate', '0.01'])
+


### PR DESCRIPTION
This PR splits out the utility optimizer into separate parts for Bert and non-Bert; this method is backwards compatible, such that `get_optimizer` gets retained to be used for methods that have not yet been migrated, while a new `get_split_optimizer` is used for methods that desire an optimizer that has been split out. 

Further, the optimizer takes an `is_peft` option which stages the optimizer to tune `.parameters()` of the Bert model instead of filtering for`.named_parameters()` which is selected. This allows HF Peft to do weird shenanigans to the parameters value, and we will—when the weights trainable is being constrained by the Peft library—tune what it tells us to tune instead of tuning things that we select via its name. 

Taking advantage of this fact that we have a split optimizer now, Part of Speech tagging with Bert finetuning features a learning rate scheduler which a warmup and a linear decay if the user requests the Bert to be tuned. 