### PR TITLE
Peft sentiment

### DIFF
--- a/.github/workflows/stanza-tests.yaml
+++ b/.github/workflows/stanza-tests.yaml
@@ -27,6 +27,7 @@ jobs:
           pwd
           pip install -e .
           pip install -e .[test]
+          pip install -e .[transformers]
           # set up for tests
           echo "Running stanza test set up..."
           rm -rf $STANZA_TEST_HOME

--- a/stanza/models/classifier.py
+++ b/stanza/models/classifier.py
@@ -229,6 +229,7 @@ def build_argparse():
     parser.add_argument('--bert_model', type=str, default=None, help="Use an external bert model (requires the transformers package)")
     parser.add_argument('--no_bert_model', dest='bert_model', action="store_const", const=None, help="Don't use bert")
     parser.add_argument('--bert_finetune', default=False, action='store_true', help="Finetune the Bert model")
+    parser.add_argument('--use_peft', default=False, action='store_true', help="Finetune Bert using peft")
     parser.add_argument('--bert_learning_rate', default=0.01, type=float, help='Scale the learning rate for transformer finetuning by this much')
     parser.add_argument('--bert_weight_decay', default=0.0001, type=float, help='Scale the weight decay for transformer finetuning by this much')
 
@@ -305,6 +306,9 @@ def parse_args(args=None):
         args.momentum = DEFAULT_MOMENTUM.get(args.optim, None)
     if args.learning_rate is None:
         args.learning_rate = DEFAULT_LEARNING_RATES.get(args.optim, None)
+    if args.use_peft and not args.bert_finetune:
+        logger.info("--use_peft set.  setting --bert_finetune as well")
+        args.bert_finetune = True
 
     return args
 

--- a/stanza/models/classifier.py
+++ b/stanza/models/classifier.py
@@ -16,7 +16,7 @@ from stanza.models.pos.vocab import CharVocab
 import stanza.models.classifiers.data as data
 from stanza.models.classifiers.trainer import Trainer
 from stanza.models.classifiers.utils import WVType, ExtraVectors, ModelType
-from stanza.models.common.peft_config import add_peft_args
+from stanza.models.common.peft_config import add_peft_args, resolve_peft_args
 
 from stanza.utils.confusion import format_confusion, confusion_to_accuracy, confusion_to_macro_f1
 
@@ -297,6 +297,7 @@ def parse_args(args=None):
     """
     parser = build_argparse()
     args = parser.parse_args(args)
+    resolve_peft_args(args)
 
     if args.wandb_name:
         args.wandb = True

--- a/stanza/models/classifier.py
+++ b/stanza/models/classifier.py
@@ -16,6 +16,7 @@ from stanza.models.pos.vocab import CharVocab
 import stanza.models.classifiers.data as data
 from stanza.models.classifiers.trainer import Trainer
 from stanza.models.classifiers.utils import WVType, ExtraVectors, ModelType
+from stanza.models.common.peft_config import add_peft_args
 
 from stanza.utils.confusion import format_confusion, confusion_to_accuracy, confusion_to_macro_f1
 
@@ -284,6 +285,7 @@ def build_argparse():
 
     parser.add_argument('--seed', default=None, type=int, help='Random seed for model')
 
+    add_peft_args(parser)
     utils.add_device_args(parser)
 
     return parser

--- a/stanza/models/classifiers/cnn_classifier.py
+++ b/stanza/models/classifiers/cnn_classifier.py
@@ -101,6 +101,8 @@ class CNNClassifier(BaseClassifier):
                                       lora_rank = getattr(args, 'lora_rank', None),
                                       lora_alpha = getattr(args, 'lora_alpha', None),
                                       lora_dropout = getattr(args, 'lora_dropout', None),
+                                      lora_modules_to_save = getattr(args, 'lora_modules_to_save', None),
+                                      lora_target_modules = getattr(args, 'lora_target_modules', None),
 
                                       bilstm = args.bilstm,
                                       bilstm_hidden_dim = args.bilstm_hidden_dim,
@@ -132,14 +134,12 @@ class CNNClassifier(BaseClassifier):
             # Hide import so that the peft dependency is optional
             from peft import LoraConfig, get_peft_model
             logger.info("Creating lora adapter with rank %d and alpha %d", self.config.lora_rank, self.config.lora_alpha)
-            # TODO: add various options for these values
-            # TODO: perhaps keep track of good values for lora_targets and lora_fully_tune for different transformers
             peft_config = LoraConfig(inference_mode=False,
                                      r=self.config.lora_rank,
-                                     target_modules=["query", "value", "output.dense", "intermediate.dense"], # self.config.lora_targets,
+                                     target_modules=self.config.lora_target_modules,
                                      lora_alpha=self.config.lora_alpha,
                                      lora_dropout=self.config.lora_dropout,
-                                     modules_to_save=[], # self.config.lora_fully_tune,
+                                     modules_to_save=self.config.lora_modules_to_save,
                                      bias="none")
 
             bert_model = get_peft_model(bert_model, peft_config)

--- a/stanza/models/classifiers/cnn_classifier.py
+++ b/stanza/models/classifiers/cnn_classifier.py
@@ -139,7 +139,7 @@ class CNNClassifier(BaseClassifier):
                                      target_modules=["query", "value", "output.dense", "intermediate.dense"], # self.config.lora_targets,
                                      lora_alpha=self.config.lora_alpha,
                                      lora_dropout=self.config.lora_dropout,
-                                     modules_to_save=["pooler"], # self.config.lora_fully_tune,
+                                     modules_to_save=[], # self.config.lora_fully_tune,
                                      bias="none")
 
             bert_model = get_peft_model(bert_model, peft_config)

--- a/stanza/models/classifiers/cnn_classifier.py
+++ b/stanza/models/classifiers/cnn_classifier.py
@@ -75,6 +75,7 @@ class CNNClassifier(BaseClassifier):
         bert_finetune = getattr(args, "bert_finetune", False)
         force_bert_saved = force_bert_saved or bert_finetune
         logger.debug("bert_finetune %s / force_bert_saved %s", bert_finetune, force_bert_saved)
+
         # we build a separate config out of the args so that we can easily save it in torch
         self.config = SimpleNamespace(filter_channels = args.filter_channels,
                                       filter_sizes = args.filter_sizes,
@@ -87,6 +88,8 @@ class CNNClassifier(BaseClassifier):
                                       extra_wordvec_max_norm = args.extra_wordvec_max_norm,
                                       char_lowercase = args.char_lowercase,
                                       charlm_projection = args.charlm_projection,
+                                      has_charlm_forward = charmodel_forward is not None,
+                                      has_charlm_backward = charmodel_backward is not None,
                                       use_elmo = args.use_elmo,
                                       elmo_projection = args.elmo_projection,
                                       bert_model = args.bert_model,

--- a/stanza/models/classifiers/cnn_classifier.py
+++ b/stanza/models/classifiers/cnn_classifier.py
@@ -96,7 +96,12 @@ class CNNClassifier(BaseClassifier):
                                       bert_model = args.bert_model,
                                       bert_finetune = bert_finetune,
                                       force_bert_saved = force_bert_saved,
+
                                       use_peft = use_peft,
+                                      lora_rank = getattr(args, 'lora_rank', None),
+                                      lora_alpha = getattr(args, 'lora_alpha', None),
+                                      lora_dropout = getattr(args, 'lora_dropout', None),
+
                                       bilstm = args.bilstm,
                                       bilstm_hidden_dim = args.bilstm_hidden_dim,
                                       maxpool_width = args.maxpool_width,
@@ -126,14 +131,14 @@ class CNNClassifier(BaseClassifier):
         if self.config.use_peft:
             # Hide import so that the peft dependency is optional
             from peft import LoraConfig, get_peft_model
-            logger.info("Creating lora adapter with rank %d", 64)
+            logger.info("Creating lora adapter with rank %d and alpha %d", self.config.lora_rank, self.config.lora_alpha)
             # TODO: add various options for these values
             # TODO: perhaps keep track of good values for lora_targets and lora_fully_tune for different transformers
             peft_config = LoraConfig(inference_mode=False,
-                                     r=64, #self.config.lora_rank,
+                                     r=self.config.lora_rank,
                                      target_modules=["query", "value", "output.dense", "intermediate.dense"], # self.config.lora_targets,
-                                     lora_alpha=128, #self.config.lora_alpha,
-                                     lora_dropout=0.1, #self.config.lora_dropout,
+                                     lora_alpha=self.config.lora_alpha,
+                                     lora_dropout=self.config.lora_dropout,
                                      modules_to_save=["pooler"], # self.config.lora_fully_tune,
                                      bias="none")
 

--- a/stanza/models/classifiers/trainer.py
+++ b/stanza/models/classifiers/trainer.py
@@ -93,8 +93,20 @@ class Trainer:
         if model_type == ModelType.CNN:
             pretrain = Trainer.load_pretrain(args, foundation_cache)
             elmo_model = utils.load_elmo(args.elmo_model) if args.use_elmo else None
-            charmodel_forward = load_charlm(args.charlm_forward_file, foundation_cache)
-            charmodel_backward = load_charlm(args.charlm_backward_file, foundation_cache)
+            # TODO: existing models don't have this attribute, so we
+            # use None as not having a setting.  If the setting is
+            # False, though, we don't load the charlm
+            # We don't want to pass a charlm to a model which doesn't use one
+            has_charlm_forward = getattr(model_params['config'], 'has_charlm_forward', None)
+            if has_charlm_forward != False:
+                charmodel_forward = load_charlm(args.charlm_forward_file, foundation_cache)
+            else:
+                charmodel_forward = None
+            has_charlm_backward = getattr(model_params['config'], 'has_charlm_backward', None)
+            if has_charlm_backward != False:
+                charmodel_backward = load_charlm(args.charlm_backward_file, foundation_cache)
+            else:
+                charmodel_backward = None
 
             bert_model = model_params['config'].bert_model
             # TODO: can get rid of the getattr after rebuilding all models

--- a/stanza/models/common/peft_config.py
+++ b/stanza/models/common/peft_config.py
@@ -3,12 +3,33 @@ Set a few common flags for peft uage
 """
 
 
+TRANSFORMER_LORA_RANK = {}
+DEFAULT_LORA_RANK = 64
+
+TRANSFORMER_LORA_ALPHA = {}
+DEFAULT_LORA_ALPHA = 128
+
+TRANSFORMER_LORA_DROPOUT = {}
+DEFAULT_LORA_DROPOUT = 0.1
+
 def add_peft_args(parser):
     """
     Add common default flags to an argparse
     """
-    parser.add_argument('--lora_rank', type=int, default=64, help="Rank of a LoRA approximation")
-    parser.add_argument('--lora_alpha', type=int, default=128, help="Alpha of a LoRA approximation")
-    parser.add_argument('--lora_dropout', type=float, default=0.1, help="Dropout for the LoRA approximation")
+    parser.add_argument('--lora_rank', type=int, default=None, help="Rank of a LoRA approximation.  Default will be %d or a model-specific parameter" % DEFAULT_LORA_RANK)
+    parser.add_argument('--lora_alpha', type=int, default=None, help="Alpha of a LoRA approximation.  Default will be %d or a model-specific parameter" % DEFAULT_LORA_ALPHA)
+    parser.add_argument('--lora_dropout', type=float, default=None, help="Dropout for the LoRA approximation.  Default will be %s or a model-specific parameter" % DEFAULT_LORA_DROPOUT)
 
 
+def resolve_peft_args(args):
+    if not hasattr(args, 'bert_model'):
+        return
+
+    if args.lora_rank is None:
+        args.lora_rank = TRANSFORMER_LORA_RANK.get(args.bert_model, DEFAULT_LORA_RANK)
+
+    if args.lora_alpha is None:
+        args.lora_alpha = TRANSFORMER_LORA_ALPHA.get(args.bert_model, DEFAULT_LORA_ALPHA)
+
+    if args.lora_dropout is None:
+        args.lora_dropout = TRANSFORMER_LORA_DROPOUT.get(args.bert_model, DEFAULT_LORA_DROPOUT)

--- a/stanza/models/common/peft_config.py
+++ b/stanza/models/common/peft_config.py
@@ -1,0 +1,14 @@
+"""
+Set a few common flags for peft uage
+"""
+
+
+def add_peft_args(parser):
+    """
+    Add common default flags to an argparse
+    """
+    parser.add_argument('--lora_rank', type=int, default=64, help="Rank of a LoRA approximation")
+    parser.add_argument('--lora_alpha', type=int, default=128, help="Alpha of a LoRA approximation")
+    parser.add_argument('--lora_dropout', type=float, default=0.1, help="Dropout for the LoRA approximation")
+
+

--- a/stanza/models/common/peft_config.py
+++ b/stanza/models/common/peft_config.py
@@ -12,6 +12,12 @@ DEFAULT_LORA_ALPHA = 128
 TRANSFORMER_LORA_DROPOUT = {}
 DEFAULT_LORA_DROPOUT = 0.1
 
+TRANSFORMER_LORA_TARGETS = {}
+DEFAULT_LORA_TARGETS = "query,value,output.dense,intermediate.dense"
+
+TRANSFORMER_LORA_SAVE = {}
+DEFAULT_LORA_SAVE = ""
+
 def add_peft_args(parser):
     """
     Add common default flags to an argparse
@@ -19,6 +25,8 @@ def add_peft_args(parser):
     parser.add_argument('--lora_rank', type=int, default=None, help="Rank of a LoRA approximation.  Default will be %d or a model-specific parameter" % DEFAULT_LORA_RANK)
     parser.add_argument('--lora_alpha', type=int, default=None, help="Alpha of a LoRA approximation.  Default will be %d or a model-specific parameter" % DEFAULT_LORA_ALPHA)
     parser.add_argument('--lora_dropout', type=float, default=None, help="Dropout for the LoRA approximation.  Default will be %s or a model-specific parameter" % DEFAULT_LORA_DROPOUT)
+    parser.add_argument('--lora_target_modules', type=str, default=None, help="Comma separated list of LoRA targets.  Default will be '%s' or a model-specific parameter" % DEFAULT_LORA_TARGETS)
+    parser.add_argument('--lora_modules_to_save', type=str, default=None, help="Comma separated list of modules to save (eg, fully tune) when using LoRA.  Default will be '%s' or a model-specific parameter" % DEFAULT_LORA_SAVE)
 
 
 def resolve_peft_args(args):
@@ -33,3 +41,17 @@ def resolve_peft_args(args):
 
     if args.lora_dropout is None:
         args.lora_dropout = TRANSFORMER_LORA_DROPOUT.get(args.bert_model, DEFAULT_LORA_DROPOUT)
+
+    if args.lora_target_modules is None:
+        args.lora_target_modules = TRANSFORMER_LORA_TARGETS.get(args.bert_model, DEFAULT_LORA_TARGETS)
+    if not args.lora_target_modules.strip():
+        args.lora_target_modules = []
+    else:
+        args.lora_target_modules = args.lora_target_modules.split(",")
+
+    if args.lora_modules_to_save is None:
+        args.lora_modules_to_save = TRANSFORMER_LORA_SAVE.get(args.bert_model, DEFAULT_LORA_SAVE)
+    if not args.lora_modules_to_save.strip():
+        args.lora_modules_to_save = []
+    else:
+        args.lora_modules_to_save = args.lora_modules_to_save.split(",")

--- a/stanza/tests/classifiers/test_classifier.py
+++ b/stanza/tests/classifiers/test_classifier.py
@@ -181,7 +181,7 @@ class TestClassifier:
         """
         bert_model = "hf-internal-testing/tiny-bert"
 
-        trainer, save_filename = self.run_training(tmp_path, fake_embeddings, train_file, dev_file, extra_args=["--bilstm_hidden_dim", "20", "--bert_model", bert_model, "--bert_finetune", "--use_peft"])
+        trainer, save_filename = self.run_training(tmp_path, fake_embeddings, train_file, dev_file, extra_args=["--bilstm_hidden_dim", "20", "--bert_model", bert_model, "--bert_finetune", "--use_peft", "--lora_modules_to_save", "pooler"])
         assert os.path.exists(save_filename)
         saved_model = torch.load(save_filename, lambda storage, loc: storage)
         # after finetuning the bert model, make sure that the save file DOES contain parts of the transformer, but only in peft form


### PR DESCRIPTION
Add a PEFT wrapper for the Sentiment training.

Works quite well on English, actually, even without splitting the optimizer or implementing any form of scheduling.
With no finetuning, adding electra-large to the 3 class English dataset (SST plus a few other pieces) gets 70 Macro F1.
The base finetuning gets between 74-75 macro F1 on sstplus, but frequently fails to successfully train, getting somewhere around 60 F1
Training with PEFT gets in the 74-75 F1 range each time, with no failures observed so far.

Adds a chunk of test to the sentiment training which starts the Pipeline with a peft-trained model

Also included is adding a uses-charlm flag to the config, so that inadvertently passing a charlm (such as via Pipeline) to the sentiment model doesn't blow up if it was trained w/o a charlm