### PR TITLE
Drop dependency on tomli and prefer tomllib in the standard library for Python >= 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'protobuf>=3.15.0',
         'requests', 
         'networkx',
-        'tomli',
+        'tomli;python_version<"3.11"',
         'torch>=1.3.0',
         'tqdm',
     ],

--- a/stanza/models/coref/model.py
+++ b/stanza/models/coref/model.py
@@ -9,7 +9,10 @@ import re
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import numpy as np      # type: ignore
-import tomli
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 import torch
 import transformers     # type: ignore
 
@@ -635,7 +638,7 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
     def _load_config(config_path: str,
                      section: str) -> Config:
         with open(config_path, "rb") as fin:
-            config = tomli.load(fin)
+            config = tomllib.load(fin)
         default_section = config["DEFAULT"]
         current_section = config[section]
         unknown_keys = (set(current_section.keys())


### PR DESCRIPTION
## Description
This PR drops dependency on the 3rd-party package `tomli` and prefer `tomllib` (implementation based on `tomli`) added to the standard library in [PEP 680](https://peps.python.org/pep-0680/) for Python >= 3.11.

## Fixes Issues
Solves #1385, along with [this commit](https://github.com/stanfordnlp/stanza/commit/29880fea14d65978fd293dd5677e93bb9f832e6b).

## Unit test coverage
Are there unit tests in place to make sure your code is functioning correctly?
(see [here](https://github.com/stanfordnlp/stanza/blob/master/tests/test_tagger.py) for a simple example)
No.

## Known breaking changes/behaviors
No.
