### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/stanza/models/common/beam.py
+++ b/stanza/models/common/beam.py
@@ -3,7 +3,7 @@ import torch
 
 import stanza.models.common.seq2seq_constant as constant
 
-"""
+r"""
  Adapted and modified from the OpenNMT project.
 
  Class for managing the internals of the beam search process.
@@ -135,7 +135,7 @@ class Beam(object):
             if len(self.copy) > 0:
                 cpy.append(self.copy[j][k])
             k = self.prevKs[j][k]
-         
+
         hyp = hyp[::-1]
         cpy = cpy[::-1]
         # postprocess: if cpy index is not -1, use cpy index instead of hyp word

--- a/stanza/pipeline/langid_processor.py
+++ b/stanza/pipeline/langid_processor.py
@@ -21,10 +21,10 @@ class LangIDProcessor(UDProcessor):
 
     # set of processor requirements this processor fulfills
     PROVIDES_DEFAULT = set([LANGID])
-    
+
     # set of processor requirements for this processor
     REQUIRES_DEFAULT = set([])
-    
+
     # default max sequence length
     MAX_SEQ_LENGTH_DEFAULT = 1000
 
@@ -57,12 +57,12 @@ class LangIDProcessor(UDProcessor):
         return prediction_labels
 
     # regexes for cleaning text
-    http_regex = re.compile("https?:\/\/t\.co/[a-zA-Z0-9]+")
+    http_regex = re.compile(r"https?:\/\/t\.co/[a-zA-Z0-9]+")
     handle_regex = re.compile("@[a-zA-Z0-9_]+")
     hashtag_regex = re.compile("#[a-zA-Z]+")
     punctuation_regex = re.compile("[!.]+")
     all_regexes = [http_regex, handle_regex, hashtag_regex, punctuation_regex]
-    
+
     @staticmethod
     def clean_text(text):
         """
@@ -114,7 +114,7 @@ class LangIDProcessor(UDProcessor):
         """
         Handle single str or Document
         """
-        
+
         wrapped_doc = [doc]
         return self._process_list(wrapped_doc)[0]
 


### PR DESCRIPTION
## Description
Resolve `DeprecationWarning`'s emitted for invalid escape sequences in python 3.11 and newer.

## Fixes Issues
Relates to #1293.

This fixes py3.11+ compatibility that arises from invalid escape literals in strings. Raw strings should be used for regexes and other strings that contain legitimate backslahes.

[Python library reference](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals).
Or on [SO](https://stackoverflow.com/questions/50504500/deprecationwarning-invalid-escape-sequence-what-to-use-instead-of-d), if you prefer.

I have made sure that no other instances of this error are present in codebase (via `ruff check . --select W605`, here's [this rule](https://docs.astral.sh/ruff/rules/invalid-escape-sequence/)) 

## Unit test coverage
This issue should be addressed at the linter level. Ready to contribute a linting solution to catch this if authors are ready to accept some linting pipeline (which would be a good thing to do).

## Known breaking changes/behaviors
This change is fully backwards-compatible. Sorry for whitespace removed on autosave, I hope it was not so important for you, guys...
