### PR TITLE
Con topdown oracle

### DIFF
--- a/stanza/models/constituency/dynamic_oracle.py
+++ b/stanza/models/constituency/dynamic_oracle.py
@@ -17,10 +17,15 @@ def advance_past_constituents(gold_sequence, cur_index):
     return None
 
 class DynamicOracle():
-    def __init__(self, root_labels, oracle_level, repair_types):
+    def __init__(self, root_labels, oracle_level, repair_types, additional_levels):
         self.root_labels = root_labels
-        self.oracle_level = oracle_level
+        # default oracle_level will be the UNKNOWN repair type (which each oracle should have)
+        # transitions after that as experimental or ambiguous, not to be used by default
+        self.oracle_level = oracle_level if oracle_level is not None else repair_types.UNKNOWN.value
         self.repair_types = repair_types
+        self.additional_levels = set()
+        if additional_levels:
+            self.additional_levels = set([repair_types[x.upper()] for x in additional_levels.split(",")])
 
     def fix_error(self, gold_transition, pred_transition, gold_sequence, gold_index):
         """
@@ -38,7 +43,7 @@ class DynamicOracle():
         for repair_type in self.repair_types:
             if repair_type.fn is None:
                 continue
-            if self.oracle_level is not None and repair_type.value > self.oracle_level:
+            if self.oracle_level is not None and repair_type.value > self.oracle_level and repair_type not in self.additional_levels:
                 continue
             repair = repair_type.fn(gold_transition, pred_transition, gold_sequence, gold_index, self.root_labels)
             if repair is not None:

--- a/stanza/models/constituency/dynamic_oracle.py
+++ b/stanza/models/constituency/dynamic_oracle.py
@@ -1,3 +1,21 @@
+from stanza.models.constituency.parse_transitions import Shift, OpenConstituent, CloseConstituent
+
+def advance_past_constituents(gold_sequence, cur_index):
+    """
+    Advance cur_index through gold_sequence until we have seen 1 more Close than Open
+
+    The index returned is the index of the Close which occurred after all the stuff
+    """
+    count = 0
+    while cur_index < len(gold_sequence):
+        if isinstance(gold_sequence[cur_index], OpenConstituent):
+            count = count + 1
+        elif isinstance(gold_sequence[cur_index], CloseConstituent):
+            count = count - 1
+            if count == -1: return cur_index
+        cur_index = cur_index + 1
+    return None
+
 class DynamicOracle():
     def __init__(self, root_labels, oracle_level, repair_types):
         self.root_labels = root_labels

--- a/stanza/models/constituency/in_order_oracle.py
+++ b/stanza/models/constituency/in_order_oracle.py
@@ -1,6 +1,6 @@
 from enum import Enum, auto
 
-from stanza.models.constituency.dynamic_oracle import DynamicOracle
+from stanza.models.constituency.dynamic_oracle import advance_past_constituents, DynamicOracle
 from stanza.models.constituency.parse_transitions import Shift, OpenConstituent, CloseConstituent
 
 def fix_wrong_open_root_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
@@ -33,22 +33,6 @@ def fix_wrong_open_unary_chain(gold_transition, pred_transition, gold_sequence, 
                 return gold_sequence[:gold_index] + gold_sequence[cur_index:]
             cur_index = cur_index + 1  # advance to the next Close
 
-    return None
-
-def advance_past_constituents(gold_sequence, cur_index):
-    """
-    Advance cur_index through gold_sequence until we have seen 1 more Close than Open
-
-    The index returned is the index of the Close which occurred after all the stuff
-    """
-    count = 0
-    while cur_index < len(gold_sequence):
-        if isinstance(gold_sequence[cur_index], OpenConstituent):
-            count = count + 1
-        elif isinstance(gold_sequence[cur_index], CloseConstituent):
-            count = count - 1
-            if count == -1: return cur_index
-        cur_index = cur_index + 1
     return None
 
 def find_constituent_end(gold_sequence, cur_index):

--- a/stanza/models/constituency/in_order_oracle.py
+++ b/stanza/models/constituency/in_order_oracle.py
@@ -374,6 +374,26 @@ def fix_close_shift_shift(gold_transition, pred_transition, gold_sequence, gold_
 class RepairType(Enum):
     """
     Keep track of which repair is used, if any, on an incorrect transition
+
+    Statistics on English w/ no charlm, no transformer,
+      eg word vectors only, best model as of January 2024
+
+    unambiguous transitions only:
+        oracle scheme          dev      test
+         no oracle            0.9245   0.9226
+          +wrong_open_root    0.9244   0.9224
+          +wrong_unary_chain  0.9243   0.9237
+          +wrong_open_unary   0.9249   0.9223
+          +wrong_open_general 0.9251   0.9215
+          +missed_unary       0.9248   0.9215
+          +open_shift         0.9243   0.9216
+          +open_close         0.9254   0.9217
+          +shift_close        0.9261   0.9238
+          +close_shift_nested 0.9253   0.9250
+
+    So honestly on EN it doesn't look too promising to use the oracle.
+    On VI, though, it seemed to do better.  Need to run more
+    experiments
     """
     def __new__(cls, fn, correct=False):
         """

--- a/stanza/models/constituency/in_order_oracle.py
+++ b/stanza/models/constituency/in_order_oracle.py
@@ -474,5 +474,5 @@ class RepairType(Enum):
     UNKNOWN                = None
 
 class InOrderOracle(DynamicOracle):
-    def __init__(self, root_labels, oracle_level):
-        super().__init__(root_labels, oracle_level, RepairType)
+    def __init__(self, root_labels, oracle_level, additional_oracle_levels):
+        super().__init__(root_labels, oracle_level, RepairType, additional_oracle_levels)

--- a/stanza/models/constituency/top_down_oracle.py
+++ b/stanza/models/constituency/top_down_oracle.py
@@ -1,0 +1,342 @@
+from enum import Enum, auto
+
+from stanza.models.constituency.dynamic_oracle import advance_past_constituents, DynamicOracle
+from stanza.models.constituency.parse_transitions import Shift, OpenConstituent, CloseConstituent
+
+def find_constituent_end(gold_sequence, cur_index):
+    """
+    Find the Close which ends the next constituent opened at or after cur_index
+    """
+    count = 0
+    while cur_index < len(gold_sequence):
+        if isinstance(gold_sequence[cur_index], OpenConstituent):
+            count = count + 1
+        elif isinstance(gold_sequence[cur_index], CloseConstituent):
+            count = count - 1
+            if count == 0:
+                return cur_index
+        cur_index += 1
+    raise AssertionError("Open constituent not closed starting from index %d in sequence %s" % (cur_index, gold_sequence))
+
+
+def fix_shift_close(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    """
+    Predicted a close when we should have shifted
+
+    The fix here is to remove the corresponding close from later in
+    the transition sequence.  The rest of the tree building is the same,
+    including doing the missing Shift immediately after
+
+    Anything else would make the situation of one precision, one
+    recall error worse
+    """
+    if not isinstance(pred_transition, CloseConstituent):
+        return None
+
+    if not isinstance(gold_transition, Shift):
+        return None
+
+    close_index = advance_past_constituents(gold_sequence, gold_index)
+    return gold_sequence[:gold_index] + [pred_transition] + gold_sequence[gold_index:close_index] + gold_sequence[close_index+1:]
+
+def fix_open_close(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    """
+    Predicted a close when we should have opened a constituent
+
+    In this case, the previous constituent is now a precision and
+    recall error, BUT we can salvage the constituent we were about to
+    open by proceeding as if everything else is still the same.
+
+    The next thing the model should do is open the transition it forgot about
+    """
+    if not isinstance(pred_transition, CloseConstituent):
+        return None
+
+    if not isinstance(gold_transition, OpenConstituent):
+        return None
+
+    close_index = advance_past_constituents(gold_sequence, gold_index)
+    return gold_sequence[:gold_index] + [pred_transition] + gold_sequence[gold_index:close_index] + gold_sequence[close_index+1:]
+
+def fix_one_open_shift(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    """
+    Predicted a shift when we should have opened a constituent
+
+    This causes a single recall error if we just pretend that
+    constituent didn't exist
+
+    Keep the shift where it was, remove the next shift
+    Also, scroll ahead, find the corresponding close, cut it out
+
+    For the corresponding multiple opens, shift error, see fix_multiple_open_shift
+    """
+    if not isinstance(pred_transition, Shift):
+        return None
+
+    if not isinstance(gold_transition, OpenConstituent):
+        return None
+
+    if not isinstance(gold_sequence[gold_index + 1], Shift):
+        return None
+
+    shift_index = gold_index + 1
+    close_index = advance_past_constituents(gold_sequence, gold_index + 1)
+    if close_index is None:
+        return None
+    # gold_index is the skipped open constituent
+    # close_index was the corresponding close
+    # shift_index is the shift to remove
+    updated_sequence = gold_sequence[:gold_index] + [pred_transition] + gold_sequence[gold_index+1:shift_index] + gold_sequence[shift_index+1:close_index] + gold_sequence[close_index+1:]
+    #print("Input sequence: %s\nIndex %d\nGold %s Pred %s\nUpdated sequence %s" % (gold_sequence, gold_index, gold_transition, pred_transition, updated_sequence))
+    return updated_sequence
+
+def fix_multiple_open_shift(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    """
+    Predicted a shift when we should have opened multiple constituents instead
+
+    This causes a single recall error per constituent if we just
+    pretend those constituents don't exist
+
+    For each open constituent, we find the corresponding close,
+    then remove both the open & close
+    """
+    if not isinstance(pred_transition, Shift):
+        return None
+
+    if not isinstance(gold_transition, OpenConstituent):
+        return None
+
+    shift_index = gold_index
+    while shift_index < len(gold_sequence) and isinstance(gold_sequence[shift_index], OpenConstituent):
+        shift_index += 1
+    if shift_index >= len(gold_sequence):
+        raise AssertionError("Found a sequence of OpenConstituent at the end of a TOP_DOWN sequence!")
+    if not isinstance(gold_sequence[shift_index], Shift):
+        raise AssertionError("Expected to find a Shift after a sequence of OpenConstituent.  There should not be a %s" % gold_sequence[shift_index])
+
+    #print("Input sequence: %s\nIndex %d\nGold %s Pred %s" % (gold_sequence, gold_index, gold_transition, pred_transition))
+    updated_sequence = gold_sequence
+    while shift_index > gold_index:
+        close_index = advance_past_constituents(updated_sequence, shift_index)
+        if close_index is None:
+            raise AssertionError("Did not find a corresponding Close for this Open")
+        # cut out the corresponding open and close
+        updated_sequence = updated_sequence[:shift_index-1] + updated_sequence[shift_index:close_index] + updated_sequence[close_index+1:]
+        shift_index -= 1
+        #print("  %s" % updated_sequence)
+
+    #print("Final updated sequence: %s" % updated_sequence)
+    return updated_sequence
+
+def fix_nested_open_constituent(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    """
+    We were supposed to predict Open(X), then Open(Y), but predicted Open(Y) instead
+
+    We treat this as a single recall error.
+
+    We could even go crazy and turn it into a Unary,
+    such as Open(Y), Open(X), Open(Y)...
+    presumably that would be very confusing to the parser
+    not to mention ambiguous as to where to close the new constituent
+    """
+    if not isinstance(pred_transition, OpenConstituent):
+        return None
+
+    if not isinstance(gold_transition, OpenConstituent):
+        return None
+
+    assert len(gold_sequence) > gold_index + 1
+
+    if not isinstance(gold_sequence[gold_index+1], OpenConstituent):
+        return None
+
+    # This replacement works if we skipped exactly one level
+    if gold_sequence[gold_index+1].label != pred_transition.label:
+        return None
+
+    close_index = advance_past_constituents(gold_sequence, gold_index+1)
+    assert close_index is not None
+    updated_sequence = gold_sequence[:gold_index] + gold_sequence[gold_index+1:close_index] + gold_sequence[close_index+1:]
+    return updated_sequence
+
+def fix_shift_open_immediate_close(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    """
+    We were supposed to Shift, but instead we Opened
+
+    The biggest problem with this type of error is that the Close of
+    the Open is ambiguous.  We could put it immediately before the
+    next Close, immediately after the Shift, or anywhere in between.
+
+    One unambiguous case would be if the proper sequence was Shift - Close.
+    Then it is unambiguous that the only possible repair is Open - Shift - Close - Close.
+    """
+    if not isinstance(pred_transition, OpenConstituent):
+        return None
+
+    if not isinstance(gold_transition, Shift):
+        return None
+
+    assert len(gold_sequence) > gold_index + 1
+    if not isinstance(gold_sequence[gold_index+1], CloseConstituent):
+        # this is the ambiguous case
+        return None
+
+    return gold_sequence[:gold_index] + [pred_transition, gold_transition, CloseConstituent()] + gold_sequence[gold_index+1:]
+
+def fix_close_shift(gold_transition, pred_transition, gold_sequence, gold_index, root_labels, count_opens=False):
+    """
+    We were supposed to Close, but instead did a Shift
+
+    In most cases, this will be ambiguous.  There is now a constituent
+    which has been missed, no matter what we do, and we are on the
+    hook for eventually closing this constituent, creating a precision
+    error as well.  The ambiguity arises because there will be
+    multiple places where the Close could occur if there are more
+    constituents created between now and when the outer constituent is
+    Closed.
+
+    The non-ambiguous case is if the proper sequence was
+      Close - Shift - Close
+    similar cases are also non-ambiguous, such as
+      Close - Close - Shift - Close
+    for that matter, so is the following, although the Opens will be lost
+      Close - Open - Shift - Close - Close
+
+    count_opens is an option to make it easy to count with or without
+      Open as different oracle fixes
+    """
+    if not isinstance(pred_transition, Shift):
+        return None
+
+    if not isinstance(gold_transition, CloseConstituent):
+        return None
+
+    num_closes = 0
+    while isinstance(gold_sequence[gold_index + num_closes], CloseConstituent):
+        num_closes += 1
+
+    # We may allow unary transitions here
+    # the opens will be lost in the repaired sequence
+    num_opens = 0
+    if count_opens:
+        while isinstance(gold_sequence[gold_index + num_closes + num_opens], OpenConstituent):
+            num_opens += 1
+
+    if not isinstance(gold_sequence[gold_index + num_closes + num_opens], Shift):
+        return None
+
+    if not isinstance(gold_sequence[gold_index + num_closes + num_opens + 1], CloseConstituent):
+        return None
+    for idx in range(num_opens):
+        if not isinstance(gold_sequence[gold_index + num_closes + num_opens + idx + 1], CloseConstituent):
+            return None
+
+    # Now we know it is Close x num_closes, Shift, Close
+    # Since we have erroneously predicted a Shift now, the best we can
+    # do is to follow that, then add num_closes Closes
+    updated_sequence = gold_sequence[:gold_index] + [pred_transition] + gold_sequence[gold_index:gold_index+num_closes] + gold_sequence[gold_index+num_closes+num_opens*2+1:]
+    return updated_sequence
+
+def fix_close_shift_with_opens(*args, **kwargs):
+    return fix_close_shift(*args, **kwargs, count_opens=True)
+
+def fix_close_open_one_con(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    """
+    We were supposed to Close, but instead did an Open
+
+    In general this is ambiguous (like close/shift), as we need to know when to close the incorrect constituent
+
+    A case that is not ambiguous is when exactly one constituent was
+    supposed to come after the Close and it matches the Open we just
+    created.  In that case, we treat that constituent as if it were
+    part of the non-Closed constituent.  For example,
+    "ate (NP spaghetti) (PP with a fork)" ->
+    "ate (NP spaghetti (PP with a fork))"
+    (delicious)
+    """
+    if not isinstance(pred_transition, OpenConstituent):
+        return None
+
+    if not isinstance(gold_transition, CloseConstituent):
+        return None
+
+    if gold_sequence[gold_index+1] != pred_transition:
+        return None
+
+    close_index = find_constituent_end(gold_sequence, gold_index+1)
+    if not isinstance(gold_sequence[close_index+1], CloseConstituent):
+        return None
+
+    # at this point, we know we can put the Close at the end of the
+    # Open which was accidentally added
+    updated_sequence = gold_sequence[:gold_index] + gold_sequence[gold_index+1:close_index+2] + [gold_transition] + gold_sequence[close_index+2:]
+    return updated_sequence
+
+class RepairType(Enum):
+    """
+    Keep track of which repair is used, if any, on an incorrect transition
+
+    A test of the top-down oracle with no charlm or transformer
+      (eg, word vectors only) on EN PTB3 goes as follows.
+      3x training rounds, best training parameters as of Jan. 2024
+    unambiguous transitions only:
+        oracle scheme         dev        test
+      no oracle              0.9230     0.9194
+       +shift/close          0.9224     0.9180
+       +open/close           0.9225     0.9193
+       +open/shift (one)     0.9245     0.9207
+       +open/shift (mult)    0.9243     0.9211
+       +open/open nested     0.9258     0.9213
+       +shift/open           0.9266     0.9229
+       +close/shift (only)   0.9270     0.9230
+       +close/shift w/ opens 0.9262     0.9221
+       +close/open one con   0.9273     0.9230
+    """
+    def __new__(cls, fn, correct=False):
+        """
+        Enumerate values as normal, but also keep a pointer to a function which repairs that kind of error
+        """
+        value = len(cls.__members__)
+        obj = object.__new__(cls)
+        obj._value_ = value + 1
+        obj.fn = fn
+        obj.correct = correct
+        return obj
+
+    def is_correct(self):
+        return self.correct
+
+    # The parser chose to close a bracket instead of shift something
+    # into the bracket
+    # This causes both a precision and a recall error as there is now
+    # an incorrect bracket and a missing correct bracket
+    # Any bracket creation here would cause more wrong brackets, though
+    SHIFT_CLOSE_ERROR            = (fix_shift_close,)
+
+    OPEN_CLOSE_ERROR             = (fix_open_close,)
+
+    # open followed by shift was instead predicted to be shift
+    ONE_OPEN_SHIFT_ERROR         = (fix_one_open_shift,)
+
+    # open followed by shift was instead predicted to be shift
+    MULTIPLE_OPEN_SHIFT_ERROR    = (fix_multiple_open_shift,)
+
+    # should have done Open(X), Open(Y)
+    # instead just did Open(Y)
+    NESTED_OPEN_OPEN_ERROR       = (fix_nested_open_constituent,)
+
+    SHIFT_OPEN_ERROR             = (fix_shift_open_immediate_close,)
+
+    CLOSE_SHIFT_ERROR            = (fix_close_shift,)
+
+    CLOSE_SHIFT_WITH_OPENS_ERROR = (fix_close_shift_with_opens,)
+
+    CLOSE_OPEN_ONE_CON_ERROR     = (fix_close_open_one_con,)
+
+    CORRECT                      = (None, True)
+
+    UNKNOWN                      = None
+
+class TopDownOracle(DynamicOracle):
+    def __init__(self, root_labels, oracle_level):
+        super().__init__(root_labels, oracle_level, RepairType)

--- a/stanza/models/constituency/trainer.py
+++ b/stanza/models/constituency/trainer.py
@@ -35,6 +35,7 @@ from stanza.models.constituency.in_order_oracle import InOrderOracle
 from stanza.models.constituency.lstm_model import LSTMModel, StackHistory
 from stanza.models.constituency.parse_transitions import TransitionScheme
 from stanza.models.constituency.parse_tree import Tree
+from stanza.models.constituency.top_down_oracle import TopDownOracle
 from stanza.models.constituency.utils import retag_tags, retag_trees, build_optimizer, build_scheduler
 from stanza.models.constituency.utils import DEFAULT_LEARNING_EPS, DEFAULT_LEARNING_RATES, DEFAULT_LEARNING_RHO, DEFAULT_WEIGHT_DECAY
 from stanza.server.parser_eval import EvaluateParser, ParseResult
@@ -818,6 +819,8 @@ def iterate_training(args, trainer, train_trees, train_sequences, transitions, d
     oracle = None
     if args['transition_scheme'] is TransitionScheme.IN_ORDER:
         oracle = InOrderOracle(model.root_labels, args['oracle_level'])
+    elif args['transition_scheme'] is TransitionScheme.TOP_DOWN:
+        oracle = TopDownOracle(model.root_labels, args['oracle_level'])
 
     leftover_training_data = []
     leftover_silver_data = []

--- a/stanza/models/constituency/trainer.py
+++ b/stanza/models/constituency/trainer.py
@@ -818,9 +818,9 @@ def iterate_training(args, trainer, train_trees, train_sequences, transitions, d
 
     oracle = None
     if args['transition_scheme'] is TransitionScheme.IN_ORDER:
-        oracle = InOrderOracle(model.root_labels, args['oracle_level'])
+        oracle = InOrderOracle(model.root_labels, args['oracle_level'], args['additional_oracle_levels'])
     elif args['transition_scheme'] is TransitionScheme.TOP_DOWN:
-        oracle = TopDownOracle(model.root_labels, args['oracle_level'])
+        oracle = TopDownOracle(model.root_labels, args['oracle_level'], args['additional_oracle_levels'])
 
     leftover_training_data = []
     leftover_silver_data = []

--- a/stanza/models/constituency_parser.py
+++ b/stanza/models/constituency_parser.py
@@ -389,6 +389,7 @@ def build_argparse():
     parser.add_argument('--oracle_frequency', type=float, default=0.8, help="How often to use the oracle vs how often to force the correct transition")
     parser.add_argument('--oracle_forced_errors', type=float, default=0.001, help="Occasionally have the model randomly walk through the state space to try to learn how to recover")
     parser.add_argument('--oracle_level', type=int, default=None, help='Restrict oracle transitions to this level or lower.  0 means off.  None means use all oracle transitions.')
+    parser.add_argument('--additional_oracle_levels', type=str, default=None, help='Add some additional experimental oracle transitions.  Basically for A/B testing transitions we expect to be bad.')
 
     # 30 is slightly slower than 50, for example, but seems to train a bit better on WSJ
     # earlier version of the model (less accurate overall) had the following results with adadelta:

--- a/stanza/tests/constituency/test_top_down_oracle.py
+++ b/stanza/tests/constituency/test_top_down_oracle.py
@@ -1,0 +1,266 @@
+import pytest
+
+from stanza.models.constituency.parse_transitions import Shift, OpenConstituent, CloseConstituent, TransitionScheme
+from stanza.models.constituency.top_down_oracle import *
+from stanza.models.constituency.transition_sequence import build_sequence
+from stanza.models.constituency.tree_reader import read_trees
+
+from stanza.tests.constituency.test_transition_sequence import reconstruct_tree
+
+pytestmark = [pytest.mark.pipeline, pytest.mark.travis]
+
+OPEN_SHIFT_EXAMPLE_TREE = """
+( (S
+     (NP (NNP Jennifer) (NNP Sh\'reyan))
+     (VP (VBZ has)
+         (NP (RB nice) (NNS antennae)))))
+"""
+
+OPEN_SHIFT_PROBLEM_TREE = """
+(ROOT (S (NP (NP (NP (DT The) (`` ``) (JJ Thin) (NNP Man) ('' '') (NN series)) (PP (IN of) (NP (NNS movies)))) (, ,) (CONJP (RB as) (RB well) (IN as)) (NP (JJ many) (NNS others)) (, ,)) (VP (VBD based) (NP (PRP$ their) (JJ entire) (JJ comedic) (NN appeal)) (PP (IN on) (NP (NP (DT the) (NN star) (NNS detectives) (POS ')) (JJ witty) (NNS quips) (CC and) (NNS puns))) (SBAR (IN as) (S (NP (NP (JJ other) (NNS characters)) (PP (IN in) (NP (DT the) (NNS movies)))) (VP (VBD were) (VP (VBN murdered)))))) (. .)))
+"""
+
+ROOT_LABELS = ["ROOT"]
+
+def test_fix_open_shift():
+    trees = read_trees(OPEN_SHIFT_EXAMPLE_TREE)
+    assert len(trees) == 1
+    tree = trees[0]
+
+    transitions = build_sequence(tree, transition_scheme=TransitionScheme.TOP_DOWN)
+    EXPECTED_ORIG = [OpenConstituent('ROOT'), OpenConstituent('S'), OpenConstituent('NP'), Shift(), Shift(), CloseConstituent(), OpenConstituent('VP'), Shift(), OpenConstituent('NP'), Shift(), Shift(), CloseConstituent(), CloseConstituent(), CloseConstituent(), CloseConstituent()]
+    EXPECTED_FIX_EARLY = [OpenConstituent('ROOT'), OpenConstituent('S'), Shift(), Shift(), OpenConstituent('VP'), Shift(), OpenConstituent('NP'), Shift(), Shift(), CloseConstituent(), CloseConstituent(), CloseConstituent(), CloseConstituent()]
+    EXPECTED_FIX_LATE = [OpenConstituent('ROOT'), OpenConstituent('S'), OpenConstituent('NP'), Shift(), Shift(), CloseConstituent(), OpenConstituent('VP'), Shift(), Shift(), Shift(), CloseConstituent(), CloseConstituent(), CloseConstituent()]
+
+    assert transitions == EXPECTED_ORIG
+
+    new_transitions = fix_one_open_shift(OpenConstituent('NP'), Shift(), transitions, 2, ROOT_LABELS)
+    assert new_transitions == EXPECTED_FIX_EARLY
+
+    new_transitions = fix_one_open_shift(OpenConstituent('NP'), Shift(), transitions, 8, ROOT_LABELS)
+    assert new_transitions == EXPECTED_FIX_LATE
+
+def test_fix_open_shift_observed_error():
+    """
+    Ran into an error on this tree, need to fix it
+
+    The problem is the multiple Open in a row all need to be removed when a Shift happens
+    """
+    trees = read_trees(OPEN_SHIFT_PROBLEM_TREE)
+    assert len(trees) == 1
+    tree = trees[0]
+
+    transitions = build_sequence(tree, transition_scheme=TransitionScheme.TOP_DOWN)
+    new_transitions = fix_one_open_shift(OpenConstituent('NP'), Shift(), transitions, 2, ROOT_LABELS)
+    assert new_transitions is None
+
+    new_transitions = fix_multiple_open_shift(OpenConstituent('NP'), Shift(), transitions, 2, ROOT_LABELS)
+
+    # Can break the expected transitions down like this:
+    # [OpenConstituent(('ROOT',)), OpenConstituent(('S',)),
+    # all gone: OpenConstituent(('NP',)), OpenConstituent(('NP',)), OpenConstituent(('NP',)),
+    # Shift, Shift, Shift, Shift, Shift, Shift,
+    # gone: CloseConstituent,
+    # OpenConstituent(('PP',)), Shift, OpenConstituent(('NP',)), Shift, CloseConstituent, CloseConstituent,
+    # gone: CloseConstituent,
+    # Shift, OpenConstituent(('CONJP',)), Shift, Shift, Shift, CloseConstituent, OpenConstituent(('NP',)), Shift, Shift, CloseConstituent, Shift,
+    # gone: CloseConstituent,
+    # and then the rest:
+    # OpenConstituent(('VP',)), Shift, OpenConstituent(('NP',)),
+    # Shift, Shift, Shift, Shift, CloseConstituent,
+    # OpenConstituent(('PP',)), Shift, OpenConstituent(('NP',)),
+    # OpenConstituent(('NP',)), Shift, Shift, Shift, Shift,
+    # CloseConstituent, Shift, Shift, Shift, Shift, CloseConstituent,
+    # CloseConstituent, OpenConstituent(('SBAR',)), Shift,
+    # OpenConstituent(('S',)), OpenConstituent(('NP',)),
+    # OpenConstituent(('NP',)), Shift, Shift, CloseConstituent,
+    # OpenConstituent(('PP',)), Shift, OpenConstituent(('NP',)),
+    # Shift, Shift, CloseConstituent, CloseConstituent,
+    # CloseConstituent, OpenConstituent(('VP',)), Shift,
+    # OpenConstituent(('VP',)), Shift, CloseConstituent,
+    # CloseConstituent, CloseConstituent, CloseConstituent,
+    # CloseConstituent, Shift, CloseConstituent, CloseConstituent]
+    expected_transitions = [OpenConstituent('ROOT'), OpenConstituent('S'), Shift(), Shift(), Shift(), Shift(), Shift(), Shift(), OpenConstituent('PP'), Shift(), OpenConstituent('NP'), Shift(), CloseConstituent(), CloseConstituent(), Shift(), OpenConstituent('CONJP'), Shift(), Shift(), Shift(), CloseConstituent(), OpenConstituent('NP'), Shift(), Shift(), CloseConstituent(), Shift(), OpenConstituent('VP'), Shift(), OpenConstituent('NP'), Shift(), Shift(), Shift(), Shift(), CloseConstituent(), OpenConstituent('PP'), Shift(), OpenConstituent('NP'), OpenConstituent('NP'), Shift(), Shift(), Shift(), Shift(), CloseConstituent(), Shift(), Shift(), Shift(), Shift(), CloseConstituent(), CloseConstituent(), OpenConstituent('SBAR'), Shift(), OpenConstituent('S'), OpenConstituent('NP'), OpenConstituent('NP'), Shift(), Shift(), CloseConstituent(), OpenConstituent('PP'), Shift(), OpenConstituent('NP'), Shift(), Shift(), CloseConstituent(), CloseConstituent(), CloseConstituent(), OpenConstituent('VP'), Shift(), OpenConstituent('VP'), Shift(), CloseConstituent(), CloseConstituent(), CloseConstituent(), CloseConstituent(), CloseConstituent(), Shift(), CloseConstituent(), CloseConstituent()]
+
+    assert new_transitions == expected_transitions
+
+CLOSE_SHIFT_EXAMPLE_TREE = """
+( (NP (DT a)
+   (ADJP (NN stock) (HYPH -) (VBG picking))
+   (NN tool)))
+"""
+
+# not intended to be a correct tree
+CLOSE_SHIFT_DEEP_EXAMPLE_TREE = """
+( (NP (DT a)
+   (VP (ADJP (NN stock) (HYPH -) (VBG picking)))
+   (NN tool)))
+"""
+
+# not intended to be a correct tree
+CLOSE_SHIFT_OPEN_EXAMPLE_TREE = """
+( (NP (DT a)
+   (ADJP (NN stock) (HYPH -) (VBG picking))
+   (NP (NN tool))))
+"""
+
+def test_fix_close_shift():
+    """
+    Test a tree of the kind we expect the close/shift to be able to get right
+    """
+    trees = read_trees(CLOSE_SHIFT_EXAMPLE_TREE)
+    assert len(trees) == 1
+    tree = trees[0]
+
+    transitions = build_sequence(tree, transition_scheme=TransitionScheme.TOP_DOWN)
+
+    new_sequence = fix_close_shift(gold_transition=transitions[7],
+                                   pred_transition=transitions[8],
+                                   gold_sequence=transitions,
+                                   gold_index=7,
+                                   root_labels=ROOT_LABELS)
+
+    expected_original = [OpenConstituent('ROOT'), OpenConstituent('NP'), Shift(), OpenConstituent('ADJP'), Shift(), Shift(), Shift(), CloseConstituent(), Shift(), CloseConstituent(), CloseConstituent()]
+    expected_update   = [OpenConstituent('ROOT'), OpenConstituent('NP'), Shift(), OpenConstituent('ADJP'), Shift(), Shift(), Shift(), Shift(), CloseConstituent(), CloseConstituent(), CloseConstituent()]
+    assert transitions == expected_original
+    assert new_sequence == expected_update
+
+def test_fix_close_shift_deeper_tree():
+    """
+    Test a tree of the kind we expect the close/shift to be able to get right
+    """
+    trees = read_trees(CLOSE_SHIFT_DEEP_EXAMPLE_TREE)
+    assert len(trees) == 1
+    tree = trees[0]
+
+    transitions = build_sequence(tree, transition_scheme=TransitionScheme.TOP_DOWN)
+
+    for count_opens in [True, False]:
+        new_sequence = fix_close_shift(gold_transition=transitions[8],
+                                       pred_transition=transitions[10],
+                                       gold_sequence=transitions,
+                                       gold_index=8,
+                                       root_labels=ROOT_LABELS,
+                                       count_opens=count_opens)
+
+        expected_original = [OpenConstituent('ROOT'), OpenConstituent('NP'), Shift(), OpenConstituent('VP'), OpenConstituent('ADJP'), Shift(), Shift(), Shift(), CloseConstituent(), CloseConstituent(), Shift(), CloseConstituent(), CloseConstituent()]
+        expected_update   = [OpenConstituent('ROOT'), OpenConstituent('NP'), Shift(), OpenConstituent('VP'), OpenConstituent('ADJP'), Shift(), Shift(), Shift(), Shift(), CloseConstituent(), CloseConstituent(), CloseConstituent(), CloseConstituent()]
+        assert transitions == expected_original
+        assert new_sequence == expected_update
+
+def test_fix_close_shift_open_tree():
+    """
+    We would like the close/shift to get this case right as well
+    """
+    trees = read_trees(CLOSE_SHIFT_OPEN_EXAMPLE_TREE)
+    assert len(trees) == 1
+    tree = trees[0]
+
+    transitions = build_sequence(tree, transition_scheme=TransitionScheme.TOP_DOWN)
+
+    assert fix_close_shift(gold_transition=transitions[7],
+                           pred_transition=transitions[9],
+                           gold_sequence=transitions,
+                           gold_index=7,
+                           root_labels=ROOT_LABELS,
+                           count_opens=False) == None
+
+    new_sequence = fix_close_shift_with_opens(gold_transition=transitions[7],
+                                              pred_transition=transitions[9],
+                                              gold_sequence=transitions,
+                                              gold_index=7,
+                                              root_labels=ROOT_LABELS)
+
+    expected_original = [OpenConstituent('ROOT'), OpenConstituent('NP'), Shift(), OpenConstituent('ADJP'), Shift(), Shift(), Shift(), CloseConstituent(), OpenConstituent('NP'), Shift(), CloseConstituent(), CloseConstituent(), CloseConstituent()]
+    expected_update   = [OpenConstituent('ROOT'), OpenConstituent('NP'), Shift(), OpenConstituent('ADJP'), Shift(), Shift(), Shift(), Shift(), CloseConstituent(), CloseConstituent(), CloseConstituent()]
+    assert transitions == expected_original
+    assert new_sequence == expected_update
+
+    assert fix_close_shift_with_opens(transitions[7], transitions[9], transitions, 7, ROOT_LABELS) == expected_update
+
+CLOSE_OPEN_EXAMPLE_TREE = """
+( (VP (VBZ eat)
+   (NP (NN spaghetti))
+   (PP (IN with) (DT a) (NN fork))))
+"""
+
+CLOSE_OPEN_DIFFERENT_LABEL_TREE = """
+( (VP (VBZ eat)
+   (NP (NN spaghetti))
+   (NP (DT a) (NN fork))))
+"""
+
+CLOSE_OPEN_TWO_LABELS_TREE = """
+( (VP (VBZ eat)
+   (NP (NN spaghetti))
+   (PP (IN with) (DT a) (NN fork))
+   (PP (IN in) (DT a) (NN restaurant))))
+"""
+
+def test_fix_close_open():
+    trees = read_trees(CLOSE_OPEN_EXAMPLE_TREE)
+    assert len(trees) == 1
+    tree = trees[0]
+
+    transitions = build_sequence(tree, transition_scheme=TransitionScheme.TOP_DOWN)
+
+    assert isinstance(transitions[5], CloseConstituent)
+    assert transitions[6] == OpenConstituent("PP")
+
+    new_transitions = fix_close_open_one_con(transitions[5], transitions[6], transitions, 5, ROOT_LABELS)
+
+    expected_original = [OpenConstituent('ROOT'), OpenConstituent('VP'), Shift(), OpenConstituent('NP'), Shift(), CloseConstituent(), OpenConstituent('PP'), Shift(), Shift(), Shift(), CloseConstituent(), CloseConstituent(), CloseConstituent()]
+    expected_update   = [OpenConstituent('ROOT'), OpenConstituent('VP'), Shift(), OpenConstituent('NP'), Shift(), OpenConstituent('PP'), Shift(), Shift(), Shift(), CloseConstituent(), CloseConstituent(), CloseConstituent(), CloseConstituent()]
+
+    assert transitions == expected_original
+    assert new_transitions == expected_update
+
+def test_fix_close_open_invalid():
+    for TREE in (CLOSE_OPEN_DIFFERENT_LABEL_TREE, CLOSE_OPEN_TWO_LABELS_TREE):
+        trees = read_trees(TREE)
+        assert len(trees) == 1
+        tree = trees[0]
+
+        transitions = build_sequence(tree, transition_scheme=TransitionScheme.TOP_DOWN)
+
+        assert isinstance(transitions[5], CloseConstituent)
+        assert isinstance(transitions[6], OpenConstituent)
+
+        new_transitions = fix_close_open_one_con(transitions[5], OpenConstituent("PP"), transitions, 5, ROOT_LABELS)
+        assert new_transitions is None
+
+SHIFT_CLOSE_EXAMPLES = [
+    ("((S (NP (DT an) (NML (NNP Oct) (CD 19)) (NN review))))", "((S (NP (DT an) (NML (NNP Oct) (CD 19))) (NN review)))", 8),
+    ("((S (NP (` `) (NP (DT The) (NN Misanthrope)) (` `) (PP (IN at) (NP (NNP Goodman) (NNP Theatre))))))",
+     "((S (NP (` `) (NP (DT The)) (NN Misanthrope) (` `) (PP (IN at) (NP (NNP Goodman) (NNP Theatre))))))", 6),
+    ("((S (NP (` `) (NP (DT The) (NN Misanthrope)) (` `) (PP (IN at) (NP (NNP Goodman) (NNP Theatre))))))",
+     "((S (NP (` `) (NP (DT The) (NN Misanthrope))) (` `) (PP (IN at) (NP (NNP Goodman) (NNP Theatre)))))", 8),
+    ("((S (NP (` `) (NP (DT The) (NN Misanthrope)) (` `) (PP (IN at) (NP (NNP Goodman) (NNP Theatre))))))",
+     "((S (NP (` `) (NP (DT The) (NN Misanthrope)) (` `) (PP (IN at) (NP (NNP Goodman)) (NNP Theatre)))))", 13),
+]
+
+def test_shift_close():
+    for idx, (orig_tree, expected_tree, shift_position) in enumerate(SHIFT_CLOSE_EXAMPLES):
+        trees = read_trees(orig_tree)
+        assert len(trees) == 1
+        tree = trees[0]
+
+        transitions = build_sequence(tree, transition_scheme=TransitionScheme.TOP_DOWN)
+        if shift_position is None:
+            print(transitions)
+            continue
+
+        assert isinstance(transitions[shift_position], Shift)
+        new_transitions = fix_shift_close(Shift(), CloseConstituent(), transitions, shift_position, ROOT_LABELS)
+        reconstructed = reconstruct_tree(tree, new_transitions, transition_scheme=TransitionScheme.TOP_DOWN)
+        if expected_tree is None:
+            print(transitions)
+            print(new_transitions)
+
+            print("{:P}".format(reconstructed))
+        else:
+            expected_tree = read_trees(expected_tree)
+            assert len(expected_tree) == 1
+            expected_tree = expected_tree[0]
+
+            assert reconstructed == expected_tree


### PR DESCRIPTION
Add an oracle for the TOP_DOWN transition scheme - seems to be effective in improving the scores for a top down parser

Includes unambiguous & ambiguous transitions

Also, keep track of stats for both the top_down and in_order oracles