### PR TITLE
Make a variant of the dataloader which limits a batch to 5000 words o…

### DIFF
--- a/stanza/models/pos/data.py
+++ b/stanza/models/pos/data.py
@@ -5,6 +5,7 @@ import torch
 from collections import namedtuple
 
 from torch.utils.data import DataLoader as DL
+from torch.utils.data.sampler import Sampler
 from torch.nn.utils.rnn import pad_sequence
 
 from stanza.models.common.bert_embedding import filter_data
@@ -221,6 +222,12 @@ class Dataset:
                   collate_fn=Dataset.__collate_fn,
                   **kwargs)
 
+    def to_length_limited_loader(self, batch_size, maximum_tokens):
+        sampler = LengthLimitedBatchSampler(self, batch_size, maximum_tokens)
+        return DL(self,
+                  collate_fn=Dataset.__collate_fn,
+                  batch_sampler = sampler)
+
     @staticmethod
     def __collate_fn(data):
         """Function used by DataLoader to pack data"""
@@ -282,6 +289,57 @@ class Dataset:
                     if data[sent_idx][tok_idx][feat_idx] is None:
                         data[sent_idx][tok_idx][feat_idx] = '_'
         return data
+
+class LengthLimitedBatchSampler(Sampler):
+    """
+    Batches up the text in batches of batch_size, but cuts off each time a batch reaches maximum_tokens
+
+    Intent is to avoid GPU OOM in situations where one sentence is significantly longer than expected,
+    leaving a batch too large to fit in the GPU
+
+    Sentences which are longer than maximum_tokens by themselves are put in their own batches
+    """
+    def __init__(self, data, batch_size, maximum_tokens):
+        """
+        Precalculate the batches, making it so len and iter just read off the precalculated batches
+        """
+        self.data = data
+        self.batch_size = batch_size
+        self.maximum_tokens = maximum_tokens
+
+        self.batches = []
+        current_batch = []
+        current_length = 0
+
+        for item, item_idx in data:
+            item_len = len(item.word)
+            if maximum_tokens and item_len > maximum_tokens:
+                if len(current_batch) > 0:
+                    self.batches.append(current_batch)
+                    current_batch = []
+                    current_length = 0
+                self.batches.append([item_idx])
+                continue
+            if len(current_batch) + 1 > batch_size or (maximum_tokens and item_len + current_length > maximum_tokens):
+                self.batches.append(current_batch)
+                current_batch = []
+                current_length = 0
+            current_batch.append(item_idx)
+            current_length += item_len
+
+        if len(current_batch) > 0:
+            self.batches.append(current_batch)
+
+    def __len__(self):
+        return len(self.batches)
+
+    def __iter__(self):
+        for batch in self.batches:
+            current_batch = []
+            for idx in batch:
+                current_batch.append(idx)
+            yield current_batch
+
 
 class ShuffledDataset:
     """A wrapper around one or more datasets which shuffles the data in batch_size chunks

--- a/stanza/models/tagger.py
+++ b/stanza/models/tagger.py
@@ -103,6 +103,7 @@ def build_argparse():
             help="Use fixed evaluation interval for all treebanks, otherwise by default the interval will be increased for larger treebanks.")
     parser.add_argument('--max_steps_before_stop', type=int, default=3000, help='Changes learning method or early terminates after this many steps if the dev scores are not improving')
     parser.add_argument('--batch_size', type=int, default=250)
+    parser.add_argument('--batch_maximum_tokens', type=int, default=5000, help='When run in a Pipeline, limit a batch to this many tokens to help avoid OOM for long sentences')
     parser.add_argument('--max_grad_norm', type=float, default=1.0, help='Gradient clipping.')
     parser.add_argument('--log_step', type=int, default=20, help='Print log every k steps.')
     parser.add_argument('--log_norms', action='store_true', default=False, help='Log the norms of all the parameters (noisy!)')

--- a/stanza/pipeline/pos_processor.py
+++ b/stanza/pipeline/pos_processor.py
@@ -67,10 +67,13 @@ class POSProcessor(UDProcessor):
         return values
 
     def process(self, document):
+        # currently, POS models are saved w/o the batch_maximum_tokens flag
+        maximum_tokens = self.config.get('batch_maximum_tokens', 5000)
+
         dataset = Dataset(
             document, self.config, self.pretrain, vocab=self.vocab, evaluation=True,
             sort_during_eval=True)
-        batch = iter(dataset.to_loader(batch_size=self.config['batch_size']))
+        batch = iter(dataset.to_length_limited_loader(batch_size=self.config['batch_size'], maximum_tokens=maximum_tokens))
         preds = []
 
         idx = []

--- a/stanza/tests/pos/test_data.py
+++ b/stanza/tests/pos/test_data.py
@@ -174,3 +174,117 @@ def test_shuffle(tmp_path):
 
     assert num_with == 100
     assert num_without == 100
+
+
+EWT_SAMPLE = """
+# sent_id = weblog-blogspot.com_alaindewitt_20040929103700_ENG_20040929_103700-0048
+# text = Bush asked for permission to go to Alabama to work on a Senate campaign.
+1	Bush	Bush	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
+2	asked	ask	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	for	for	ADP	IN	_	4	case	4:case	_
+4	permission	permission	NOUN	NN	Number=Sing	2	obl	2:obl:for	_
+5	to	to	PART	TO	_	6	mark	6:mark	_
+6	go	go	VERB	VB	VerbForm=Inf	4	acl	4:acl:to	_
+7	to	to	ADP	IN	_	8	case	8:case	_
+8	Alabama	Alabama	PROPN	NNP	Number=Sing	6	obl	6:obl:to	_
+9	to	to	PART	TO	_	10	mark	10:mark	_
+10	work	work	VERB	VB	VerbForm=Inf	6	advcl	6:advcl:to	_
+11	on	on	ADP	IN	_	14	case	14:case	_
+12	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
+13	Senate	Senate	PROPN	NNP	Number=Sing	14	compound	14:compound	_
+14	campaign	campaign	NOUN	NN	Number=Sing	10	obl	10:obl:on	SpaceAfter=No
+15	.	.	PUNCT	.	_	2	punct	2:punct	_
+
+# sent_id = weblog-blogspot.com_alaindewitt_20040929103700_ENG_20040929_103700-0049
+# text = His superior officers said OK.
+1	His	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	nmod:poss	3:nmod:poss	_
+2	superior	superior	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
+3	officers	officer	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
+4	said	say	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	OK	ok	INTJ	UH	_	4	obj	4:obj	SpaceAfter=No
+6	.	.	PUNCT	.	_	4	punct	4:punct	_
+
+# sent_id = weblog-blogspot.com_alaindewitt_20040929103700_ENG_20040929_103700-0053
+# text = In ’72 or ’73, if you were a pilot, active or Guard, and you had an obligation and wanted to get out, no problem.
+1	In	in	ADP	IN	_	2	case	2:case	_
+2	’72	'72	NUM	CD	NumForm=Digit|NumType=Card	10	obl	10:obl:in	_
+3	or	or	CCONJ	CC	_	4	cc	4:cc	_
+4	’73	'73	NUM	CD	NumForm=Digit|NumType=Card	2	conj	2:conj:or|10:obl:in	SpaceAfter=No
+5	,	,	PUNCT	,	_	2	punct	2:punct	_
+6	if	if	SCONJ	IN	_	10	mark	10:mark	_
+7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
+8	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	10	cop	10:cop	_
+9	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
+10	pilot	pilot	NOUN	NN	Number=Sing	28	advcl	28:advcl:if	SpaceAfter=No
+11	,	,	PUNCT	,	_	12	punct	12:punct	_
+12	active	active	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
+13	or	or	CCONJ	CC	_	14	cc	14:cc	_
+14	Guard	Guard	PROPN	NNP	Number=Sing	12	conj	10:amod|12:conj:or	SpaceAfter=No
+15	,	,	PUNCT	,	_	18	punct	18:punct	_
+16	and	and	CCONJ	CC	_	18	cc	18:cc	_
+17	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj|22:nsubj|24:nsubj:xsubj	_
+18	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	10	conj	10:conj:and|28:advcl:if	_
+19	an	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
+20	obligation	obligation	NOUN	NN	Number=Sing	18	obj	18:obj	_
+21	and	and	CCONJ	CC	_	22	cc	22:cc	_
+22	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	18	conj	18:conj:and	_
+23	to	to	PART	TO	_	24	mark	24:mark	_
+24	get	get	VERB	VB	VerbForm=Inf	22	xcomp	22:xcomp	_
+25	out	out	ADV	RB	_	24	advmod	24:advmod	SpaceAfter=No
+26	,	,	PUNCT	,	_	10	punct	10:punct	_
+27	no	no	DET	DT	PronType=Neg	28	det	28:det	_
+28	problem	problem	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+29	.	.	PUNCT	.	_	28	punct	28:punct	_
+
+# sent_id = weblog-blogspot.com_alaindewitt_20040929103700_ENG_20040929_103700-0054
+# text = In fact, you were helping them solve their problem.”
+1	In	in	ADP	IN	_	2	case	2:case	_
+2	fact	fact	NOUN	NN	Number=Sing	6	obl	6:obl:in	SpaceAfter=No
+3	,	,	PUNCT	,	_	2	punct	2:punct	_
+4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
+5	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	6	aux	6:aux	_
+6	helping	help	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+7	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	6	obj	6:obj|8:nsubj:xsubj	_
+8	solve	solve	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
+9	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
+10	problem	problem	NOUN	NN	Number=Sing	8	obj	8:obj	SpaceAfter=No
+11	.	.	PUNCT	.	_	6	punct	6:punct	SpaceAfter=No
+12	”	"	PUNCT	''	_	6	punct	6:punct	_
+
+# sent_id = weblog-blogspot.com_alaindewitt_20040929103700_ENG_20040929_103700-0055
+# text = So Bush stopped flying.
+1	So	so	ADV	RB	_	3	advmod	3:advmod	_
+2	Bush	Bush	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj|4:nsubj:xsubj	_
+3	stopped	stop	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	flying	fly	VERB	VBG	VerbForm=Ger	3	xcomp	3:xcomp	SpaceAfter=No
+5	.	.	PUNCT	.	_	3	punct	3:punct	_
+""".lstrip()
+
+def test_length_limited_dataloader():
+    sample = CoNLL.conll2doc(input_str=EWT_SAMPLE)
+
+    args = tagger.parse_args(args=["--batch_size", "10", "--shorthand", "en_test", "--augment_nopunct", "0.0"])
+    data = Dataset(sample, args, None)
+
+    # this should read the whole dataset
+    dl = data.to_length_limited_loader(5, 1000)
+    batches = [batch.idx for batch in dl]
+    assert batches == [(0, 1, 2, 3, 4)]
+
+    dl = data.to_length_limited_loader(4, 1000)
+    batches = [batch.idx for batch in dl]
+    assert batches == [(0, 1, 2, 3), (4,)]
+
+    dl = data.to_length_limited_loader(2, 1000)
+    batches = [batch.idx for batch in dl]
+    assert batches == [(0, 1), (2, 3), (4,)]
+
+    # the first three sentences should reach this limit
+    dl = data.to_length_limited_loader(5, 55)
+    batches = [batch.idx for batch in dl]
+    assert batches == [(0, 1, 2), (3, 4)]
+
+    # the third sentence (2) is already past this limit by itself
+    dl = data.to_length_limited_loader(5, 25)
+    batches = [batch.idx for batch in dl]
+    assert batches == [(0, 1), (2,), (3, 4)]


### PR DESCRIPTION
Make a variant of the dataloader which limits a batch to 5000 words or less (by default) for the Pipeline.  Should help avoid OOM for things such as a few very long sentence soaking up too many resources.  https://github.com/stanfordnlp/stanza/issues/1372
