### PR TITLE
Con oracle

### DIFF
--- a/stanza/models/constituency/dynamic_oracle.py
+++ b/stanza/models/constituency/dynamic_oracle.py
@@ -93,6 +93,13 @@ class DynamicOracle():
             if repair_type in self.deactivated_levels:
                 continue
             repair = repair_type.fn(gold_transition, pred_transition, gold_sequence, gold_index, self.root_labels)
+            if repair is None:
+                continue
+
+            if isinstance(repair, tuple) and len(repair) == 2:
+                return repair
+
+            # TODO: could update all of the returns to be tuples of length 2
             if repair is not None:
                 return repair_type, repair
 

--- a/stanza/models/constituency/dynamic_oracle.py
+++ b/stanza/models/constituency/dynamic_oracle.py
@@ -88,7 +88,7 @@ class DynamicOracle():
         for repair_type in self.repair_types:
             if repair_type.fn is None:
                 continue
-            if self.oracle_level is not None and repair_type.value > self.oracle_level and repair_type not in self.additional_levels:
+            if self.oracle_level is not None and repair_type.value > self.oracle_level and repair_type not in self.additional_levels and not repair_type.debug:
                 continue
             if repair_type in self.deactivated_levels:
                 continue

--- a/stanza/models/constituency/dynamic_oracle.py
+++ b/stanza/models/constituency/dynamic_oracle.py
@@ -16,6 +16,48 @@ def advance_past_constituents(gold_sequence, cur_index):
         cur_index = cur_index + 1
     return None
 
+def find_previous_open(gold_sequence, cur_index):
+    """
+    Go backwards from cur_index to find the open which opens the previous block of stuff.
+
+    Return None if it can't be found.
+    """
+    count = 0
+    cur_index = cur_index - 1
+    while cur_index >= 0:
+        if isinstance(gold_sequence[cur_index], OpenConstituent):
+            count = count + 1
+            if count > 0:
+                return cur_index
+        elif isinstance(gold_sequence[cur_index], CloseConstituent):
+            count = count - 1
+        cur_index = cur_index - 1
+    return None
+
+def find_in_order_constituent_end(gold_sequence, cur_index):
+    """
+    Advance cur_index through gold_sequence until the next block has ended
+
+    This is different from advance_past_constituents in that it will
+    also return when there is a Shift when count == 0.  That way, we
+    return the first block of things we know attach to the left
+    """
+    count = 0
+    saw_shift = False
+    while cur_index < len(gold_sequence):
+        if isinstance(gold_sequence[cur_index], OpenConstituent):
+            count = count + 1
+        elif isinstance(gold_sequence[cur_index], CloseConstituent):
+            count = count - 1
+            if count == -1: return cur_index
+        elif isinstance(gold_sequence[cur_index], Shift):
+            if saw_shift and count == 0:
+                return cur_index
+            else:
+                saw_shift = True
+        cur_index = cur_index + 1
+    return None
+
 class DynamicOracle():
     def __init__(self, root_labels, oracle_level, repair_types, additional_levels, deactivated_levels):
         self.root_labels = root_labels

--- a/stanza/models/constituency/ensemble.py
+++ b/stanza/models/constituency/ensemble.py
@@ -76,7 +76,7 @@ class Ensemble(nn.Module):
             if self.models[0].transition_scheme() != model.transition_scheme():
                 raise ValueError("Models {} and {} are incompatible.  {} vs {}".format(filenames[0], filenames[model_idx], self.models[0].transition_scheme(), model.transition_scheme()))
             if self.models[0].transitions != model.transitions:
-                raise ValueError("Models %s and %s are incompatible: different transitions" % (filenames[0], filenames[model_idx]))
+                raise ValueError(f"Models {filenames[0]} and {filenames[model_idx]} are incompatible: different transitions\n{filenames[0]}:\n{self.models[0].transitions}\n{filenames[model_idx]}:\n{model.transitions}")
             if self.models[0].constituents != model.constituents:
                 raise ValueError("Models %s and %s are incompatible: different constituents" % (filenames[0], filenames[model_idx]))
             if self.models[0].root_labels != model.root_labels:

--- a/stanza/models/constituency/in_order_compound_oracle.py
+++ b/stanza/models/constituency/in_order_compound_oracle.py
@@ -76,7 +76,7 @@ def fix_open_open_two_subtrees_error(gold_transition, pred_transition, gold_sequ
         return None
 
     # no fix is possible, so we just return here
-    return None
+    return RepairType.OPEN_OPEN_TWO_SUBTREES_ERROR, None
 
 def fix_open_open_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels, exactly_three):
     if gold_transition == pred_transition:
@@ -273,7 +273,7 @@ class RepairType(Enum):
     # but the correctly replaced transitions are unambiguous
     OPEN_OPEN_THREE_SUBTREES_ERROR         = (fix_open_open_three_subtrees_error,)
 
-    # this is ambiguous, but we can still try the same fix as three_subtrees
+    # this is ambiguous, but we can still try the same fix as three_subtrees (see above)
     OPEN_OPEN_MANY_SUBTREES_ERROR          = (fix_open_open_many_subtrees_error,)
 
     # We were supposed to shift a new item onto the stack,

--- a/stanza/models/constituency/in_order_compound_oracle.py
+++ b/stanza/models/constituency/in_order_compound_oracle.py
@@ -273,9 +273,6 @@ class RepairType(Enum):
     # but the correctly replaced transitions are unambiguous
     OPEN_OPEN_THREE_SUBTREES_ERROR         = (fix_open_open_three_subtrees_error,)
 
-    # this is ambiguous, but we can still try the same fix as three_subtrees (see above)
-    OPEN_OPEN_MANY_SUBTREES_ERROR          = (fix_open_open_many_subtrees_error,)
-
     # We were supposed to shift a new item onto the stack,
     # but instead we closed the previous constituent
     # This causes a precision error, but we can avoid the recall error
@@ -314,6 +311,9 @@ class RepairType(Enum):
     # however, what we can do to minimize further errors is
     # to at least reopen the label between X and Y
     OPEN_CLOSE_ERROR                       = (fix_open_close_error,)
+
+    # this is ambiguous, but we can still try the same fix as three_subtrees (see above)
+    OPEN_OPEN_MANY_SUBTREES_ERROR          = (fix_open_open_many_subtrees_error,)
 
     CORRECT                                = (None, True)
 

--- a/stanza/models/constituency/in_order_compound_oracle.py
+++ b/stanza/models/constituency/in_order_compound_oracle.py
@@ -212,7 +212,7 @@ class RepairType(Enum):
      +close_shift:              0.9266  0.9229
      +open_close:               0.9267  0.9256
     """
-    def __new__(cls, fn, correct=False):
+    def __new__(cls, fn, correct=False, debug=False):
         """
         Enumerate values as normal, but also keep a pointer to a function which repairs that kind of error
         """
@@ -221,6 +221,7 @@ class RepairType(Enum):
         obj._value_ = value + 1
         obj.fn = fn
         obj.correct = correct
+        obj.debug = debug
         return obj
 
     def is_correct(self):

--- a/stanza/models/constituency/in_order_compound_oracle.py
+++ b/stanza/models/constituency/in_order_compound_oracle.py
@@ -1,0 +1,325 @@
+from enum import Enum
+
+from stanza.models.constituency.dynamic_oracle import advance_past_constituents, find_in_order_constituent_end, find_previous_open, DynamicOracle
+from stanza.models.constituency.parse_transitions import Shift, OpenConstituent, CloseConstituent, CompoundUnary, Finalize
+
+def fix_missing_unary_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    """
+    A CompoundUnary transition was missed after a Shift, but the sequence was continued correctly otherwise
+    """
+    if not isinstance(gold_transition, CompoundUnary):
+        return None
+
+    if pred_transition != gold_sequence[gold_index + 1]:
+        return None
+    if isinstance(pred_transition, Finalize):
+        # this can happen if the entire tree is a single word
+        # but it can't be fixed if it means the parser missed the ROOT transition
+        return None
+
+    return gold_sequence[:gold_index] + gold_sequence[gold_index+1:]
+
+def fix_wrong_unary_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    if not isinstance(gold_transition, CompoundUnary):
+        return None
+
+    if not isinstance(pred_transition, CompoundUnary):
+        return None
+
+    assert gold_transition != pred_transition
+
+    return gold_sequence[:gold_index] + [pred_transition] + gold_sequence[gold_index+1:]
+
+def fix_spurious_unary_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    if isinstance(gold_transition, CompoundUnary):
+        return None
+
+    if not isinstance(pred_transition, CompoundUnary):
+        return None
+
+    return gold_sequence[:gold_index] + [pred_transition] + gold_sequence[gold_index:]
+
+def fix_open_shift_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    """
+    Fix a missed Open constituent where we predicted a Shift and the next transition was a Shift
+
+    In fact, the subsequent transition MUST be a Shift with this transition scheme
+    """
+    if not isinstance(gold_transition, OpenConstituent):
+        return None
+
+    if not isinstance(pred_transition, Shift):
+        return None
+
+    #if not isinstance(gold_sequence[gold_index+1], Shift):
+    #    return None
+    assert isinstance(gold_sequence[gold_index+1], Shift)
+
+    # close_index represents the Close for the missing Open
+    close_index = advance_past_constituents(gold_sequence, gold_index+1)
+    assert close_index is not None
+    return gold_sequence[:gold_index] + gold_sequence[gold_index+1:close_index] + gold_sequence[close_index+1:]
+
+def fix_open_open_two_subtrees_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    if gold_transition == pred_transition:
+        return None
+
+    if not isinstance(gold_transition, OpenConstituent):
+        return None
+    if not isinstance(pred_transition, OpenConstituent):
+        return None
+
+    block_end = find_in_order_constituent_end(gold_sequence, gold_index+1)
+    if isinstance(gold_sequence[block_end], Shift):
+        # this is a multiple subtrees version of this error
+        # we are only skipping the two subtrees errors for now
+        return None
+
+    # no fix is possible, so we just return here
+    return None
+
+def fix_open_open_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels, exactly_three):
+    if gold_transition == pred_transition:
+        return None
+
+    if not isinstance(gold_transition, OpenConstituent):
+        return None
+    if not isinstance(pred_transition, OpenConstituent):
+        return None
+
+    block_end = find_in_order_constituent_end(gold_sequence, gold_index+1)
+    if not isinstance(gold_sequence[block_end], Shift):
+        # this is a multiple subtrees version of this error
+        # we are only skipping the two subtrees errors for now
+        return None
+
+    next_block_end = find_in_order_constituent_end(gold_sequence, block_end+1)
+    if exactly_three and isinstance(gold_sequence[next_block_end], Shift):
+        # for exactly three subtrees,
+        # we can put back the missing open transition
+        # and now we have no recall error, only precision error
+        # for more than three, we separate that out as an ambiguous choice
+        return None
+    elif not exactly_three and isinstance(gold_sequence[next_block_end], CloseConstituent):
+        # this is ambiguous, but we can still try this fix
+        return None
+
+    # at this point, we build a new sequence with the origin constituent inserted
+    return gold_sequence[:gold_index] + [pred_transition] + gold_sequence[gold_index+1:block_end] + [CloseConstituent(), gold_transition] + gold_sequence[block_end:]
+
+
+def fix_open_open_three_subtrees_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    return fix_open_open_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels, exactly_three=True)
+
+def fix_open_open_many_subtrees_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    return fix_open_open_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels, exactly_three=False)
+
+def fix_open_close_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    """
+    Find the closed bracket, reopen it
+
+    The Open we just missed must be forgotten - it cannot be reopened
+    """
+    if not isinstance(gold_transition, OpenConstituent):
+        return None
+
+    if not isinstance(pred_transition, CloseConstituent):
+        return None
+
+    # find the appropriate Open so we can reopen it
+    open_idx = find_previous_open(gold_sequence, gold_index)
+    # actually, if the Close is legal, this can't happen
+    # but it might happen in a unit test which doesn't check legality
+    if open_idx is None:
+        return None
+
+    # also, since we are punting on the missed Open, we need to skip
+    # the Close which would have closed it
+    close_idx = advance_past_constituents(gold_sequence, gold_index+1)
+
+    return gold_sequence[:gold_index] + [pred_transition, gold_sequence[open_idx]] + gold_sequence[gold_index+1:close_idx] + gold_sequence[close_idx+1:]
+
+def fix_shift_close_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    """
+    Find the closed bracket, reopen it
+    """
+    if not isinstance(gold_transition, Shift):
+        return None
+
+    if not isinstance(pred_transition, CloseConstituent):
+        return None
+
+    # don't do this at the start or immediately after opening
+    if gold_index == 0 or isinstance(gold_sequence[gold_index - 1], OpenConstituent):
+        return None
+
+    open_idx = find_previous_open(gold_sequence, gold_index)
+    assert open_idx is not None
+
+    return gold_sequence[:gold_index] + [pred_transition, gold_sequence[open_idx]] + gold_sequence[gold_index:]
+
+def fix_shift_open_unambiguous_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    if not isinstance(gold_transition, Shift):
+        return None
+
+    if not isinstance(pred_transition, OpenConstituent):
+        return None
+
+    bracket_end = find_in_order_constituent_end(gold_sequence, gold_index)
+    assert bracket_end is not None
+    if isinstance(gold_sequence[bracket_end], Shift):
+        # this is an ambiguous error
+        # multiple possible places to end the wrong constituent
+        return None
+    assert isinstance(gold_sequence[bracket_end], CloseConstituent)
+
+    return gold_sequence[:gold_index] + [pred_transition] + gold_sequence[gold_index:bracket_end] + [CloseConstituent()] + gold_sequence[bracket_end:]
+
+def fix_close_shift_unambiguous_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    if not isinstance(gold_transition, CloseConstituent):
+        return None
+
+    if not isinstance(pred_transition, Shift):
+        return None
+    if not isinstance(gold_sequence[gold_index+1], Shift):
+        return None
+
+    bracket_end = find_in_order_constituent_end(gold_sequence, gold_index+1)
+    assert bracket_end is not None
+    if isinstance(gold_sequence[bracket_end], Shift):
+        # this is an ambiguous error
+        # multiple possible places to end the wrong constituent
+        return None
+    assert isinstance(gold_sequence[bracket_end], CloseConstituent)
+
+    return gold_sequence[:gold_index] + gold_sequence[gold_index+1:bracket_end] + [CloseConstituent()] + gold_sequence[bracket_end:]
+
+class RepairType(Enum):
+    """
+    Keep track of which repair is used, if any, on an incorrect transition
+
+    Effects of different repair types:
+      no oracle:                0.9251  0.9226
+     +missing_unary:            0.9246  0.9214
+     +wrong_unary:              0.9236  0.9213
+     +spurious_unary:           0.9247  0.9229
+     +open_shift_error:         0.9258  0.9226
+     +open_open_two_subtrees:   0.9256  0.9215    # nothing changes with this one...
+     +open_open_three_subtrees: 0.9256  0.9226
+     +open_open_many_subtrees:  0.9257  0.9234
+     +shift_close:              0.9267  0.9250
+     +shift_open:               0.9273  0.9247
+     +close_shift:              0.9266  0.9229
+     +open_close:               0.9267  0.9256
+    """
+    def __new__(cls, fn, correct=False):
+        """
+        Enumerate values as normal, but also keep a pointer to a function which repairs that kind of error
+        """
+        value = len(cls.__members__)
+        obj = object.__new__(cls)
+        obj._value_ = value + 1
+        obj.fn = fn
+        obj.correct = correct
+        return obj
+
+    def is_correct(self):
+        return self.correct
+
+    # The correct sequence went Shift - Unary - Stuff
+    # but the CompoundUnary was missed and Stuff predicted
+    # so now we just proceed as if nothing happened
+    # note that CompoundUnary happens immediately after a Shift
+    # complicated nodes are created with single Open transitions
+    MISSING_UNARY_ERROR                    = (fix_missing_unary_error,)
+
+    # Predicted a wrong CompoundUnary.  No way to fix this, so just keep going
+    WRONG_UNARY_ERROR                      = (fix_wrong_unary_error,)
+
+    # The correct sequence went Shift - Stuff
+    # but instead we predicted a CompoundUnary
+    # again, we just keep going
+    SPURIOUS_UNARY_ERROR                   = (fix_spurious_unary_error,)
+
+    # Were supposed to open a new constituent,
+    # but instead shifted an item onto the stack
+    #
+    # The missed Open cannot be recovered
+    #
+    # One could ask, is it possible to open a bigger constituent later,
+    # but if the constituent patterns go
+    #   X (good open) Y (missed open) Z
+    # when we eventually close Y and Z, because of the missed Open,
+    # it is guaranteed to capture X as well
+    # since it will grab constituents until one left of the previous Open before Y
+    #
+    # Therefore, in this case, we must simply forget about this Open (recall error)
+    OPEN_SHIFT_ERROR                       = (fix_open_shift_error,)
+
+    # With this transition scheme, it is not possible to fix the following pattern:
+    #   T1 O_x T2 C -> T1 O_y T2 C
+    # seeing as how there are no unary transitions
+    # so whatever precision & recall errors are caused by substituting O_x -> O_y
+    # (which could include multiple transitions)
+    # those errors are unfixable in any way
+    OPEN_OPEN_TWO_SUBTREES_ERROR           = (fix_open_open_two_subtrees_error,)
+
+    # With this transition scheme, a three subtree branch with a wrong Open
+    # has a non-ambiguous fix
+    #   T1 O_x T2 T3 C -> T1 O_y T2 T3 C
+    # this can become
+    #   T1 O_y T2 C O_x T3 C
+    # now there are precision errors from the incorrectly added transition(s),
+    # but the correctly replaced transitions are unambiguous
+    OPEN_OPEN_THREE_SUBTREES_ERROR         = (fix_open_open_three_subtrees_error,)
+
+    # this is ambiguous, but we can still try the same fix as three_subtrees
+    OPEN_OPEN_MANY_SUBTREES_ERROR          = (fix_open_open_many_subtrees_error,)
+
+    # We were supposed to shift a new item onto the stack,
+    # but instead we closed the previous constituent
+    # This causes a precision error, but we can avoid the recall error
+    # by immediately reopening the closed constituent.
+    SHIFT_CLOSE_ERROR                      = (fix_shift_close_error,)
+
+    # We opened a new constituent instead of shifting
+    # In the event that the next constituent ends with a close,
+    # rather than building another new constituent,
+    # then there is no ambiguity
+    SHIFT_OPEN_UNAMBIGUOUS_ERROR           = (fix_shift_open_unambiguous_error,)
+
+    # Suppose we were supposed to Close, then Shift
+    # but instead we just did a Shift
+    # Similar to shift_open_unambiguous, we now have an opened
+    # constituent which shouldn't be there
+    # We can scroll past the next constituent created to see
+    # if the outer constituents close at that point
+    # If so, we can close this constituent as well in an unambiguous manner
+    # TODO: analyze the case where we were supposed to Close, Open
+    # but instead did a Shift
+    CLOSE_SHIFT_UNAMBIGUOUS_ERROR          = (fix_close_shift_unambiguous_error,)
+
+    # Supposed to open a new constituent,
+    # instead closed an existing constituent
+    #
+    #  X (good open) Y (open -> close) Z
+    #
+    # the constituent that should contain Y, Z is unfortunately lost
+    # since now the stack has
+    #
+    #  XY ...
+    #
+    # furthermore, there is now a precision error for the extra XY
+    # constituent that should not exist
+    # however, what we can do to minimize further errors is
+    # to at least reopen the label between X and Y
+    OPEN_CLOSE_ERROR                       = (fix_open_close_error,)
+
+    CORRECT                                = (None, True)
+
+    UNKNOWN                                = None
+
+
+class InOrderCompoundOracle(DynamicOracle):
+    def __init__(self, root_labels, oracle_level, additional_oracle_levels, deactivated_oracle_levels):
+        super().__init__(root_labels, oracle_level, RepairType, additional_oracle_levels, deactivated_oracle_levels)

--- a/stanza/models/constituency/in_order_oracle.py
+++ b/stanza/models/constituency/in_order_oracle.py
@@ -469,15 +469,20 @@ class RepairType(Enum):
           close after first bracket        0.9265   0.9256
           close after last bracket         0.9264   0.9240
     """
-    def __new__(cls, fn, correct=False):
+    def __new__(cls, fn, correct=False, debug=False):
         """
         Enumerate values as normal, but also keep a pointer to a function which repairs that kind of error
+
+        correct: this represents a correct transition
+
+        debug: always run this, as it just counts statistics
         """
         value = len(cls.__members__)
         obj = object.__new__(cls)
         obj._value_ = value + 1
         obj.fn = fn
         obj.correct = correct
+        obj.debug = debug
         return obj
 
     def is_correct(self):
@@ -603,17 +608,17 @@ class RepairType(Enum):
     # as a unary transition or with a close at the end of the first constituent
     SHIFT_OPEN_LATE_CLOSE        = (ambiguous_shift_open_late_close,)
 
-    OTHER_CLOSE_SHIFT            = (report_close_shift,)
+    OTHER_CLOSE_SHIFT            = (report_close_shift, False, True)
 
-    OTHER_CLOSE_OPEN             = (report_close_open,)
+    OTHER_CLOSE_OPEN             = (report_close_open, False, True)
 
-    OTHER_OPEN_OPEN              = (report_open_open,)
+    OTHER_OPEN_OPEN              = (report_open_open, False, True)
 
-    OTHER_OPEN_CLOSE             = (report_open_close,)
+    OTHER_OPEN_CLOSE             = (report_open_close, False, True)
 
-    OTHER_OPEN_SHIFT             = (report_open_shift,)
+    OTHER_OPEN_SHIFT             = (report_open_shift, False, True)
 
-    OTHER_SHIFT_OPEN             = (report_shift_open,)
+    OTHER_SHIFT_OPEN             = (report_shift_open, False, True)
 
     # any other open transition we get wrong, which hasn't already
     # been carved out as an exception above, we just accept the

--- a/stanza/models/constituency/in_order_oracle.py
+++ b/stanza/models/constituency/in_order_oracle.py
@@ -362,6 +362,55 @@ def fix_close_shift_shift(gold_transition, pred_transition, gold_sequence, gold_
 
     return gold_sequence[:gold_index] + gold_sequence[start_index:end_index] + [CloseConstituent()] + gold_sequence[end_index:]
 
+
+def report_close_shift(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    if not isinstance(gold_transition, CloseConstituent):
+        return None
+    if not isinstance(pred_transition, Shift):
+        return None
+
+    return RepairType.OTHER_CLOSE_SHIFT, None
+
+def report_close_open(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    if not isinstance(gold_transition, CloseConstituent):
+        return None
+    if not isinstance(pred_transition, OpenConstituent):
+        return None
+
+    return RepairType.OTHER_CLOSE_OPEN, None
+
+def report_open_open(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    if not isinstance(gold_transition, OpenConstituent):
+        return None
+    if not isinstance(pred_transition, OpenConstituent):
+        return None
+
+    return RepairType.OTHER_OPEN_OPEN, None
+
+def report_open_shift(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    if not isinstance(gold_transition, OpenConstituent):
+        return None
+    if not isinstance(pred_transition, Shift):
+        return None
+
+    return RepairType.OTHER_OPEN_SHIFT, None
+
+def report_open_close(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    if not isinstance(gold_transition, OpenConstituent):
+        return None
+    if not isinstance(pred_transition, CloseConstituent):
+        return None
+
+    return RepairType.OTHER_OPEN_CLOSE, None
+
+def report_shift_open(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+    if not isinstance(gold_transition, Shift):
+        return None
+    if not isinstance(pred_transition, OpenConstituent):
+        return None
+
+    return RepairType.OTHER_SHIFT_OPEN, None
+
 class RepairType(Enum):
     """
     Keep track of which repair is used, if any, on an incorrect transition
@@ -506,6 +555,18 @@ class RepairType(Enum):
     # but keeps the O_x subtree correct
     # This is an ambiguous transition - we can experiment with different fixes
     WRONG_OPEN_MULTIPLE_SUBTREES = (fix_wrong_open_multiple_subtrees,)
+
+    OTHER_CLOSE_SHIFT            = (report_close_shift,)
+
+    OTHER_CLOSE_OPEN             = (report_close_open,)
+
+    OTHER_OPEN_OPEN              = (report_open_open,)
+
+    OTHER_OPEN_CLOSE             = (report_open_close,)
+
+    OTHER_OPEN_SHIFT             = (report_open_shift,)
+
+    OTHER_SHIFT_OPEN             = (report_shift_open,)
 
     CORRECT                = (None, True)
 

--- a/stanza/models/constituency/in_order_oracle.py
+++ b/stanza/models/constituency/in_order_oracle.py
@@ -393,7 +393,7 @@ def fix_close_shift_nested(gold_transition, pred_transition, gold_sequence, gold
 
     return gold_sequence[:gold_index] + gold_sequence[open_index+1:]
 
-def fix_close_shift_shift(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
+def fix_close_shift_shift_unambiguous(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
     """
     Repair Close/Shift -> Shift by moving the Close to after the next block is created
     """
@@ -642,20 +642,6 @@ class RepairType(Enum):
     #   T_A O_X T_B T_C C O_Y C
     CLOSE_SHIFT_UNAMBIGUOUS_BRACKET = (fix_close_shift_unambiguous_bracket,)
 
-    # If the model is supposed to build a block after a Close
-    # operation, attach that block to the piece to the left
-    # a couple different variations on this were tried
-    # we tried attaching all constituents to the
-    #   bracket which should have been closed
-    # we tried attaching exactly one constituent
-    # and we tried attaching only if there was
-    #   exactly one following constituent
-    # none of these improved f1.  for example, on the VI dataset, we
-    # lost 0.15 F1 with the exactly one following constituent version
-    # it might be worthwhile double checking some of the other
-    # versions to make sure those also fail, though
-    # CLOSE_SHIFT_SHIFT      = (fix_close_shift_shift,)
-
     # Similarly to WRONG_OPEN_TWO_SUBTREES, if the correct sequence is
     #   T1 O_x T2 T3 C
     # and instead we predicted
@@ -671,6 +657,20 @@ class RepairType(Enum):
     CORRECT                = (None, True)
 
     UNKNOWN                = None
+
+    # If the model is supposed to build a block after a Close
+    # operation, attach that block to the piece to the left
+    # a couple different variations on this were tried
+    # we tried attaching all constituents to the
+    #   bracket which should have been closed
+    # we tried attaching exactly one constituent
+    # and we tried attaching only if there was
+    #   exactly one following constituent
+    # none of these improved f1.  for example, on the VI dataset, we
+    # lost 0.15 F1 with the exactly one following constituent version
+    # it might be worthwhile double checking some of the other
+    # versions to make sure those also fail, though
+    CLOSE_SHIFT_SHIFT      = (fix_close_shift_shift_unambiguous,)
 
     # If a sequence should have gone Close - Open - Shift,
     # and instead we went Shift,

--- a/stanza/models/constituency/in_order_oracle.py
+++ b/stanza/models/constituency/in_order_oracle.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from stanza.models.constituency.dynamic_oracle import advance_past_constituents, DynamicOracle
+from stanza.models.constituency.dynamic_oracle import advance_past_constituents, find_in_order_constituent_end, find_previous_open, DynamicOracle
 from stanza.models.constituency.parse_transitions import Shift, OpenConstituent, CloseConstituent
 
 def fix_wrong_open_root_error(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
@@ -35,30 +35,6 @@ def fix_wrong_open_unary_chain(gold_transition, pred_transition, gold_sequence, 
 
     return None
 
-def find_constituent_end(gold_sequence, cur_index):
-    """
-    Advance cur_index through gold_sequence until the next block has ended
-
-    This is different from advance_past_constituents in that it will
-    also return when there is a Shift when count == 0.  That way, we
-    return the first block of things we know attach to the left
-    """
-    count = 0
-    saw_shift = False
-    while cur_index < len(gold_sequence):
-        if isinstance(gold_sequence[cur_index], OpenConstituent):
-            count = count + 1
-        elif isinstance(gold_sequence[cur_index], CloseConstituent):
-            count = count - 1
-            if count == -1: return cur_index
-        elif isinstance(gold_sequence[cur_index], Shift):
-            if saw_shift and count == 0:
-                return cur_index
-            else:
-                saw_shift = True
-        cur_index = cur_index + 1
-    return None
-
 def fix_wrong_open_subtrees(gold_transition, pred_transition, gold_sequence, gold_index, root_labels, more_than_two):
     if gold_transition == pred_transition:
         return None
@@ -74,7 +50,7 @@ def fix_wrong_open_subtrees(gold_transition, pred_transition, gold_sequence, gol
     assert not isinstance(gold_sequence[gold_index+1], OpenConstituent)
     assert isinstance(gold_sequence[gold_index+1], Shift)
 
-    block_end = find_constituent_end(gold_sequence, gold_index+1)
+    block_end = find_in_order_constituent_end(gold_sequence, gold_index+1)
     assert block_end is not None
 
     if more_than_two and isinstance(gold_sequence[block_end], CloseConstituent):
@@ -232,24 +208,6 @@ def fix_open_shift(gold_transition, pred_transition, gold_sequence, gold_index, 
     repair = gold_sequence[:gold_index] + gold_sequence[stuff_start:stuff_end] + gold_sequence[cur_index:]
     return repair
 
-def find_previous_open(gold_sequence, cur_index):
-    """
-    Go backwards from cur_index to find the open which opens the previous block of stuff.
-
-    Return None if it can't be found.
-    """
-    count = 0
-    cur_index = cur_index - 1
-    while cur_index >= 0:
-        if isinstance(gold_sequence[cur_index], OpenConstituent):
-            count = count + 1
-            if count > 0:
-                return cur_index
-        elif isinstance(gold_sequence[cur_index], CloseConstituent):
-            count = count - 1
-        cur_index = cur_index - 1
-    return None
-
 def fix_open_close(gold_transition, pred_transition, gold_sequence, gold_index, root_labels):
     """
     Fix an Open replaced with a Close
@@ -390,7 +348,7 @@ def fix_close_shift_shift(gold_transition, pred_transition, gold_sequence, gold_
     if not isinstance(gold_sequence[start_index], Shift):
         return None
 
-    end_index = find_constituent_end(gold_sequence, start_index)
+    end_index = find_in_order_constituent_end(gold_sequence, start_index)
     if end_index is None:
         return None
     # if this *isn't* a close, we don't allow it.

--- a/stanza/models/constituency/parse_transitions.py
+++ b/stanza/models/constituency/parse_transitions.py
@@ -16,39 +16,46 @@ from stanza.models.constituency.parse_tree import Tree
 logger = logging.getLogger('stanza')
 
 class TransitionScheme(Enum):
+    def __new__(cls, value, short_name):
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.short_name = short_name
+        return obj
+
+
     # top down, so the open transition comes before any constituents
     # score on vi_vlsp22 with 5 different sizes of bert layers,
     # bert tagger, no silver dataset:
     #   0.8171
-    TOP_DOWN           = 1
+    TOP_DOWN           = 1, "top"
     # unary transitions are modeled as one entire transition
     # version that uses one transform per item,
     # score on experiment described above:
     #   0.8157
     # score using one combination step for an entire transition:
     #   0.8178
-    TOP_DOWN_COMPOUND  = 2
+    TOP_DOWN_COMPOUND  = 2, "topc"
     # unary is a separate transition.  doesn't help
     # score on experiment described above:
     #   0.8128
-    TOP_DOWN_UNARY     = 3
+    TOP_DOWN_UNARY     = 3, "topu"
 
     # open transition comes after the first constituent it cares about
     # score on experiment described above:
     #   0.8205
     # note that this is with an oracle, whereas IN_ORDER_COMPOUND does
     # not have a dynamic oracle, so there may be room for improvement
-    IN_ORDER           = 4
+    IN_ORDER           = 4, "in"
 
     # in order, with unaries after preterminals represented as a single
     # transition after the preterminal
     # and unaries elsewhere tied to the rest of the constituent
     # score: 0.8186
-    IN_ORDER_COMPOUND  = 5
+    IN_ORDER_COMPOUND  = 5, "inc"
 
     # in order, with CompoundUnary on both preterminals and internal nodes
     # score: 0.8166
-    IN_ORDER_UNARY     = 6
+    IN_ORDER_UNARY     = 6, "inu"
 
 @functools.total_ordering
 class Transition(ABC):

--- a/stanza/models/constituency/parser_training.py
+++ b/stanza/models/constituency/parser_training.py
@@ -16,6 +16,7 @@ from stanza.models.common.large_margin_loss import LargeMarginInSoftmaxLoss
 from stanza.models.constituency import parse_transitions
 from stanza.models.constituency import transition_sequence
 from stanza.models.constituency import tree_reader
+from stanza.models.constituency.in_order_compound_oracle import InOrderCompoundOracle
 from stanza.models.constituency.in_order_oracle import InOrderOracle
 from stanza.models.constituency.lstm_model import LSTMModel
 from stanza.models.constituency.parse_transitions import TransitionScheme
@@ -379,6 +380,8 @@ def iterate_training(args, trainer, train_trees, train_sequences, transitions, d
     oracle = None
     if args['transition_scheme'] is TransitionScheme.IN_ORDER:
         oracle = InOrderOracle(trainer.root_labels, args['oracle_level'], args['additional_oracle_levels'], args['deactivated_oracle_levels'])
+    elif args['transition_scheme'] is TransitionScheme.IN_ORDER_COMPOUND:
+        oracle = InOrderCompoundOracle(trainer.root_labels, args['oracle_level'], args['additional_oracle_levels'], args['deactivated_oracle_levels'])
     elif args['transition_scheme'] is TransitionScheme.TOP_DOWN:
         oracle = TopDownOracle(trainer.root_labels, args['oracle_level'], args['additional_oracle_levels'], args['deactivated_oracle_levels'])
 

--- a/stanza/models/constituency/parser_training.py
+++ b/stanza/models/constituency/parser_training.py
@@ -224,7 +224,8 @@ def train(args, model_load_file, retag_pipeline):
 
         train_trees = tree_reader.read_treebank(args['train_file'])
         tlogger.info("Read %d trees for the training set", len(train_trees))
-        train_trees = remove_duplicate_trees(train_trees, "train")
+        if args['train_remove_duplicates']:
+            train_trees = remove_duplicate_trees(train_trees, "train")
         train_trees = remove_singleton_trees(train_trees)
 
         dev_trees = tree_reader.read_treebank(args['eval_file'])

--- a/stanza/models/constituency/parser_training.py
+++ b/stanza/models/constituency/parser_training.py
@@ -125,8 +125,8 @@ def build_trainer(args, train_trees, dev_trees, silver_trees, foundation_cache, 
     train_constituents = Tree.get_unique_constituent_labels(train_trees)
     tlogger.info("Unique constituents in training set: %s", train_constituents)
     if args['check_valid_states']:
-        check_constituents(train_constituents, dev_trees, "dev")
-        check_constituents(train_constituents, silver_trees, "silver")
+        check_constituents(train_constituents, dev_trees, "dev", fail=args['strict_check_constituents'])
+        check_constituents(train_constituents, silver_trees, "silver", fail=args['strict_check_constituents'])
     constituent_counts = Tree.get_constituent_counts(train_trees)
     tlogger.info("Constituent node counts: %s", constituent_counts)
 

--- a/stanza/models/constituency/parser_training.py
+++ b/stanza/models/constituency/parser_training.py
@@ -540,7 +540,7 @@ def train_model_one_epoch(epoch, trainer, transition_tensors, process_outputs, m
     tlogger.info("Transitions correct: %d\n  %s", total_correct, str(epoch_stats.transitions_correct))
     tlogger.info("Transitions incorrect: %d\n  %s", total_incorrect, str(epoch_stats.transitions_incorrect))
     if len(epoch_stats.repairs_used) > 0:
-        tlogger.info("Oracle repairs:\n  %s", epoch_stats.repairs_used)
+        tlogger.info("Oracle repairs:\n  %s", "\n  ".join("%s (%d): %d" % (x, x.value, y) for x, y in epoch_stats.repairs_used.most_common()))
     if epoch_stats.fake_transitions_used > 0:
         tlogger.info("Fake transitions used: %d", epoch_stats.fake_transitions_used)
 

--- a/stanza/models/constituency/top_down_oracle.py
+++ b/stanza/models/constituency/top_down_oracle.py
@@ -536,7 +536,7 @@ class RepairType(Enum):
        +open/open random       0.9257     0.9235
     so that didn't work great compared to the individual transitions
     """
-    def __new__(cls, fn, correct=False):
+    def __new__(cls, fn, correct=False, debug=False):
         """
         Enumerate values as normal, but also keep a pointer to a function which repairs that kind of error
         """
@@ -545,6 +545,7 @@ class RepairType(Enum):
         obj._value_ = value + 1
         obj.fn = fn
         obj.correct = correct
+        obj.debug = debug
         return obj
 
     def is_correct(self):

--- a/stanza/models/constituency/utils.py
+++ b/stanza/models/constituency/utils.py
@@ -329,7 +329,7 @@ def check_constituents(train_constituents, trees, treebank_name, fail=True):
                         first_error = tree_idx
             error = "Found constituent label {} in the {} set which don't exist in the train set.  This constituent label occured in {} trees, with the first tree index at {} counting from 1\nThe error tree (which may have POS tags changed from the retagger and may be missing functional tags or empty nodes) is:\n{:P}".format(con, treebank_name, num_errors, (first_error+1), trees[first_error])
             if fail:
-                raise RuntimeError()
+                raise RuntimeError(error)
             else:
                 warnings.warn(error)
 

--- a/stanza/models/constituency/utils.py
+++ b/stanza/models/constituency/utils.py
@@ -4,6 +4,7 @@ Collects a few of the conparser utility methods which don't belong elsewhere
 
 from collections import Counter
 import logging
+import warnings
 
 import torch.nn as nn
 from torch import optim
@@ -311,7 +312,7 @@ def verify_transitions(trees, sequences, transition_scheme, unary_limit, reverse
         if tree != result:
             raise RuntimeError("Tree {} of {} failed: transition sequence did not match for a tree!\nOriginal tree:{}\nTransitions: {}\nResult tree:{}".format(tree_idx, name, tree, sequence, result))
 
-def check_constituents(train_constituents, trees, treebank_name):
+def check_constituents(train_constituents, trees, treebank_name, fail=True):
     """
     Check that all the constituents in the other dataset are known in the train set
     """
@@ -326,7 +327,11 @@ def check_constituents(train_constituents, trees, treebank_name):
                     num_errors += 1
                     if first_error is None:
                         first_error = tree_idx
-            raise RuntimeError("Found constituent label {} in the {} set which don't exist in the train set.  This constituent label occured in {} trees, with the first tree index at {} counting from 1\nThe error tree (which may have POS tags changed from the retagger and may be missing functional tags or empty nodes) is:\n{:P}".format(con, treebank_name, num_errors, (first_error+1), trees[first_error]))
+            error = "Found constituent label {} in the {} set which don't exist in the train set.  This constituent label occured in {} trees, with the first tree index at {} counting from 1\nThe error tree (which may have POS tags changed from the retagger and may be missing functional tags or empty nodes) is:\n{:P}".format(con, treebank_name, num_errors, (first_error+1), trees[first_error])
+            if fail:
+                raise RuntimeError()
+            else:
+                warnings.warn(error)
 
 def check_root_labels(root_labels, other_trees, treebank_name):
     """

--- a/stanza/models/constituency_parser.py
+++ b/stanza/models/constituency_parser.py
@@ -703,6 +703,7 @@ def build_model_filename(args):
                                                finetune=maybe_finetune,
                                                transformer_finetune_begin=transformer_finetune_begin,
                                                transition_scheme=args['transition_scheme'].name.lower().replace("_", ""),
+                                               tscheme=args['transition_scheme'].short_name,
                                                trans_layers=args['bert_hidden_layers'],
                                                seed=args['seed'])
     model_save_file = re.sub("_+", "_", model_save_file)

--- a/stanza/models/constituency_parser.py
+++ b/stanza/models/constituency_parser.py
@@ -337,6 +337,7 @@ def build_argparse():
     parser.add_argument('--delta_embedding_dim', type=int, default=100, help="Embedding size for a delta embedding")
 
     parser.add_argument('--train_file', type=str, default=None, help='Input file for data loader.')
+    parser.add_argument('--no_train_remove_duplicates', default=True, action='store_false', dest="train_remove_duplicates", help="Do/don't remove duplicates from the training file.  Could be useful for intentionally reweighting some trees")
     parser.add_argument('--silver_file', type=str, default=None, help='Secondary training file.')
     parser.add_argument('--silver_remove_duplicates', default=False, action='store_true', help="Do/don't remove duplicates from the silver training file.  Could be useful for intentionally reweighting some trees")
     parser.add_argument('--eval_file', type=str, default=None, help='Input file for data loader.')

--- a/stanza/models/constituency_parser.py
+++ b/stanza/models/constituency_parser.py
@@ -430,6 +430,7 @@ def build_argparse():
     parser.add_argument('--seed', type=int, default=1234)
 
     parser.add_argument('--no_check_valid_states', default=True, action='store_false', dest='check_valid_states', help="Don't check the constituents or transitions in the dev set when starting a new parser.  Warning: the parser will never guess unknown constituents")
+    parser.add_argument('--no_strict_check_constituents', default=True, action='store_false', dest='strict_check_constituents', help="Don't check the constituents between the train & dev set.  May result in untrainable transitions")
     utils.add_device_args(parser)
 
     # Numbers are on a VLSP dataset, before adding attn or other improvements

--- a/stanza/tests/constituency/test_in_order_compound_oracle.py
+++ b/stanza/tests/constituency/test_in_order_compound_oracle.py
@@ -1,0 +1,93 @@
+import pytest
+
+from stanza.models.constituency import in_order_compound_oracle
+from stanza.models.constituency import tree_reader
+from stanza.models.constituency.parse_transitions import CloseConstituent, OpenConstituent, Shift, TransitionScheme
+from stanza.models.constituency.transition_sequence import build_treebank
+
+from stanza.tests.constituency.test_transition_sequence import reconstruct_tree
+
+pytestmark = [pytest.mark.pipeline, pytest.mark.travis]
+
+# A sample tree from PTB with a triple unary transition (at a location other than root)
+# Here we test the incorrect closing of various brackets
+TRIPLE_UNARY_START_TREE = """
+( (S
+    (PRN
+      (S
+        (NP-SBJ (-NONE- *) )
+        (VP (VB See) )))
+    (, ,)
+    (NP-SBJ
+      (NP (DT the) (JJ other) (NN rule) )
+      (PP (IN of)
+        (NP (NN thumb) ))
+      (PP (IN about)
+        (NP (NN ballooning) )))))
+"""
+
+TREES = [TRIPLE_UNARY_START_TREE]
+TREEBANK = "\n".join(TREES)
+
+ROOT_LABELS = ["ROOT"]
+
+@pytest.fixture(scope="module")
+def trees():
+    trees = tree_reader.read_trees(TREEBANK)
+    trees = [t.prune_none().simplify_labels() for t in trees]
+    assert len(trees) == len(TREES)
+
+    return trees
+
+@pytest.fixture(scope="module")
+def gold_sequences(trees):
+    gold_sequences = build_treebank(trees, TransitionScheme.IN_ORDER_COMPOUND)
+    return gold_sequences
+
+def get_repairs(gold_sequence, wrong_transition, repair_fn):
+    """
+    Use the repair function and the wrong transition to iterate over the gold sequence
+
+    Returns a list of possible repairs, one for each position in the sequence
+    Repairs are tuples, (idx, seq)
+    """
+    repairs = [(idx, repair_fn(gold_transition, wrong_transition, gold_sequence, idx, ROOT_LABELS))
+               for idx, gold_transition in enumerate(gold_sequence)]
+    repairs = [x for x in repairs if x[1] is not None]
+    return repairs
+
+def test_fix_shift_close():
+    trees = tree_reader.read_trees(TRIPLE_UNARY_START_TREE)
+    trees = [t.prune_none().simplify_labels() for t in trees]
+    assert len(trees) == 1
+    tree = trees[0]
+
+    gold_sequences = build_treebank(trees, TransitionScheme.IN_ORDER_COMPOUND)
+
+    # there are three places in this tree where a long bracket (more than 2 subtrees)
+    # could theoretically be closed and then reopened
+    repairs = get_repairs(gold_sequences[0], CloseConstituent(), in_order_compound_oracle.fix_shift_close_error)
+    assert len(repairs) == 3
+
+    expected_trees = ["(ROOT (S (S (PRN (S (VP (VB See)))) (, ,)) (NP (NP (DT the) (JJ other) (NN rule)) (PP (IN of) (NP (NN thumb))) (PP (IN about) (NP (NN ballooning))))))",
+                      "(ROOT (S (PRN (S (VP (VB See)))) (, ,) (NP (NP (NP (DT the) (JJ other)) (NN rule)) (PP (IN of) (NP (NN thumb))) (PP (IN about) (NP (NN ballooning))))))",
+                      "(ROOT (S (PRN (S (VP (VB See)))) (, ,) (NP (NP (NP (DT the) (JJ other) (NN rule)) (PP (IN of) (NP (NN thumb)))) (PP (IN about) (NP (NN ballooning))))))"]
+
+    for repair, expected in zip(repairs, expected_trees):
+        repaired_tree = reconstruct_tree(tree, repair[1], transition_scheme=TransitionScheme.IN_ORDER_COMPOUND)
+        assert str(repaired_tree) == expected
+
+def test_fix_open_close():
+    trees = tree_reader.read_trees(TRIPLE_UNARY_START_TREE)
+    trees = [t.prune_none().simplify_labels() for t in trees]
+    assert len(trees) == 1
+    tree = trees[0]
+
+    gold_sequences = build_treebank(trees, TransitionScheme.IN_ORDER_COMPOUND)
+
+    repairs = get_repairs(gold_sequences[0], CloseConstituent(), in_order_compound_oracle.fix_open_close_error)
+    print("------------------")
+    for repair in repairs:
+        print(repair)
+        repaired_tree = reconstruct_tree(tree, repair[1], transition_scheme=TransitionScheme.IN_ORDER_COMPOUND)
+        print("{:P}".format(repaired_tree))

--- a/stanza/tests/constituency/test_in_order_oracle.py
+++ b/stanza/tests/constituency/test_in_order_oracle.py
@@ -366,6 +366,62 @@ def test_close_shift_nested(unary_trees, gold_sequences):
                 result_tree = reconstruct_tree(tree, repair[1])
                 assert str(result_tree) == expected[repair[0]]
 
+def check_repairs(trees, gold_sequences, expected_trees, transition, repair_fn):
+    for tree_idx, (gold_tree, gold_sequence, expected) in enumerate(zip(trees, gold_sequences, expected_trees)):
+        repairs = get_repairs(gold_sequence, transition, repair_fn)
+        if expected is not None:
+            assert len(repairs) == len(expected)
+            for repair in repairs:
+                assert repair[0] in expected
+                result_tree = reconstruct_tree(gold_tree, repair[1])
+                assert str(result_tree) == expected[repair[0]]
+        else:
+            print("---------------------")
+            print("{:P}".format(gold_tree))
+            print(gold_sequence)
+            #print(repairs)
+            for repair in repairs:
+                print("---------------------")
+                print(gold_sequence)
+                print(repair[1])
+                result_tree = reconstruct_tree(gold_tree, repair[1])
+                print("{:P}".format(gold_tree))
+                print("{:P}".format(result_tree))
+                print(tree_idx)
+                print(repair[0])
+                print(result_tree)
+
+def test_close_shift_unambiguous(unary_trees, gold_sequences):
+    shift_transition = Shift()
+
+    expected_trees = [{},
+                      {8: "(ROOT (S (NP (NP (RB Not) (PDT all) (DT those)) (SBAR (WHNP (WP who) (S (VP (VBD wrote)))))) (VP (VBP oppose) (NP (DT the) (NNS changes))) (. .)))"},
+                      {},
+                      {2: "(ROOT (S (NP (NNS optimists) (VP (VBP expect) (S (NP (NNP Hong) (NNP Kong)) (VP (TO to) (VP (VB hum) (ADVP (RB along)) (SBAR (RB as) (S (VP (ADVP (IN before))))))))))))",
+                       9: "(ROOT (S (NP (NNS optimists)) (VP (VBP expect) (S (NP (NNP Hong) (NNP Kong) (VP (TO to) (VP (VB hum) (ADVP (RB along)) (SBAR (RB as) (S (VP (ADVP (IN before))))))))))))"}]
+    check_repairs(unary_trees, gold_sequences, expected_trees, shift_transition, fix_close_shift_unambiguous_bracket)
+
+def test_close_shift_ambiguous_early(unary_trees, gold_sequences):
+    shift_transition = Shift()
+
+    expected_trees = [{4: "(ROOT (S (NP (DT A) (NN record) (NN date) (VP (VBZ has) (RB n't) (VP (VBN been) (VP (VBN set))))) (. .)))"},
+                      {16: "(ROOT (S (NP (NP (RB Not) (PDT all) (DT those)) (SBAR (WHNP (WP who)) (S (VP (VBD wrote)))) (VP (VBP oppose) (NP (DT the) (NNS changes)))) (. .)))"},
+                      {2: "(ROOT (S (PRN (S (VP (VB See) (, ,)))) (NP (NP (DT the) (JJ other) (NN rule)) (PP (IN of) (NP (NN thumb))) (PP (IN about) (NP (NN ballooning))))))",
+                       6: "(ROOT (S (PRN (S (VP (VB See))) (, ,)) (NP (NP (DT the) (JJ other) (NN rule)) (PP (IN of) (NP (NN thumb))) (PP (IN about) (NP (NN ballooning))))))"},
+                      {}]
+    check_repairs(unary_trees, gold_sequences, expected_trees, shift_transition, fix_close_shift_ambiguous_bracket_early)
+
+def test_close_shift_ambiguous_late(unary_trees, gold_sequences):
+    shift_transition = Shift()
+
+    expected_trees = [{4: "(ROOT (S (NP (DT A) (NN record) (NN date) (VP (VBZ has) (RB n't) (VP (VBN been) (VP (VBN set)))) (. .))))"},
+                      {16: "(ROOT (S (NP (NP (RB Not) (PDT all) (DT those)) (SBAR (WHNP (WP who)) (S (VP (VBD wrote)))) (VP (VBP oppose) (NP (DT the) (NNS changes))) (. .))))"},
+                      {2: "(ROOT (S (PRN (S (VP (VB See) (, ,) (NP (NP (DT the) (JJ other) (NN rule)) (PP (IN of) (NP (NN thumb))) (PP (IN about) (NP (NN ballooning)))))))))",
+                       6: "(ROOT (S (PRN (S (VP (VB See))) (, ,) (NP (NP (DT the) (JJ other) (NN rule)) (PP (IN of) (NP (NN thumb))) (PP (IN about) (NP (NN ballooning)))))))"},
+                      {}]
+    check_repairs(unary_trees, gold_sequences, expected_trees, shift_transition, fix_close_shift_ambiguous_bracket_late)
+
+
 def test_close_shift_shift(unary_trees):
     """
     Test that close -> shift works when there is a single block shifted after

--- a/stanza/tests/constituency/test_in_order_oracle.py
+++ b/stanza/tests/constituency/test_in_order_oracle.py
@@ -353,16 +353,18 @@ def test_close_shift_nested(unary_trees, gold_sequences):
 
     expected_trees = [{},
                       {4: "(ROOT (S (NP (RB Not) (PDT all) (DT those) (SBAR (WHNP (WP who)) (S (VP (VBD wrote))))) (VP (VBP oppose) (NP (DT the) (NNS changes))) (. .)))"},
-                      {13: "(ROOT (S (PRN (S (VP (VB See)))) (, ,) (NP (DT the) (JJ other) (NN rule) (PP (IN of) (NP (NN thumb))) (PP (IN about) (NP (NN ballooning))))))"},
+                      {4: "(ROOT (S (VP (VB See)) (, ,) (NP (NP (DT the) (JJ other) (NN rule)) (PP (IN of) (NP (NN thumb))) (PP (IN about) (NP (NN ballooning))))))",
+                       13: "(ROOT (S (PRN (S (VP (VB See)))) (, ,) (NP (DT the) (JJ other) (NN rule) (PP (IN of) (NP (NN thumb))) (PP (IN about) (NP (NN ballooning))))))"},
                       {}]
 
     for tree, gold_sequence, expected in zip(unary_trees, gold_sequences, expected_trees):
         repairs = get_repairs(gold_sequence, shift_transition, fix_close_shift_nested)
         assert len(repairs) == len(expected)
-        if len(expected) == 1:
-            assert repairs[0][0] in expected.keys()
-            result_tree = reconstruct_tree(tree, repairs[0][1])
-            assert str(result_tree) == expected[repairs[0][0]]
+        if len(expected) >= 1:
+            for repair in repairs:
+                assert repair[0] in expected.keys()
+                result_tree = reconstruct_tree(tree, repair[1])
+                assert str(result_tree) == expected[repair[0]]
 
 def test_close_shift_shift(unary_trees):
     """

--- a/stanza/tests/constituency/test_in_order_oracle.py
+++ b/stanza/tests/constituency/test_in_order_oracle.py
@@ -475,3 +475,48 @@ def test_close_shift_shift(unary_trees, wide_trees):
     gold_sequences = build_treebank(test_trees, TransitionScheme.IN_ORDER)
 
     check_repairs(test_trees, gold_sequences, expected_trees, shift_transition, fix_close_shift_shift_unambiguous)
+
+
+def test_close_shift_shift_early(unary_trees, wide_trees):
+    """
+    Test that close -> shift works when there are multiple blocks shifted after
+
+    Also checks that the single block case is skipped, so as to keep them separate when testing
+
+    A tree with the expected property was specifically added for this test
+    """
+    shift_transition = Shift()
+
+    test_trees = unary_trees + wide_trees
+    gold_sequences = build_treebank(test_trees, TransitionScheme.IN_ORDER)
+
+    expected_trees = [{},
+                      {},
+                      {},
+                      {},
+                      {},
+                      {21: "(ROOT (S (NP (DT These) (NNS studies)) (VP (VBP demonstrate) (SBAR (IN that) (S (NP (NNS mice)) (VP (VBP are) (NP (NP (DT a) (ADJP (JJ practical) (CC and) (JJ powerful) (JJ experimental)) (NN system)) (SBAR (S (VP (TO to) (VP (VB study) (NP (DT the) (NN genetics)))))))))))))"}]
+
+    check_repairs(test_trees, gold_sequences, expected_trees, shift_transition, fix_close_shift_shift_ambiguous_early)
+
+def test_close_shift_shift_late(unary_trees, wide_trees):
+    """
+    Test that close -> shift works when there are multiple blocks shifted after
+
+    Also checks that the single block case is skipped, so as to keep them separate when testing
+
+    A tree with the expected property was specifically added for this test
+    """
+    shift_transition = Shift()
+
+    test_trees = unary_trees + wide_trees
+    gold_sequences = build_treebank(test_trees, TransitionScheme.IN_ORDER)
+
+    expected_trees = [{},
+                      {},
+                      {},
+                      {},
+                      {},
+                      {21: "(ROOT (S (NP (DT These) (NNS studies)) (VP (VBP demonstrate) (SBAR (IN that) (S (NP (NNS mice)) (VP (VBP are) (NP (NP (DT a) (ADJP (JJ practical) (CC and) (JJ powerful) (JJ experimental) (NN system))) (SBAR (S (VP (TO to) (VP (VB study) (NP (DT the) (NN genetics)))))))))))))"}]
+
+    check_repairs(test_trees, gold_sequences, expected_trees, shift_transition, fix_close_shift_shift_ambiguous_late)

--- a/stanza/tests/constituency/test_in_order_oracle.py
+++ b/stanza/tests/constituency/test_in_order_oracle.py
@@ -444,7 +444,7 @@ def test_close_shift_shift(unary_trees):
     gold_sequences = build_treebank(test_trees, TransitionScheme.IN_ORDER)
 
     for tree, gold_sequence, expected_repairs in zip(test_trees, gold_sequences, expected_trees):
-        repairs = get_repairs(gold_sequence, shift_transition, fix_close_shift_shift)
+        repairs = get_repairs(gold_sequence, shift_transition, fix_close_shift_shift_unambiguous)
         assert len(repairs) == len(expected_repairs)
         for repair, expected in zip(repairs, expected_repairs):
             assert repair[0] == expected[0]

--- a/stanza/tests/constituency/test_in_order_oracle.py
+++ b/stanza/tests/constituency/test_in_order_oracle.py
@@ -430,11 +430,11 @@ def test_close_shift_shift(unary_trees):
     """
     shift_transition = Shift()
 
-    expected_trees = [[(15, "(ROOT (S (NP (DT A) (NN record) (NN date)) (VP (VBZ has) (RB n't) (VP (VBN been) (VP (VBN set))) (. .))))")],
-                      [(24, "(ROOT (S (NP (NP (RB Not) (PDT all) (DT those)) (SBAR (WHNP (WP who)) (S (VP (VBD wrote))))) (VP (VBP oppose) (NP (DT the) (NNS changes)) (. .))))")],
-                      [(20, "(ROOT (S (PRN (S (VP (VB See)))) (, ,) (NP (NP (DT the) (JJ other) (NN rule)) (PP (IN of) (NP (NN thumb)) (PP (IN about) (NP (NN ballooning)))))))")],
-                      [(17, "(ROOT (S (NP (NNS optimists)) (VP (VBP expect) (S (NP (NNP Hong) (NNP Kong)) (VP (TO to) (VP (VB hum) (ADVP (RB along) (SBAR (RB as) (S (VP (ADVP (IN before))))))))))))")],
-                      []]
+    expected_trees = [{15: "(ROOT (S (NP (DT A) (NN record) (NN date)) (VP (VBZ has) (RB n't) (VP (VBN been) (VP (VBN set))) (. .))))"},
+                      {24: "(ROOT (S (NP (NP (RB Not) (PDT all) (DT those)) (SBAR (WHNP (WP who)) (S (VP (VBD wrote))))) (VP (VBP oppose) (NP (DT the) (NNS changes)) (. .))))"},
+                      {20: "(ROOT (S (PRN (S (VP (VB See)))) (, ,) (NP (NP (DT the) (JJ other) (NN rule)) (PP (IN of) (NP (NN thumb)) (PP (IN about) (NP (NN ballooning)))))))"},
+                      {17: "(ROOT (S (NP (NNS optimists)) (VP (VBP expect) (S (NP (NNP Hong) (NNP Kong)) (VP (TO to) (VP (VB hum) (ADVP (RB along) (SBAR (RB as) (S (VP (ADVP (IN before))))))))))))"},
+                      {}]
 
     np_trees = tree_reader.read_trees(NOUN_PHRASE_TREE)
     np_trees = [t.prune_none().simplify_labels() for t in np_trees]
@@ -443,11 +443,4 @@ def test_close_shift_shift(unary_trees):
     test_trees = unary_trees + np_trees
     gold_sequences = build_treebank(test_trees, TransitionScheme.IN_ORDER)
 
-    for tree, gold_sequence, expected_repairs in zip(test_trees, gold_sequences, expected_trees):
-        repairs = get_repairs(gold_sequence, shift_transition, fix_close_shift_shift_unambiguous)
-        assert len(repairs) == len(expected_repairs)
-        for repair, expected in zip(repairs, expected_repairs):
-            assert repair[0] == expected[0]
-            result_tree = reconstruct_tree(tree, repair[1])
-            assert str(result_tree) == expected[1]
-
+    check_repairs(test_trees, gold_sequences, expected_trees, shift_transition, fix_close_shift_shift_unambiguous)

--- a/stanza/utils/constituency/grep_dev_logs.py
+++ b/stanza/utils/constituency/grep_dev_logs.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+
+iteration = sys.argv[1]
+filenames = sys.argv[2:]
+
+total_score = 0.0
+num_scores = 0
+
+for filename in filenames:
+    grep_cmd = ["grep", "Dev score.* %s[)]" % iteration, "-A1", filename]
+    grep_result = subprocess.run(grep_cmd, stdout=subprocess.PIPE, encoding="utf-8")
+    grep_result = grep_result.stdout.strip()
+    if not grep_result:
+        max_cmd = ["grep", "Dev score", filename]
+        max_result = subprocess.run(max_cmd, stdout=subprocess.PIPE, encoding="utf-8")
+        max_result = max_result.stdout.strip()
+        if not max_result:
+            print("{}: no result".format(filename))
+        else:
+            max_it = max_result.split("\n")[-1]
+            max_it = int(max_it.split(":")[0].split("(")[-1][:-1])
+            epoch_finished_string = "Epoch %d finished" % max_it
+            finish_cmd = ["grep", epoch_finished_string, filename]
+            finish_result = subprocess.run(finish_cmd, stdout=subprocess.PIPE, encoding="utf-8")
+            finish_result = finish_result.stdout.strip()
+            finish_time = finish_result.split(" INFO")[0]
+            print("{}: no result.  max iteration: {}   finished at {}".format(filename, max_it, finish_time))
+    else:
+        grep_result = grep_result.split("\n")[-1]
+        score = float(grep_result.split(":")[-1])
+        best_iteration = int(grep_result.split(":")[-2][-6:-1])
+        print("{}: {}  ({})".format(filename, score, best_iteration))
+        total_score += score
+        num_scores += 1
+
+if num_scores > 0:
+    avg = total_score / num_scores
+    print("Avg: {}".format(avg))
+

--- a/stanza/utils/constituency/grep_test_logs.py
+++ b/stanza/utils/constituency/grep_test_logs.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+
+filenames = sys.argv[1:]
+
+total_score = 0.0
+num_scores = 0
+
+for filename in filenames:
+    grep_cmd = ["grep", "F1 score.*test.*", filename]
+    grep_result = subprocess.run(grep_cmd, stdout=subprocess.PIPE, encoding="utf-8")
+    grep_result = grep_result.stdout.strip()
+    if not grep_result:
+        print("{}: no result".format(filename))
+        continue
+
+    score = float(grep_result.split()[-1])
+    print("{}: {}".format(filename, score))
+    total_score += score
+    num_scores += 1
+
+if num_scores > 0:
+    avg = total_score / num_scores
+    print("Avg: {}".format(avg))

--- a/stanza/utils/datasets/constituency/split_holdout.py
+++ b/stanza/utils/datasets/constituency/split_holdout.py
@@ -1,0 +1,70 @@
+"""
+Split a constituency dataset randomly into 90/10 splits
+
+TODO: add a function to rotate the pieces of the split so that each
+training instance gets seen once
+"""
+
+import argparse
+import os
+import random
+import shutil
+
+from stanza.models.constituency import tree_reader
+from stanza.utils.default_paths import get_default_paths
+
+def copy_dev_test(base_path, input_dataset, output_dataset):
+    shutil.copy2(os.path.join(base_path, "%s_dev.mrg" % input_dataset),
+                 os.path.join(base_path, "%s_dev.mrg" % output_dataset))
+    shutil.copy2(os.path.join(base_path, "%s_test.mrg" % input_dataset),
+                 os.path.join(base_path, "%s_test.mrg" % output_dataset))
+
+def write_trees(base_path, dataset_name, trees):
+    output_path = os.path.join(base_path, "%s_train.mrg" % dataset_name)
+    with open(output_path, "w", encoding="utf-8") as fout:
+        for tree in trees:
+            fout.write("%s\n" % tree)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Split a standard dataset into 90/10 proportions of train so there is held out training data")
+    parser.add_argument('--dataset', type=str, default="id_icon", help='dataset to split')
+    parser.add_argument('--base_dataset', type=str, default=None, help='output name for base dataset')
+    parser.add_argument('--holdout_dataset', type=str, default=None, help='output name for holdout dataset')
+    parser.add_argument('--ratio', type=float, default=0.1, help='Number of trees to hold out')
+    parser.add_argument('--seed', type=int, default=1234, help='Random seed')
+    args = parser.parse_args()
+
+    if args.base_dataset is None:
+        args.base_dataset = args.dataset + "-base"
+        print("--base_dataset not set, using %s" % args.base_dataset)
+
+    if args.holdout_dataset is None:
+        args.holdout_dataset = args.dataset + "-holdout"
+        print("--holdout_dataset not set, using %s" % args.holdout_dataset)
+
+    base_path = get_default_paths()["CONSTITUENCY_DATA_DIR"]
+    copy_dev_test(base_path, args.dataset, args.base_dataset)
+    copy_dev_test(base_path, args.dataset, args.holdout_dataset)
+
+    train_file = os.path.join(base_path, "%s_train.mrg" % args.dataset)
+    print("Reading %s" % train_file)
+    trees = tree_reader.read_tree_file(train_file)
+
+    base_train = []
+    holdout_train = []
+
+    random.seed(args.seed)
+
+    for tree in trees:
+        if random.random() < args.ratio:
+            holdout_train.append(tree)
+        else:
+            base_train.append(tree)
+
+    write_trees(base_path, args.base_dataset, base_train)
+    write_trees(base_path, args.holdout_dataset, holdout_train)
+
+if __name__ == '__main__':
+    main()
+

--- a/stanza/utils/datasets/constituency/split_holdout.py
+++ b/stanza/utils/datasets/constituency/split_holdout.py
@@ -8,16 +8,10 @@ training instance gets seen once
 import argparse
 import os
 import random
-import shutil
 
 from stanza.models.constituency import tree_reader
+from stanza.utils.datasets.constituency.utils import copy_dev_test
 from stanza.utils.default_paths import get_default_paths
-
-def copy_dev_test(base_path, input_dataset, output_dataset):
-    shutil.copy2(os.path.join(base_path, "%s_dev.mrg" % input_dataset),
-                 os.path.join(base_path, "%s_dev.mrg" % output_dataset))
-    shutil.copy2(os.path.join(base_path, "%s_test.mrg" % input_dataset),
-                 os.path.join(base_path, "%s_test.mrg" % output_dataset))
 
 def write_trees(base_path, dataset_name, trees):
     output_path = os.path.join(base_path, "%s_train.mrg" % dataset_name)

--- a/stanza/utils/datasets/constituency/utils.py
+++ b/stanza/utils/datasets/constituency/utils.py
@@ -3,10 +3,17 @@ Utilities for the processing of constituency treebanks
 """
 
 import os
+import shutil
 
 from stanza.models.constituency import parse_tree
 
 SHARDS = ("train", "dev", "test")
+
+def copy_dev_test(base_path, input_dataset, output_dataset):
+    shutil.copy2(os.path.join(base_path, "%s_dev.mrg" % input_dataset),
+                 os.path.join(base_path, "%s_dev.mrg" % output_dataset))
+    shutil.copy2(os.path.join(base_path, "%s_test.mrg" % input_dataset),
+                 os.path.join(base_path, "%s_test.mrg" % output_dataset))
 
 def write_dataset(datasets, output_dir, dataset_name):
     for dataset, shard in zip(datasets, SHARDS):


### PR DESCRIPTION
Add an oracle for the in-order-compound transition scheme, along with extensive upgrades to the in-order oracle (although the accuracy gainz are of course not earth-shattering) and some instrumentation such as the ability to add dummy oracle transitions which log the misses in the in-order system.

As incidental changes, include a script to go through the current formatting of conparse results (not expected to change) and some scripts to experiment with different data divisions for building the ensemble.  Spoiler: none of the ensemble mechanisms actually helped improve results over just averaging 5 models together