### PR TITLE
Peft cache

### DIFF
--- a/stanza/models/classifiers/cnn_classifier.py
+++ b/stanza/models/classifiers/cnn_classifier.py
@@ -17,7 +17,6 @@ from stanza.models.classifiers.utils import ExtraVectors, ModelType, build_outpu
 from stanza.models.common.bert_embedding import extract_bert_embeddings
 from stanza.models.common.data import get_long_tensor, sort_all
 from stanza.models.common.foundation_cache import load_bert
-from stanza.models.common.peft_config import build_peft_wrapper
 from stanza.models.common.vocab import PAD_ID, UNK_ID
 
 """
@@ -133,7 +132,6 @@ class CNNClassifier(BaseClassifier):
                 raise ValueError("Got a forward charlm as a backward charlm!")
 
         if self.config.use_peft:
-            bert_model = build_peft_wrapper(bert_model, vars(self.config), tlogger)
             # we use a peft-specific pathway for saving peft weights
             self.add_unsaved_module('bert_model', bert_model)
             self.bert_model.train()
@@ -536,7 +534,7 @@ class CNNClassifier(BaseClassifier):
         if self.config.use_peft:
             # Hide import so that peft dependency is optional
             from peft import get_peft_model_state_dict
-            params["bert_lora"] = get_peft_model_state_dict(self.bert_model)
+            params["bert_lora"] = get_peft_model_state_dict(self.bert_model, adapter_name="sentiment")
         return params
 
     def preprocess_data(self, sentences):

--- a/stanza/models/classifiers/cnn_classifier.py
+++ b/stanza/models/classifiers/cnn_classifier.py
@@ -16,7 +16,6 @@ from stanza.models.classifiers.data import SentimentDatum
 from stanza.models.classifiers.utils import ExtraVectors, ModelType, build_output_layers
 from stanza.models.common.bert_embedding import extract_bert_embeddings
 from stanza.models.common.data import get_long_tensor, sort_all
-from stanza.models.common.foundation_cache import load_bert
 from stanza.models.common.utils import attach_bert_model
 from stanza.models.common.vocab import PAD_ID, UNK_ID
 

--- a/stanza/models/classifiers/cnn_classifier.py
+++ b/stanza/models/classifiers/cnn_classifier.py
@@ -17,6 +17,7 @@ from stanza.models.classifiers.utils import ExtraVectors, ModelType, build_outpu
 from stanza.models.common.bert_embedding import extract_bert_embeddings
 from stanza.models.common.data import get_long_tensor, sort_all
 from stanza.models.common.foundation_cache import load_bert
+from stanza.models.common.utils import attach_bert_model
 from stanza.models.common.vocab import PAD_ID, UNK_ID
 
 """
@@ -131,15 +132,7 @@ class CNNClassifier(BaseClassifier):
             if charmodel_backward.is_forward_lm:
                 raise ValueError("Got a forward charlm as a backward charlm!")
 
-        if self.config.use_peft:
-            # we use a peft-specific pathway for saving peft weights
-            self.add_unsaved_module('bert_model', bert_model)
-            self.bert_model.train()
-        elif force_bert_saved:
-            self.bert_model = bert_model
-        else:
-            self.add_unsaved_module('bert_model', bert_model)
-        self.add_unsaved_module('bert_tokenizer', bert_tokenizer)
+        attach_bert_model(self, bert_model, bert_tokenizer, self.config.use_peft, force_bert_saved)
 
         # The Pretrain has PAD and UNK already (indices 0 and 1), but we
         # possibly want to train UNK while freezing the rest of the embedding

--- a/stanza/models/classifiers/trainer.py
+++ b/stanza/models/classifiers/trainer.py
@@ -142,6 +142,7 @@ class Trainer:
                 'charlm_forward_file': args.charlm_forward_file,
                 'charlm_backward_file': args.charlm_backward_file,
             }
+            # TODO: integrate with peft for the constituency version
             tree_embedding = TreeEmbedding.model_from_params(model_params['tree_embedding'], pretrain_args, foundation_cache)
             model = constituency_classifier.ConstituencyClassifier(tree_embedding=tree_embedding,
                                                                    labels=model_params['labels'],

--- a/stanza/models/common/bert_embedding.py
+++ b/stanza/models/common/bert_embedding.py
@@ -427,13 +427,22 @@ def extract_base_embeddings(model_name, tokenizer, model, data, device, keep_end
 
     return processed
 
-def extract_bert_embeddings(model_name, tokenizer, model, data, device, keep_endpoints, num_layers=None, detach=True):
+def extract_bert_embeddings(model_name, tokenizer, model, data, device, keep_endpoints, num_layers=None, detach=True, peft_name=None):
     """
     Extract transformer embeddings using a generic roberta extraction
 
     data: list of list of string (the text tokens)
     num_layers: how many to return.  If None, the average of -2, -3, -4 is returned
     """
+    # TODO: can maybe cache this value for a model and save some time
+    # TODO: too bad it isn't thread safe, but then again, who does?
+    if peft_name is None:
+        if model._hf_peft_config_loaded:
+            model.disable_adapters()
+    else:
+        model.enable_adapters()
+        model.set_adapter(peft_name)
+
     if model_name.startswith("vinai/phobert"):
         return extract_phobert_embeddings(model_name, tokenizer, model, data, device, keep_endpoints, num_layers, detach)
 

--- a/stanza/models/common/utils.py
+++ b/stanza/models/common/utils.py
@@ -786,3 +786,17 @@ def log_norms(model):
         lines.append(line_format % line)
     logger.info("\n".join(lines))
 
+def attach_bert_model(model, bert_model, bert_tokenizer, use_peft, force_bert_saved):
+    if use_peft:
+        # we use a peft-specific pathway for saving peft weights
+        model.add_unsaved_module('bert_model', bert_model)
+        model.bert_model.train()
+    elif force_bert_saved:
+        model.bert_model = bert_model
+    elif bert_model is not None:
+        model.add_unsaved_module('bert_model', bert_model)
+        for _, parameter in bert_model.named_parameters():
+            parameter.requires_grad = False
+    else:
+        model.bert_model = None
+    model.add_unsaved_module('bert_tokenizer', bert_tokenizer)

--- a/stanza/models/constituency/lstm_model.py
+++ b/stanza/models/constituency/lstm_model.py
@@ -211,7 +211,7 @@ class ConstituencyComposition(Enum):
     UNTIED_KEY            = 10
 
 class LSTMModel(BaseModel, nn.Module):
-    def __init__(self, pretrain, forward_charlm, backward_charlm, bert_model, bert_tokenizer, force_bert_saved, transitions, constituents, tags, words, rare_words, root_labels, constituent_opens, unary_limit, args):
+    def __init__(self, pretrain, forward_charlm, backward_charlm, bert_model, bert_tokenizer, force_bert_saved, peft_name, transitions, constituents, tags, words, rare_words, root_labels, constituent_opens, unary_limit, args):
         """
         pretrain: a Pretrain object
         transitions: a list of all possible transitions which will be
@@ -353,6 +353,7 @@ class LSTMModel(BaseModel, nn.Module):
         # try to train our own
         self.force_bert_saved = force_bert_saved or self.args['bert_finetune'] or self.args['stage1_bert_finetune']
         attach_bert_model(self, bert_model, bert_tokenizer, self.args.get('use_peft', False), self.force_bert_saved)
+        self.peft_name = peft_name
 
         if bert_model is not None:
             if bert_tokenizer is None:
@@ -751,7 +752,8 @@ class LSTMModel(BaseModel, nn.Module):
             bert_embeddings = extract_bert_embeddings(self.args['bert_model'], self.bert_tokenizer, self.bert_model, all_word_labels, device,
                                                       keep_endpoints=self.sentence_boundary_vectors is not SentenceBoundary.NONE,
                                                       num_layers=self.bert_layer_mix.in_features if self.bert_layer_mix is not None else None,
-                                                      detach=not self.args['bert_finetune'] and not self.args['stage1_bert_finetune'])
+                                                      detach=not self.args['bert_finetune'] and not self.args['stage1_bert_finetune'],
+                                                      peft_name=self.peft_name)
             if self.bert_layer_mix is not None:
                 # add the average so that the default behavior is to
                 # take an average of the N layers, and anything else

--- a/stanza/models/constituency/tree_embedding.py
+++ b/stanza/models/constituency/tree_embedding.py
@@ -128,7 +128,8 @@ class TreeEmbedding(nn.Module):
 
     @staticmethod
     def model_from_params(params, args, foundation_cache=None):
-        constituency_parser = Trainer.model_from_params(params['constituency'], args, foundation_cache)
+        # TODO: integrate with peft
+        constituency_parser = Trainer.model_from_params(params['constituency'], None, args, foundation_cache)
         model = TreeEmbedding(constituency_parser, params['config'])
         model.load_state_dict(params['model'], strict=False)
         return model

--- a/stanza/models/ner/model.py
+++ b/stanza/models/ner/model.py
@@ -14,22 +14,21 @@ from stanza.models.common.dropout import WordDropout, LockedDropout
 from stanza.models.common.char_model import CharacterModel, CharacterLanguageModel
 from stanza.models.common.crf import CRFLoss
 from stanza.models.common.foundation_cache import load_bert
+from stanza.models.common.utils import attach_bert_model
 from stanza.models.common.vocab import PAD_ID, UNK_ID, EMPTY_ID
 from stanza.models.common.bert_embedding import extract_bert_embeddings
 
 logger = logging.getLogger('stanza')
 
+# this gets created in two places in trainer
+# in both places, pass in the bert model & tokenizer
 class NERTagger(nn.Module):
-    def __init__(self, args, vocab, emb_matrix=None, foundation_cache=None, force_bert_saved=False):
+    def __init__(self, args, vocab, emb_matrix=None, foundation_cache=None, bert_model=None, bert_tokenizer=None, force_bert_saved=False, peft_name=None):
         super().__init__()
 
         self.vocab = vocab
         self.args = args
         self.unsaved_modules = []
-
-        def add_unsaved_module(name, module):
-            self.unsaved_modules += [name]
-            setattr(self, name, module)
 
         # input layers
         input_size = 0
@@ -45,7 +44,7 @@ class NERTagger(nn.Module):
                 # if emb_finetune is off
                 # or if the delta embedding is present
                 # then we won't fine tune the original embedding
-                add_unsaved_module('word_emb', word_emb)
+                self.add_unsaved_module('word_emb', word_emb)
                 self.word_emb.weight.detach_()
             else:
                 self.word_emb = word_emb
@@ -68,10 +67,12 @@ class NERTagger(nn.Module):
 
             input_size += self.args['word_emb_dim']
 
-        # TODO: this, pos, depparse should all be refactored
+        self.peft_name = peft_name
+        attach_bert_model(self, bert_model, bert_tokenizer, self.args.get('use_peft', False), force_bert_saved)
         # FIXME: possibly pos and depparse are all losing a finetuned transformer if loaded & saved
         # (the force_bert_saved option here handles that)
         if self.args.get('bert_model', None):
+            # TODO: refactor bert_hidden_layers between the different models
             if args.get('bert_hidden_layers', False):
                 # The average will be offset by 1/N so that the default zeros
                 # represents an average of the N layers
@@ -81,26 +82,7 @@ class NERTagger(nn.Module):
                 # an average of layers 2, 3, 4 will be used
                 # (for historic reasons)
                 self.bert_layer_mix = None
-            # first we load the transformer model and possibly turn off its requires_grad parameters ...
-            if self.args.get('bert_finetune', False):
-                bert_model, bert_tokenizer = load_bert(self.args['bert_model'])
-            else:
-                bert_model, bert_tokenizer = load_bert(self.args['bert_model'], foundation_cache)
-                for n, p in bert_model.named_parameters():
-                    p.requires_grad = False
-            # then we attach it to the NER model
-            # if force_bert_saved is True, that probably indicates the save file had a transformer in it
-            # thus we need to save it again in the future to avoid losing it when resaving
-            if self.args.get('bert_finetune', False) or force_bert_saved:
-                self.bert_model = bert_model
-                add_unsaved_module('bert_tokenizer', bert_tokenizer)
-            else:
-                add_unsaved_module('bert_model', bert_model)
-                add_unsaved_module('bert_tokenizer', bert_tokenizer)
             input_size += self.bert_model.config.hidden_size
-        else:
-            self.bert_model = None
-            self.bert_tokenizer = None
 
         if self.args['char'] and self.args['char_emb_dim'] > 0:
             if self.args['charlm']:
@@ -108,8 +90,8 @@ class NERTagger(nn.Module):
                     raise ForwardCharlmNotFoundError('Could not find forward character model: {}  Please specify with --charlm_forward_file'.format(args['charlm_forward_file']), args['charlm_forward_file'])
                 if args['charlm_backward_file'] is None or not os.path.exists(args['charlm_backward_file']):
                     raise BackwardCharlmNotFoundError('Could not find backward character model: {}  Please specify with --charlm_backward_file'.format(args['charlm_backward_file']), args['charlm_backward_file'])
-                add_unsaved_module('charmodel_forward', CharacterLanguageModel.load(args['charlm_forward_file'], finetune=False))
-                add_unsaved_module('charmodel_backward', CharacterLanguageModel.load(args['charlm_backward_file'], finetune=False))
+                self.add_unsaved_module('charmodel_forward', CharacterLanguageModel.load(args['charlm_forward_file'], finetune=False))
+                self.add_unsaved_module('charmodel_backward', CharacterLanguageModel.load(args['charlm_backward_file'], finetune=False))
                 input_size += self.charmodel_forward.hidden_dim() + self.charmodel_backward.hidden_dim()
             else:
                 self.charmodel = CharacterModel(args, vocab, bidirectional=True, attention=False)
@@ -155,6 +137,10 @@ class NERTagger(nn.Module):
         assert emb_matrix.size() == (vocab_size, dim), \
             "Input embedding matrix must match size: {} x {}, found {}".format(vocab_size, dim, emb_matrix.size())
         self.word_emb.weight.data.copy_(emb_matrix)
+
+    def add_unsaved_module(self, name, module):
+        self.unsaved_modules += [name]
+        setattr(self, name, module)
 
     def log_norms(self):
         lines = ["NORMS FOR MODEL PARAMTERS"]
@@ -208,7 +194,8 @@ class NERTagger(nn.Module):
             device = next(self.parameters()).device
             processed_bert = extract_bert_embeddings(self.args['bert_model'], self.bert_tokenizer, self.bert_model, sentences, device, keep_endpoints=False,
                                                      num_layers=self.bert_layer_mix.in_features if self.bert_layer_mix is not None else None,
-                                                     detach=not self.args.get('bert_finetune', False))
+                                                     detach=not self.args.get('bert_finetune', False),
+                                                     peft_name=self.peft_name)
             if self.bert_layer_mix is not None:
                 # use a linear layer to weighted average the embedding dynamically
                 processed_bert = [self.bert_layer_mix(feature).squeeze(2) + feature.sum(axis=2) / self.bert_layer_mix.in_features for feature in processed_bert]

--- a/stanza/models/ner_tagger.py
+++ b/stanza/models/ner_tagger.py
@@ -105,6 +105,7 @@ def build_argparse():
     parser.add_argument('--max_steps_no_improve', type=int, default=2500, help='if the model doesn\'t improve after this many steps, give up or switch to new optimizer.')
     parser.add_argument('--eval_interval', type=int, default=500)
     parser.add_argument('--batch_size', type=int, default=32)
+    parser.add_argument('--max_batch_words', type=int, default=800, help='Long sentences can overwhelm even a large GPU when finetuning a transformer on otherwise reasonable batch sizes.  This cuts off those batches early')
     parser.add_argument('--max_grad_norm', type=float, default=5.0, help='Gradient clipping.')
     parser.add_argument('--log_step', type=int, default=20, help='Print log every k steps.')
     parser.add_argument('--log_norms', action='store_true', default=False, help='Log the norms of all the parameters (noisy!)')
@@ -249,7 +250,7 @@ def train(args):
     logger.info("Loaded %d sentences of training data", len(train_doc.sentences))
     if len(train_doc.sentences) == 0:
         raise ValueError("File %s exists but has no usable training data" % args['train_file'])
-    train_batch = DataLoader(train_doc, args['batch_size'], args, pretrain, vocab=vocab, evaluation=False, scheme=args.get('train_scheme'))
+    train_batch = DataLoader(train_doc, args['batch_size'], args, pretrain, vocab=vocab, evaluation=False, scheme=args.get('train_scheme'), max_batch_words=args['max_batch_words'])
     vocab = train_batch.vocab
     logger.info("Loading dev data from %s", args['eval_file'])
     with open(args['eval_file']) as fin:

--- a/stanza/tests/constituency/test_trainer.py
+++ b/stanza/tests/constituency/test_trainer.py
@@ -216,7 +216,8 @@ class TestTrainer:
 
         # check that the model can be loaded back
         assert os.path.exists(args['save_name'])
-        tr = trainer.Trainer.load(args['save_name'], load_optimizer=True, foundation_cache=retag_pipeline.foundation_cache)
+        peft_name = trained_model.model.peft_name
+        tr = trainer.Trainer.load(args['save_name'], load_optimizer=True, foundation_cache=retag_pipeline.foundation_cache, peft_name=trained_model.model.peft_name)
         assert tr.optimizer is not None
         assert tr.scheduler is not None
         assert tr.epochs_trained >= 1
@@ -224,7 +225,7 @@ class TestTrainer:
             if p.requires_grad:
                 assert p._backward_hooks is None
 
-        tr = trainer.Trainer.load(args['checkpoint_save_name'], load_optimizer=True, foundation_cache=retag_pipeline.foundation_cache)
+        tr = trainer.Trainer.load(args['checkpoint_save_name'], load_optimizer=True, foundation_cache=retag_pipeline.foundation_cache, peft_name=trained_model.model.peft_name)
         assert tr.optimizer is not None
         assert tr.scheduler is not None
         assert tr.epochs_trained == num_epochs
@@ -232,7 +233,7 @@ class TestTrainer:
         for i in range(1, num_epochs+1):
             model_name = each_name % i
             assert os.path.exists(model_name)
-            tr = trainer.Trainer.load(model_name, load_optimizer=True, foundation_cache=retag_pipeline.foundation_cache)
+            tr = trainer.Trainer.load(model_name, load_optimizer=True, foundation_cache=retag_pipeline.foundation_cache, peft_name=trained_model.model.peft_name)
             assert tr.epochs_trained == i
             assert tr.batches_trained == (4 * i if use_silver else 2 * i)
 


### PR DESCRIPTION
Rearrange the Pipeline to allow for multiple peft adapters on the same transformer, mostly by using named adapters for conparse and sentiment.  (POS, depparse, and NER would require their own names if we use peft for those)

At training time, the easiest solution is to use a separate transformer so that the optimizer is not cluttered up with peft adapters for other annotators, such as if POS is used to retag depparse or conparse