### PR TITLE
multilingual coreference and singletons support

### DIFF
--- a/stanza/models/coref/bert.py
+++ b/stanza/models/coref/bert.py
@@ -44,8 +44,12 @@ def get_subwords_batches(doc: Doc,
             while end and doc["sent_id"][doc["word_id"][end - 1]] == sent_id:
                 end -= 1
 
-        # if we ended up at prev end, well, looks like we will
-        # just chop off the sentence
+        # this occurs IFF there was no sentence end found throughout
+        # the forward scan; this means that our sentence was waay too
+        # long (i.e. longer than the max length of the transformer.
+        #
+        # if so, we give up and just chop the sentence off at the max length
+        # that was given
         if end == prev_end:
             end = min(end + batch_size, len(subwords))
 

--- a/stanza/models/coref/bert.py
+++ b/stanza/models/coref/bert.py
@@ -32,6 +32,10 @@ def get_subwords_batches(doc: Doc,
     start, end = 0, 0
 
     while end < len(subwords):
+        # to prevent the case where a batch_size step forward
+        # doesn't capture more than 1 sentence, we will just cut
+        # that sequence
+        prev_end = end
         end = min(end + batch_size, len(subwords))
 
         # Move back till we hit a sentence end
@@ -40,14 +44,19 @@ def get_subwords_batches(doc: Doc,
             while end and doc["sent_id"][doc["word_id"][end - 1]] == sent_id:
                 end -= 1
 
+        # if we ended up at prev end, well, looks like we will
+        # just chop off the sentence
+        if end == prev_end:
+            end = min(end + batch_size, len(subwords))
+
         length = end - start
-        batch = [tok.cls_token] + subwords[start:end] + [tok.sep_token]
-        batch_ids = [-1] + list(range(start, end)) + [-1]
+        if tok.cls_token == None or tok.sep_token == None:
+            batch = [tok.eos_token] + subwords[start:end] + [tok.eos_token]
+        else:
+            batch = [tok.cls_token] + subwords[start:end] + [tok.sep_token]
 
         # Padding to desired length
-        # -1 means the token is a special token
         batch += [tok.pad_token] * (batch_size - length)
-        batch_ids += [-1] * (batch_size - length)
 
         subwords_batches.append([tok.convert_tokens_to_ids(token)
                                  for token in batch])

--- a/stanza/models/coref/cluster_checker.py
+++ b/stanza/models/coref/cluster_checker.py
@@ -4,6 +4,12 @@ See aclweb.org/anthology/P16-1060.pdf. """
 from typing import Hashable, List, Tuple
 
 from stanza.models.coref.const import EPSILON
+import numpy as np
+
+import math
+import logging
+
+logger = logging.getLogger('stanza')
 
 
 class ClusterChecker:
@@ -15,7 +21,24 @@ class ClusterChecker:
         self._r = 0.0
         self._p_weight = 0.0
         self._r_weight = 0.0
+        self._num_preds = 0.0
 
+        # muc
+        self._mp = 0.0
+        self._mr = 0.0
+
+        # b3
+        self._bp = 0.0
+        self._br = 0.0
+
+        # ceafe
+        self._cp = 0.0
+        self._cr = 0.0
+
+    @staticmethod
+    def _f1(p,r):
+        return (p * r) / (p+r + EPSILON) * 2
+    
     def add_predictions(self,
                         gold_clusters: List[List[Hashable]],
                         pred_clusters: List[List[Hashable]]):
@@ -26,8 +49,28 @@ class ClusterChecker:
         Returns:
             LEA score for the document as a tuple of (f1, precision, recall)
         """
+
+        # if len(gold_clusters) == 0:
+            # breakpoint()
+
+        self._num_preds += 1
+        
         recall, r_weight = ClusterChecker._lea(gold_clusters, pred_clusters)
         precision, p_weight = ClusterChecker._lea(pred_clusters, gold_clusters)
+
+        self._mr +=  ClusterChecker._muc(gold_clusters, pred_clusters)
+        self._mp += ClusterChecker._muc(pred_clusters, gold_clusters)
+
+        self._br += ClusterChecker._b3(gold_clusters, pred_clusters)
+        self._bp += ClusterChecker._b3(pred_clusters, gold_clusters)
+
+        ceafe_precision, ceafe_recall = ClusterChecker._ceafe(pred_clusters, gold_clusters)
+        if math.isnan(ceafe_precision) and len(gold_clusters) > 0:
+            # because our model predicted no clusters
+            ceafe_precision = 0.0
+
+        self._cp += ceafe_precision
+        self._cr += ceafe_recall
 
         self._r += recall
         self._r_weight += r_weight
@@ -41,12 +84,30 @@ class ClusterChecker:
         return doc_f1, doc_precision, doc_recall
 
     @property
+    def bakeoff(self):
+        """ Get the F1 macroaverage score used by the bakeoff """
+        return sum(self.mbc)/3
+
+    @property
+    def mbc(self):
+        """ Get the F1 average score of (muc, b3, ceafe) over docs """
+        avg_precisions = [self._mp, self._bp, self._cp]
+        avg_precisions = [i/(self._num_preds + EPSILON) for i in avg_precisions]
+
+        avg_recalls = [self._mr, self._br, self._cr]
+        avg_recalls = [i/(self._num_preds + EPSILON) for i in avg_recalls]
+
+        avg_f1s = [self._f1(p,r) for p,r in zip(avg_precisions, avg_recalls)]
+
+        return avg_f1s
+
+    @property
     def total_lea(self):
         """ Returns weighted LEA for all the documents as
         (f1, precision, recall) """
         precision = self._p / (self._p_weight + EPSILON)
         recall = self._r / (self._r_weight + EPSILON)
-        f1 = (precision * recall) / (precision + recall + EPSILON) * 2
+        f1 = self._f1(precision, recall)
         return f1, precision, recall
 
     @staticmethod
@@ -73,3 +134,97 @@ class ClusterChecker:
         res = sum(imp * res for imp, res in zip(importances, resolutions))
         weight = sum(importances)
         return res, weight
+
+    @staticmethod
+    def _muc(key: List[List[Hashable]],
+             response: List[List[Hashable]]) -> float:
+        """ See aclweb.org/anthology/P16-1060.pdf. """
+
+        response_clusters = [set(cluster) for cluster in response]
+        response_map = {mention: cluster
+                        for cluster in response_clusters
+                        for mention in cluster}
+
+        top = 0 # sum over k of |k_i| - response_partitions(|k_i|)
+        bottom = 0 # sum over k of |k_i| - 1
+
+        for entity in key:
+            S = len(entity)
+            # we need to figure the number of DIFFERENT clusters 
+            # the response assigns to members of the entity; ideally
+            # this number is 1 (i.e. they are all assigned the same
+            # coref).
+            response_clusters = [response_map.get(i, None) for i in entity]
+            # and dedplicate
+            deduped = []
+            for i in response_clusters:
+                if i == None:
+                    deduped.append(i)
+                elif i not in deduped:
+                    deduped.append(i)
+            # the "partitions" will then be size of the deduped list
+            p_k = len(deduped)
+            top += (S - p_k)
+            bottom += (S - 1)
+        
+        try:
+            return top/bottom
+        except ZeroDivisionError:
+            logger.warning("muc got a zero division error because the model predicted no spans!")
+            return 0 # +inf technically
+
+    @staticmethod
+    def _b3(key: List[List[Hashable]],
+            response: List[List[Hashable]]) -> float:
+        """ See aclweb.org/anthology/P16-1060.pdf. """
+        
+        response_clusters = [set(cluster) for cluster in response]
+
+        top = 0 # sum over key and response of (|k intersect response|^2/|k|)
+        bottom = 0 # sum over k of |k_i|
+
+        for entity in key:
+            bottom += len(entity)
+            entity = set(entity)
+
+            for res_entity in response_clusters:
+                top += (len(entity.intersection(res_entity))**2)/len(entity)
+
+        try:
+            return top/bottom
+        except ZeroDivisionError:
+            logger.warning("b3 got a zero division error because the model predicted no spans!")
+            return 0 # +inf technically
+
+
+
+    @staticmethod
+    def _phi4(c1, c2):
+        return 2 * len([m for m in c1 if m in c2]) / float(len(c1) + len(c2))
+
+    @staticmethod
+    def _ceafe(clusters: List[List[Hashable]], gold_clusters: List[List[Hashable]]):
+        """ see https://github.com/ufal/corefud-scorer/blob/main/coval/eval/evaluator.py """
+
+        try:
+            from scipy.optimize import linear_sum_assignment
+        except ImportError:
+            raise ImportError("To perform CEAF scoring, please install scipy via `pip install scipy` for the Kuhn-Munkres linear assignment scheme.")
+
+        clusters = [c for c in clusters]
+        scores = np.zeros((len(gold_clusters), len(clusters)))
+        for i in range(len(gold_clusters)):
+            for j in range(len(clusters)):
+                scores[i, j] = ClusterChecker._phi4(gold_clusters[i], clusters[j])
+        row_ind, col_ind = linear_sum_assignment(-scores)
+        similarity = scores[row_ind, col_ind].sum()
+
+        # precision, recall
+        try:
+            prec = similarity/len(clusters)
+        except ZeroDivisionError:
+            logger.warning("ceafe got a zero division error because the model predicted no spans!")
+            prec = 0
+        recc = similarity/len(gold_clusters)
+        return prec, recc
+

--- a/stanza/models/coref/config.py
+++ b/stanza/models/coref/config.py
@@ -40,9 +40,12 @@ class Config:  # pylint: disable=too-many-instance-attributes, too-few-public-me
     lora_rank: int
     lora_dropout: float
 
+    full_pairwise: bool
+
     lora_targets: List[str]
     lora_fully_tune: List[str]
 
+    clusters_starts_are_singletons: bool
     bert_finetune: bool
     dropout_rate: float
     learning_rate: float
@@ -58,4 +61,5 @@ class Config:  # pylint: disable=too-many-instance-attributes, too-few-public-me
 
     save_each_checkpoint: bool
     log_norms: bool
-
+    singletons: bool
+    

--- a/stanza/models/coref/conll.py
+++ b/stanza/models/coref/conll.py
@@ -61,17 +61,15 @@ def write_conll(doc: Doc,
             cluster_info_lst.append(f"e{cluster_marker})")
 
 
-        # we need our clusters to be ordered such that the one that closest first is listed last
+        # we need our clusters to be ordered such that the one that is closest the first change
+        # is listed last in the chains
         def compare_sort(x):
             split = x.split("-")
             if len(split) > 1: 
-                try:
-                    return int(split[-1].replace(")", "").strip())  
-                except ValueError:
-                    breakpoint()
+                return int(split[-1].replace(")", "").strip())  
             else: 
                 # we want everything that's a closer to be first
-                return 1000000000
+                return float("inf")
 
         cluster_info_lst = sorted(cluster_info_lst, key=compare_sort, reverse=True)
         cluster_info = "".join(cluster_info_lst) if cluster_info_lst else "_"

--- a/stanza/models/coref/const.py
+++ b/stanza/models/coref/const.py
@@ -17,9 +17,11 @@ Span = Tuple[int, int]
 class CorefResult:
     coref_scores: torch.Tensor = None                  # [n_words, k + 1]
     coref_y: torch.Tensor = None                       # [n_words, k + 1]
+    rough_y: torch.Tensor = None                       # [n_words, n_words]
 
     word_clusters: List[List[int]] = None
     span_clusters: List[List[Span]] = None
 
+    rough_scores: torch.Tensor = None                  # [n_words, n_words]
     span_scores: torch.Tensor = None                   # [n_heads, n_words, 2]
     span_y: Tuple[torch.Tensor, torch.Tensor] = None   # [n_heads] x2

--- a/stanza/models/coref/coref_config.toml
+++ b/stanza/models/coref/coref_config.toml
@@ -11,21 +11,9 @@ data_dir = "data/coref"
 save_dir = "saved_models/coref"
 
 # Train, dev and test jsonlines
-#train_data = "data/coref/huge.json"
-#dev_data = "data/coref/huge.json"
-#test_data = "data/coref/huge.json"
-
 # train_data = "data/coref/en_gum-ud.train.nosgl.json"
 # dev_data = "data/coref/en_gum-ud.dev.nosgl.json"
 # test_data = "data/coref/en_gum-ud.test.nosgl.json"
-
-# train_data = "data/coref/corefud_concat_short_v1_0.train.json"
-# dev_data = "data/coref/corefud_concat_short_v1_0.dev.json"
-# test_data = "data/coref/corefud_concat_short_v1_0.dev.json"
-
-#train_data = "data/coref/corefud_concat_v1_0_langid-bal.train.json"
-#dev_data = "data/coref/corefud_concat_v1_0_langid-bal.dev.json"
-#test_data = "data/coref/corefud_concat_v1_0_langid-bal.test.json"
 
 train_data = "data/coref/corefud_concat_v1_0_langid.train.json"
 dev_data = "data/coref/corefud_concat_v1_0_langid.dev.json"
@@ -93,8 +81,8 @@ rough_k = 50
 
 # LoRA settings
 lora = false
-lora_dropout = 0.1
 lora_alpha = 128
+lora_dropout = 0.1
 lora_rank = 64
 lora_targets = []
 lora_fully_tune = []

--- a/stanza/models/coref/coref_config.toml
+++ b/stanza/models/coref/coref_config.toml
@@ -11,9 +11,32 @@ data_dir = "data/coref"
 save_dir = "saved_models/coref"
 
 # Train, dev and test jsonlines
-train_data = "data/coref/english_train_head.jsonlines"
-dev_data = "data/coref/english_development_head.jsonlines"
-test_data = "data/coref/english_test_head.jsonlines"
+#train_data = "data/coref/huge.json"
+#dev_data = "data/coref/huge.json"
+#test_data = "data/coref/huge.json"
+
+# train_data = "data/coref/en_gum-ud.train.nosgl.json"
+# dev_data = "data/coref/en_gum-ud.dev.nosgl.json"
+# test_data = "data/coref/en_gum-ud.test.nosgl.json"
+
+# train_data = "data/coref/corefud_concat_short_v1_0.train.json"
+# dev_data = "data/coref/corefud_concat_short_v1_0.dev.json"
+# test_data = "data/coref/corefud_concat_short_v1_0.dev.json"
+
+#train_data = "data/coref/corefud_concat_v1_0_langid-bal.train.json"
+#dev_data = "data/coref/corefud_concat_v1_0_langid-bal.dev.json"
+#test_data = "data/coref/corefud_concat_v1_0_langid-bal.test.json"
+
+train_data = "data/coref/corefud_concat_v1_0_langid.train.json"
+dev_data = "data/coref/corefud_concat_v1_0_langid.dev.json"
+test_data = "data/coref/corefud_concat_v1_0_langid.dev.json"
+
+#train_data = "data/coref/english_train_head.jsonlines"
+#dev_data = "data/coref/english_development_head.jsonlines"
+#test_data = "data/coref/english_test_head.jsonlines"
+
+# do not use the full pairwise encoding scheme
+full_pairwise = false
 
 # The device where everything is to be placed. "cuda:N"/"cpu" are supported.
 device = "cuda:0"
@@ -31,7 +54,6 @@ bert_model = "bert-large-cased"
 # Must be less than or equal to 512
 bert_window_size = 512
 
-
 # General model settings =============
 
 # Controls the dimensionality of feature embeddings
@@ -43,11 +65,14 @@ sp_embedding_size = 64
 # Controls the number of spans for which anaphoricity can be scores in one
 # batch. Only affects final scoring; mention extraction and rough scoring
 # are less memory intensive, so they are always done in just one batch.
-a_scoring_batch_size = 512
+a_scoring_batch_size = 128
 
 # AnaphoricityScorer FFNN parameters
 hidden_size = 1024
 n_hidden_layers = 1
+
+# Do you want to support singletons?
+singletons = true
 
 
 # Mention extraction settings ========
@@ -68,14 +93,17 @@ rough_k = 50
 
 # LoRA settings
 lora = false
-lora_alpha = 128
 lora_dropout = 0.1
+lora_alpha = 128
 lora_rank = 64
 lora_targets = []
 lora_fully_tune = []
 
 
 # Training settings ==================
+
+# Controls whether the first dummy node predicts cluster starts or singletons
+clusters_starts_are_singletons = true
 
 # Controls whether to fine-tune bert_model
 bert_finetune = true
@@ -91,7 +119,7 @@ bert_finetune_begin_epoch = 0.5
 learning_rate = 3e-4
 
 # For how many epochs the training is done
-train_epochs = 25
+train_epochs = 32
 
 # Controls the weight of binary cross entropy loss added to nlml loss
 bce_loss_weight = 0.5
@@ -103,6 +131,9 @@ conll_log_dir = "data/conll_logs"
 # Extra keyword arguments to be passed to bert tokenizers of specified models
 [DEFAULT.tokenizer_kwargs]
     [DEFAULT.tokenizer_kwargs.roberta-large]
+        "add_prefix_space" = true
+
+    [DEFAULT.tokenizer_kwargs.xlm-roberta-large]
         "add_prefix_space" = true
 
     [DEFAULT.tokenizer_kwargs.spanbert-large-cased]
@@ -125,6 +156,18 @@ lora = true
 lora_targets = [ "query", "value", "output.dense", "intermediate.dense" ]
 lora_fully_tune = [ "pooler" ]
 
+[xlm_roberta]
+bert_model = "FacebookAI/xlm-roberta-large"
+bert_learning_rate = 0.00001
+bert_finetune = true
+
+[xlm_roberta_lora]
+bert_model = "FacebookAI/xlm-roberta-large"
+bert_learning_rate = 0.000025
+lora = true
+lora_targets = [ "query", "value", "output.dense", "intermediate.dense" ]
+lora_fully_tune = [ "pooler" ]
+
 [deberta_lora]
 bert_model = "microsoft/deberta-v3-large"
 bert_learning_rate = 0.00001
@@ -141,6 +184,30 @@ bert_model = "google/electra-large-discriminator"
 bert_learning_rate = 0.000025
 lora = true
 lora_targets = [ "query", "value", "output.dense", "intermediate.dense" ]
+lora_fully_tune = [  ]
+
+[t5_lora]
+bert_model = "google-t5/t5-large"
+bert_learning_rate = 0.000025
+bert_window_size = 1024
+lora = true
+lora_targets = [ "q", "v", "o", "wi", "wo" ]
+lora_fully_tune = [  ]
+
+[mt5_lora]
+bert_model = "google/mt5-base"
+bert_learning_rate = 0.000025
+lora_alpha = 64
+lora_rank = 32
+lora = true
+lora_targets = [ "q", "v", "o", "wi", "wo" ]
+lora_fully_tune = [  ]
+
+[deepnarrow_t5_xl_lora]
+bert_model = "google/t5-efficient-xl"
+bert_learning_rate = 0.00025
+lora = true
+lora_targets = [ "q", "v", "o", "wi", "wo" ]
 lora_fully_tune = [  ]
 
 [roberta_no_finetune]

--- a/stanza/models/coref/dataset.py
+++ b/stanza/models/coref/dataset.py
@@ -1,0 +1,61 @@
+import json
+import logging
+from torch.utils.data import Dataset
+
+from stanza.models.coref.tokenizer_customization import TOKENIZER_FILTERS, TOKENIZER_MAPS
+
+logger = logging.getLogger('stanza')
+
+class CorefDataset(Dataset):
+
+    def __init__(self, path, config, tokenizer):
+        self.config = config
+        self.tokenizer = tokenizer
+
+        # by default, this doesn't filter anything (see lambda _ True);
+        # however, there are some subword symbols which are standalone
+        # tokens which we don't want on models like Albert; hence we
+        # pass along a filter if needed.
+        self.__filter_func = TOKENIZER_FILTERS.get(self.config.bert_model,
+                                                   lambda _: True)
+        self.__token_map = TOKENIZER_MAPS.get(self.config.bert_model, {})
+
+        try:
+            with open(path, encoding="utf-8") as fin:
+                data_f = json.load(fin)
+        except json.decoder.JSONDecodeError:
+            # read the old jsonlines format if necessary
+            with open(path, encoding="utf-8") as fin:
+                text = "[" + ",\n".join(fin) + "]"
+            data_f = json.loads(text)
+        logger.info("Processing %d docs from %s...", len(data_f), path)
+        self.__raw = data_f
+        self.__avg_span = sum(len(doc["head2span"]) for doc in self.__raw) / len(self.__raw)
+        self.__out = []
+        for doc in self.__raw:
+            doc["span_clusters"] = [[tuple(mention) for mention in cluster]
+                                for cluster in doc["span_clusters"]]
+            word2subword = []
+            subwords = []
+            word_id = []
+            for i, word in enumerate(doc["cased_words"]):
+                tokenized_word = self.__token_map.get(word, self.tokenizer.tokenize(word))
+                tokenized_word = list(filter(self.__filter_func, tokenized_word))
+                word2subword.append((len(subwords), len(subwords) + len(tokenized_word)))
+                subwords.extend(tokenized_word)
+                word_id.extend([i] * len(tokenized_word))
+            doc["word2subword"] = word2subword
+            doc["subwords"] = subwords
+            doc["word_id"] = word_id
+            self.__out.append(doc)
+        logger.info("Loaded %d docs from %s.", len(data_f), path)
+
+    @property
+    def avg_span(self):
+        return self.__avg_span
+
+    def __getitem__(self, x):
+        return self.__out[x]
+
+    def __len__(self):
+        return len(self.__out)

--- a/stanza/models/coref/model.py
+++ b/stanza/models/coref/model.py
@@ -16,6 +16,8 @@ except ImportError:
 import torch
 import transformers     # type: ignore
 
+from stanza.utils.get_tqdm import get_tqdm   # type: ignore
+tqdm = get_tqdm()
 
 from stanza.models.coref import bert, conll, utils
 from stanza.models.coref.anaphoricity_scorer import AnaphoricityScorer
@@ -26,15 +28,13 @@ from stanza.models.coref.loss import CorefLoss
 from stanza.models.coref.pairwise_encoder import PairwiseEncoder
 from stanza.models.coref.rough_scorer import RoughScorer
 from stanza.models.coref.span_predictor import SpanPredictor
-from stanza.models.coref.tokenizer_customization import TOKENIZER_FILTERS, TOKENIZER_MAPS
 from stanza.models.coref.utils import GraphNode
 from stanza.models.coref.word_encoder import WordEncoder
 from stanza.models.coref.dataset import CorefDataset
 
-from torch.utils.data import Dataset
-
 from peft import LoraConfig, get_peft_model, get_peft_model_state_dict, set_peft_model_state_dict
 
+logger = logging.getLogger('stanza')
 
 class CorefModel:  # pylint: disable=too-many-instance-attributes
     """Combines all coref modules together to find coreferent spans.

--- a/stanza/models/coref/model.py
+++ b/stanza/models/coref/model.py
@@ -30,12 +30,66 @@ from stanza.models.coref.tokenizer_customization import TOKENIZER_FILTERS, TOKEN
 from stanza.models.coref.utils import GraphNode
 from stanza.models.coref.word_encoder import WordEncoder
 
+from torch.utils.data import Dataset
+from functools import lru_cache, wraps
+import weakref
+
 from peft import LoraConfig, get_peft_model, get_peft_model_state_dict, set_peft_model_state_dict
 
 from stanza.utils.get_tqdm import get_tqdm   # type: ignore
 tqdm = get_tqdm()
 
 logger = logging.getLogger('stanza')
+
+class CorefDataset(Dataset):
+
+    def __init__(self, path, config, tokenizer):
+        self.config = config
+        self.tokenizer = tokenizer
+
+        self.__filter_func = TOKENIZER_FILTERS.get(self.config.bert_model,
+                                                   lambda _: True)
+        self.__token_map = TOKENIZER_MAPS.get(self.config.bert_model, {})
+
+        try:
+            with open(path, encoding="utf-8") as fin:
+                data_f = json.load(fin)
+        except json.decoder.JSONDecodeError:
+            # read the old jsonlines format if necessary
+            with open(path, encoding="utf-8") as fin:
+                text = "[" + ",\n".join(fin) + "]"
+            data_f = json.loads(text)
+        logger.info("Processing %d docs from %s...", len(data_f), path)
+        self.__raw = data_f
+        self.__avg_span = sum(len(doc["head2span"]) for doc in self.__raw) / len(self.__raw)
+        self.__out = []
+        for doc in self.__raw:
+            doc["span_clusters"] = [[tuple(mention) for mention in cluster]
+                                for cluster in doc["span_clusters"]]
+            word2subword = []
+            subwords = []
+            word_id = []
+            for i, word in enumerate(doc["cased_words"]):
+                tokenized_word = self.__token_map.get(word, self.tokenizer.tokenize(word))
+                tokenized_word = list(filter(self.__filter_func, tokenized_word))
+                word2subword.append((len(subwords), len(subwords) + len(tokenized_word)))
+                subwords.extend(tokenized_word)
+                word_id.extend([i] * len(tokenized_word))
+            doc["word2subword"] = word2subword
+            doc["subwords"] = subwords
+            doc["word_id"] = word_id
+            self.__out.append(doc)
+        logger.info("Loaded %d docs from %s.", len(data_f), path)
+
+    @property
+    def avg_span(self):
+        return self.__avg_span
+
+    def __getitem__(self, x):
+        return self.__out[x]
+
+    def __len__(self):
+        return len(self.__out)
 
 class CorefModel:  # pylint: disable=too-many-instance-attributes
     """Combines all coref modules together to find coreferent spans.
@@ -80,7 +134,6 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
         self.optimizers = {}
         self.schedulers = {}
 
-        # TODO make this actually configurable
         if hasattr(self.config, 'lora') and self.config.lora:
             logger.debug("Creating lora adapter with rank %d", self.config.lora_rank)
             self.__peft_config = LoraConfig(inference_mode=False,
@@ -91,14 +144,15 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
                                             modules_to_save=self.config.lora_fully_tune,
                                             bias="none")
 
-            self.bert = get_peft_model(self.bert, self.__peft_config)
             self.bert.train()
+            self.bert = get_peft_model(self.bert, self.__peft_config)
             self.trainable["bert"] = self.bert
 
         if build_optimizers:
             self._build_optimizers()
         self._set_training(False)
         self._coref_criterion = CorefLoss(self.config.bce_loss_weight)
+        self._rough_criterion = CorefLoss(0)
         self._span_criterion = torch.nn.CrossEntropyLoss(reduction="sum")
 
     @property
@@ -117,13 +171,15 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
     @torch.no_grad()
     def evaluate(self,
                  data_split: str = "dev",
-                 word_level_conll: bool = False
+                 word_level_conll: bool = False, 
+                 eval_lang=None
                  ) -> Tuple[float, Tuple[float, float, float]]:
         """ Evaluates the modes on the data split provided.
 
         Args:
             data_split (str): one of 'dev'/'test'/'train'
             word_level_conll (bool): if True, outputs conll files on word-level
+            eval_lang (str): which language to evaluate
 
         Returns:
             mean loss
@@ -141,7 +197,16 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
                 as (gold_f, pred_f):
             pbar = tqdm(docs, unit="docs", ncols=0)
             for doc in pbar:
+                if eval_lang and doc.get("lang", "") != eval_lang:
+                    # skip that document, only used for ablation where we only
+                    # want to test evaluation on one language
+                    continue
+ 
                 res = self.run(doc)
+
+                if (res.coref_y.argmax(dim=1) == 1).all():
+                    logger.warning(f"EVAL: skipping document with no corefs...")
+                    continue
 
                 running_loss += self._coref_criterion(res.coref_scores, res.coref_y).item()
 
@@ -151,18 +216,12 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
                     s_correct += ((res.span_y[0] == pred_starts) * (res.span_y[1] == pred_ends)).sum().item()
                     s_total += len(pred_starts)
 
+
                 if word_level_conll:
-                    conll.write_conll(doc,
-                                      [[(i, i + 1) for i in cluster]
-                                       for cluster in doc["word_clusters"]],
-                                      gold_f)
-                    conll.write_conll(doc,
-                                      [[(i, i + 1) for i in cluster]
-                                       for cluster in res.word_clusters],
-                                      pred_f)
+                    raise NotImplementedError("We now write Conll-U conforming to UDCoref, which means that the span_clusters annotations will have headword info. word_level option is meaningless.")
                 else:
-                    conll.write_conll(doc, doc["span_clusters"], gold_f)
-                    conll.write_conll(doc, res.span_clusters, pred_f)
+                    conll.write_conll(doc, doc["span_clusters"], doc["word_clusters"], gold_f)
+                    conll.write_conll(doc, res.span_clusters, res.word_clusters, pred_f)
 
                 w_checker.add_predictions(doc["word_clusters"], res.word_clusters)
                 w_lea = w_checker.total_lea
@@ -185,8 +244,9 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
                     f" p: {s_lea[1]:.5f},"
                     f" r: {s_lea[2]:<.5f}"
                 )
+            logger.info(f"BAKE!: {w_checker.bakeoff:.5f}")
 
-        return (running_loss / len(docs), *s_checker.total_lea)
+        return (running_loss / len(docs), *s_checker.total_lea, *w_checker.total_lea, *s_checker.mbc, *w_checker.mbc, w_checker.bakeoff, s_checker.bakeoff)
 
     def load_weights(self,
                      path: Optional[str] = None,
@@ -200,18 +260,21 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
         Assumes files are named like {configuration}_(e{epoch}_{time})*.pt.
         """
         if path is None:
-            pattern = rf"{self.config.section}_\(e(\d+)_[^()]*\).*\.pt"
+            # pattern = rf"{self.config.section}_\(e(\d+)_[^()]*\).*\.pt"
+            # tries to load the last checkpoint in the same dir
+            pattern = rf"{self.config.section}.*?\.checkpoint\.pt"
             files = []
+            os.makedirs(self.config.save_dir, exist_ok=True)
             for f in os.listdir(self.config.save_dir):
                 match_obj = re.match(pattern, f)
                 if match_obj:
-                    files.append((int(match_obj.group(1)), f))
+                    files.append(f)
             if not files:
                 if noexception:
                     logger.debug("No weights have been loaded", flush=True)
                     return
                 raise OSError(f"No weights found in {self.config.save_dir}!")
-            _, path = sorted(files)[-1]
+            path = sorted(files)[-1]
             path = os.path.join(self.config.save_dir, path)
 
         if map_location is None:
@@ -321,7 +384,7 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
         # Obtain bilinear scores and leave only top-k antecedents for each word
         # top_rough_scores  [n_words, n_ants]
         # top_indices       [n_words, n_ants]
-        top_rough_scores, top_indices = self.rough_scorer(words)
+        top_rough_scores, top_indices, rough_scores = self.rough_scorer(words)
 
         # Get pairwise features [n_words, n_ants, n_pw_features]
         pw = self.pw(top_indices, doc)
@@ -337,9 +400,8 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
 
             # a_scores_batch    [batch_size, n_ants]
             a_scores_batch = self.a_scorer(
-                all_mentions=words, mentions_batch=words_batch,
-                pw_batch=pw_batch, top_indices_batch=top_indices_batch,
-                top_rough_scores_batch=top_rough_scores_batch
+                top_mentions=words[top_indices_batch], mentions_batch=words_batch,
+                pw_batch=pw_batch, top_rough_scores_batch=top_rough_scores_batch
             )
             a_scores_lst.append(a_scores_batch)
 
@@ -349,9 +411,13 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
         res.coref_scores = torch.cat(a_scores_lst, dim=0)
 
         res.coref_y = self._get_ground_truth(
-            cluster_ids, top_indices, (top_rough_scores > float("-inf")))
-        res.word_clusters = self._clusterize(doc, res.coref_scores,
-                                             top_indices)
+            cluster_ids, top_indices, (top_rough_scores > float("-inf")),
+            self.config.clusters_starts_are_singletons,
+            self.config.singletons)
+
+        res.word_clusters = self._clusterize(doc, res.coref_scores, top_indices,
+                                             self.config.singletons)
+
         res.span_scores, res.span_y = self.sp.get_training_data(doc, words)
 
         if not self.training:
@@ -397,17 +463,18 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
         Trains all the trainable blocks in the model using the config provided.
 
         log: whether or not to log using wandb
+        skip_lang: str if we want to skip training this language (used for ablation)
         """
 
         if log:
             import wandb
             wandb.watch((self.bert, self.pw,
                          self.a_scorer, self.we,
-                         self.rough_scorer, self.sp), log_freq=4, log="all", log_graph=True)
+                         self.rough_scorer, self.sp), log_freq=4, log="all")
 
-        docs = list(self._get_docs(self.config.train_data))
+        docs = self._get_docs(self.config.train_data)
         docs_ids = list(range(len(docs)))
-        avg_spans = sum(len(doc["head2span"]) for doc in docs) / len(docs)
+        avg_spans = docs.avg_span
 
         best_f1 = None
         for epoch in range(self.epochs_trained, self.config.train_epochs):
@@ -421,12 +488,17 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
             for doc_indx, doc_id in enumerate(pbar):
                 doc = docs[doc_id]
 
+                # skip very long documents during training time
+                if len(doc["subwords"]) > 5000:
+                    continue
+
                 for optim in self.optimizers.values():
                     optim.zero_grad()
 
                 res = self.run(doc)
 
                 c_loss = self._coref_criterion(res.coref_scores, res.coref_y)
+
                 if res.span_y:
                     s_loss = (self._span_criterion(res.span_scores[:, :, 0], res.span_y[0])
                               + self._span_criterion(res.span_scores[:, :, 1], res.span_y[1])) / avg_spans / 2
@@ -436,11 +508,12 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
                 del res
 
                 (c_loss + s_loss).backward()
+
                 running_c_loss += c_loss.item()
                 running_s_loss += s_loss.item()
 
-                # log every 50 docs
-                if log and doc_indx % 50 == 0:
+                # log every 100 docs
+                if log and doc_indx % 100 == 0:
                     wandb.log({'train_c_loss': c_loss.item(),
                                'train_s_loss': s_loss.item()})
 
@@ -464,6 +537,7 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
             prev_best_f1 = best_f1
             if log:
                 wandb.log({'dev_score': scores[1]})
+                wandb.log({'dev_bakeoff': scores[-1]})
 
             if best_f1 is None or scores[1] > best_f1:
 
@@ -490,30 +564,44 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
     # ========================================================= Private methods
 
     def _bertify(self, doc: Doc) -> torch.Tensor:
-        subwords_batches = bert.get_subwords_batches(doc, self.config,
-                                                     self.tokenizer)
+        all_batches = bert.get_subwords_batches(doc, self.config, self.tokenizer)
 
-        special_tokens = np.array([self.tokenizer.cls_token_id,
-                                   self.tokenizer.sep_token_id,
-                                   self.tokenizer.pad_token_id])
-        subword_mask = ~(np.isin(subwords_batches, special_tokens))
+        # we index the batches n at a time to prevent oom
+        result = []
+        for i in range(0, all_batches.shape[0], 1024):
+            subwords_batches = all_batches[i:i+1024]
 
-        subwords_batches_tensor = torch.tensor(subwords_batches,
-                                               device=self.config.device,
-                                               dtype=torch.long)
-        subword_mask_tensor = torch.tensor(subword_mask,
-                                           device=self.config.device)
+            special_tokens = np.array([self.tokenizer.cls_token_id,
+                                    self.tokenizer.sep_token_id,
+                                    self.tokenizer.pad_token_id,
+                                    self.tokenizer.eos_token_id])
+            subword_mask = ~(np.isin(subwords_batches, special_tokens))
 
-        # Obtain bert output for selected batches only
-        attention_mask = (subwords_batches != self.tokenizer.pad_token_id)
-        out = self.bert(
-            subwords_batches_tensor,
-            attention_mask=torch.tensor(
-                attention_mask, device=self.config.device))
-        out = out['last_hidden_state']
+            subwords_batches_tensor = torch.tensor(subwords_batches,
+                                                device=self.config.device,
+                                                dtype=torch.long)
+            subword_mask_tensor = torch.tensor(subword_mask,
+                                            device=self.config.device)
 
-        # [n_subwords, bert_emb]
-        return out[subword_mask_tensor]
+            # Obtain bert output for selected batches only
+            attention_mask = (subwords_batches != self.tokenizer.pad_token_id)
+            if "t5" in self.config.bert_model:
+                out = self.bert.encoder(
+                        input_ids=subwords_batches_tensor,
+                        attention_mask=torch.tensor(
+                            attention_mask, device=self.config.device))
+            else:
+                out = self.bert(
+                        subwords_batches_tensor,
+                        attention_mask=torch.tensor(
+                            attention_mask, device=self.config.device))
+
+            out = out['last_hidden_state']
+            # [n_subwords, bert_emb]
+            result.append(out[subword_mask_tensor])
+
+        # stack returns and return
+        return torch.cat(result)
 
     def _build_model(self):
         self.bert, self.tokenizer = bert.load_bert(self.config)
@@ -578,8 +666,15 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
                 0, n_docs * self.config.train_epochs
             )
 
-    def _clusterize(self, doc: Doc, scores: torch.Tensor, top_indices: torch.Tensor):
-        antecedents = scores.argmax(dim=1) - 1
+    def _clusterize(self, doc: Doc, scores: torch.Tensor, top_indices: torch.Tensor,
+                    singletons: bool = True):
+        if singletons:
+            antecedents = scores[:,1:].argmax(dim=1) - 1
+            # set the dummy values to -1, so that they are not coref to themselves
+            is_start = (scores[:, :2].argmax(dim=1) == 0)
+        else:
+            antecedents = scores.argmax(dim=1) - 1
+
         not_dummy = antecedents >= 0
         coref_span_heads = torch.arange(0, len(scores), device=not_dummy.device)[not_dummy]
         antecedents = top_indices[coref_span_heads, antecedents[not_dummy]]
@@ -588,6 +683,8 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
         for i, j in zip(coref_span_heads.tolist(), antecedents.tolist()):
             nodes[i].link(nodes[j])
             assert nodes[i] is not nodes[j]
+
+        visited = {}
 
         clusters = []
         for node in nodes:
@@ -600,18 +697,30 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
                     cluster.append(current_node.id)
                     stack.extend(link for link in current_node.links if not link.visited)
                 assert len(cluster) > 1
+                for i in cluster:
+                    visited[i] = True
                 clusters.append(sorted(cluster))
+
+        if singletons:
+            # go through the is_start nodes; if no clusters contain that node
+            # i.e. visited[i] == False, we add it as a singleton
+            for indx, i in enumerate(is_start):
+                if i and not visited.get(indx, False):
+                    clusters.append([indx])
+
         return sorted(clusters)
 
     def _get_docs(self, path: str) -> List[Doc]:
         if path not in self._docs:
-            self._docs[path] = self._tokenize_docs(path)
+            self._docs[path] = CorefDataset(path, self.config, self.tokenizer)
         return self._docs[path]
 
     @staticmethod
     def _get_ground_truth(cluster_ids: torch.Tensor,
                           top_indices: torch.Tensor,
-                          valid_pair_map: torch.Tensor) -> torch.Tensor:
+                          valid_pair_map: torch.Tensor,
+                          cluster_starts: bool,
+                          singletons:bool = True) -> torch.Tensor:
         """
         Args:
             cluster_ids: tensor of shape [n_words], containing cluster indices
@@ -629,9 +738,35 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
         y = cluster_ids[top_indices] * valid_pair_map  # [n_words, n_ants]
         y[y == 0] = -1                                 # -1 for non-gold words
         y = utils.add_dummy(y)                         # [n_words, n_cands + 1]
+
+        if singletons:
+            if not cluster_starts:
+                unique, counts = cluster_ids.unique(return_counts=True)
+                singleton_clusters = unique[(counts == 1) & (unique != 0)]
+                first_corefs = [(cluster_ids == i).nonzero().flatten()[0] for i in singleton_clusters]
+                if len(first_corefs) > 0:
+                    first_coref = torch.stack(first_corefs)
+                else:
+                    first_coref = torch.tensor([]).to(cluster_ids.device).long()
+            else:
+                # I apologize for this abuse of everything that's good about PyTorch.
+                # in essence, this line finds the INDEX of FIRST OCCURENCE of each NON-ZERO value
+                # from cluster_ids. We need this information because we use it to mark the
+                # special "is-start-of-ref" marker used to detect singletons.
+                first_coref = (cluster_ids ==
+                            cluster_ids.unique().sort().values[1:].unsqueeze(1)
+                            ).float().topk(k=1, dim=1).indices.squeeze()
         y = (y == cluster_ids.unsqueeze(1))            # True if coreferent
         # For all rows with no gold antecedents setting dummy to True
         y[y.sum(dim=1) == 0, 0] = True
+
+        if singletons:
+            # add another dummy for firts coref
+            y = utils.add_dummy(y)                         # [n_words, n_cands + 2]
+            # for all rows that's a first coref, setting its dummy to True and unset the
+            # non-coref dummy to false
+            y[first_coref, 0] = True
+            y[first_coref, 1] = False
         return y.to(torch.float)
 
     @staticmethod
@@ -652,38 +787,3 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
         for module in self.trainable.values():
             module.train(self._training)
 
-    def _tokenize_docs(self, path: str) -> List[Doc]:
-        logger.debug(f"Tokenizing documents at {path}...", flush=True)
-        out: List[Doc] = []
-        filter_func = TOKENIZER_FILTERS.get(self.config.bert_model,
-                                            lambda _: True)
-        token_map = TOKENIZER_MAPS.get(self.config.bert_model, {})
-        try:
-            with open(path, encoding="utf-8") as fin:
-                data_f = json.load(fin)
-        except json.decoder.JSONDecodeError:
-            # read the old jsonlines format if necessary
-            with open(path, encoding="utf-8") as fin:
-                text = "[" + ",\n".join(fin) + "]"
-            data_f = json.loads(text)
-        logger.info("Loaded %d docs from %s", len(data_f), path)
-        for doc in data_f:
-            doc["span_clusters"] = [[tuple(mention) for mention in cluster]
-                               for cluster in doc["span_clusters"]]
-            word2subword = []
-            subwords = []
-            word_id = []
-            for i, word in enumerate(doc["cased_words"]):
-                tokenized_word = (token_map[word]
-                                  if word in token_map
-                                  else self.tokenizer.tokenize(word))
-                tokenized_word = list(filter(filter_func, tokenized_word))
-                word2subword.append((len(subwords), len(subwords) + len(tokenized_word)))
-                subwords.extend(tokenized_word)
-                word_id.extend([i] * len(tokenized_word))
-            doc["word2subword"] = word2subword
-            doc["subwords"] = subwords
-            doc["word_id"] = word_id
-            out.append(doc)
-        logger.debug("Tokenization OK", flush=True)
-        return out

--- a/stanza/models/coref/model.py
+++ b/stanza/models/coref/model.py
@@ -470,7 +470,7 @@ class CorefModel:  # pylint: disable=too-many-instance-attributes
             import wandb
             wandb.watch((self.bert, self.pw,
                          self.a_scorer, self.we,
-                         self.rough_scorer, self.sp), log_freq=4, log="all")
+                         self.rough_scorer, self.sp))
 
         docs = self._get_docs(self.config.train_data)
         docs_ids = list(range(len(docs)))

--- a/stanza/models/coref/rough_scorer.py
+++ b/stanza/models/coref/rough_scorer.py
@@ -29,7 +29,6 @@ class RoughScorer(torch.nn.Module):
         Returns rough anaphoricity scores for candidates, which consist of
         the bilinear output of the current model summed with mention scores.
         """
-
         # [n_mentions, n_mentions]
         pair_mask = torch.arange(mentions.shape[0])
         pair_mask = pair_mask.unsqueeze(1) - pair_mask.unsqueeze(0)

--- a/stanza/models/coref/rough_scorer.py
+++ b/stanza/models/coref/rough_scorer.py
@@ -29,6 +29,7 @@ class RoughScorer(torch.nn.Module):
         Returns rough anaphoricity scores for candidates, which consist of
         the bilinear output of the current model summed with mention scores.
         """
+
         # [n_mentions, n_mentions]
         pair_mask = torch.arange(mentions.shape[0])
         pair_mask = pair_mask.unsqueeze(1) - pair_mask.unsqueeze(0)
@@ -58,4 +59,4 @@ class RoughScorer(torch.nn.Module):
         top_scores, indices = torch.topk(rough_scores,
                                          k=min(self.k, len(rough_scores)),
                                          dim=1, sorted=False)
-        return top_scores, indices
+        return top_scores, indices, rough_scores

--- a/stanza/models/mwt/trainer.py
+++ b/stanza/models/mwt/trainer.py
@@ -87,10 +87,6 @@ class Trainer(BaseTrainer):
                     pred_tokens.append("".join(pred_seq))
         else:
             pred_tokens = ["".join(seq) for seq in pred_seqs] # join chars to be tokens
-            # if any tokens are predicted to expand to blank,
-            # that is likely an error.  use the original text
-            # this originally came up with the Spanish model turning 's' into a blank
-            pred_tokens = [x if x else y for x, y in zip(pred_tokens, orig_text)]
         if unsort:
             pred_tokens = utils.unsort(pred_tokens, orig_idx)
         return pred_tokens

--- a/stanza/models/mwt/trainer.py
+++ b/stanza/models/mwt/trainer.py
@@ -87,6 +87,10 @@ class Trainer(BaseTrainer):
                     pred_tokens.append("".join(pred_seq))
         else:
             pred_tokens = ["".join(seq) for seq in pred_seqs] # join chars to be tokens
+            # if any tokens are predicted to expand to blank,
+            # that is likely an error.  use the original text
+            # this originally came up with the Spanish model turning 's' into a blank
+            pred_tokens = [x if x else y for x, y in zip(pred_tokens, orig_text)]
         if unsort:
             pred_tokens = utils.unsort(pred_tokens, orig_idx)
         return pred_tokens

--- a/stanza/models/wl_coref.py
+++ b/stanza/models/wl_coref.py
@@ -85,9 +85,22 @@ if __name__ == "__main__":
                                 " Defaults to 'test'."
                                 " Ignored in 'train' mode.")
     argparser.add_argument("--batch-size", type=int,
-                           help="Adjust to override the config value if you're"
-                                " experiencing out-of-memory issues")
-    argparser.add_argument("--warm-start", action="store_true",
+                           help="Adjust to override the config value of anaphoricity "
+                                "batch size if you are experiencing out-of-memory "
+                                "issues")
+    argparser.add_argument("--disable_singletons", action="store_true",
+                           help="don't predict singletons")
+    argparser.add_argument("--hidden_size", type=int,
+                           help="Adjust the anaphoricity scorer hidden size")
+    argparser.add_argument("--rough_k", type=int,
+                           help="Adjust the number of dummies to keep")
+    argparser.add_argument("--n_hidden_layers", type=int,
+                           help="Adjust the anaphoricity scorer hidden layers")
+    argparser.add_argument("--dummy_mix", type=float,
+                           help="Adjust the dummy mix")
+    argparser.add_argument("--bert_finetune_begin_epoch", type=float,
+                           help="Adjust the bert finetune begin epoch")
+    argparser.add_argument("--warm_start", action="store_true",
                            help="If set, the training will resume from the"
                                 " last checkpoint saved if any. Ignored in"
                                 " evaluation modes."
@@ -101,10 +114,14 @@ if __name__ == "__main__":
                            help="If set, output word-level conll-formatted"
                                 " files in evaluation modes. Ignored in"
                                 " 'train' mode.")
+    argparser.add_argument("--learning_rate", default=None, type=float,
+                           help="If set, update the learning rate for the model")
     argparser.add_argument("--bert_learning_rate", default=None, type=float,
                            help="If set, update the learning rate for the transformer")
     argparser.add_argument("--save_dir", default=None,
                            help="If set, update the save directory for writing models")
+    argparser.add_argument("--score_lang", default=None,
+                           help="only score a particular language for eval")
     argparser.add_argument("--log_norms", action="store_true", default=None,
                            help="If set, log all of the trainable norms each epoch.  Very noisy!")
     argparser.add_argument('--wandb', action='store_true', help='Start a wandb session and write the results of training.  Only applies to training.  Use --wandb_name instead to specify a name', default=False)
@@ -120,12 +137,26 @@ if __name__ == "__main__":
     config = CorefModel._load_config(args.config_file, args.experiment)
     if args.batch_size:
         config.a_scoring_batch_size = args.batch_size
+    if args.hidden_size:
+        config.hidden_size = args.hidden_size
+    if args.n_hidden_layers:
+        config.n_hidden_layers = args.n_hidden_layers
+    if args.learning_rate is not None:
+        config.learning_rate = args.learning_rate
     if args.bert_learning_rate is not None:
         config.bert_learning_rate = args.bert_learning_rate
+    if args.bert_finetune_begin_epoch is not None:
+        config.bert_finetune_begin_epoch = args.bert_finetune_begin_epoch
+    if args.dummy_mix is not None:
+        config.dummy_mix = args.dummy_mix
     if args.save_dir is not None:
         config.save_dir = args.save_dir
+    if args.rough_k is not None:
+        config.rough_k = args.rough_k
     if args.log_norms is not None:
         config.log_norms = args.log_norms
+    if args.disable_singletons:
+        config.singletons = False
     # if wandb, generate wandb configuration 
     if args.mode == "train":
         if args.wandb:
@@ -151,5 +182,7 @@ if __name__ == "__main__":
                                               "bert_scheduler", "general_scheduler"},
                                       config_update=config_update)
         results = model.evaluate(data_split=args.data_split,
-                                 word_level_conll=args.word_level)
-        logger.info(results)
+                                 word_level_conll=args.word_level, 
+                                 eval_lang=args.score_lang)
+        # logger.info(("mean loss", "))
+        print("\t".join([str(round(i, 3)) for i in results]))

--- a/stanza/models/wl_coref.py
+++ b/stanza/models/wl_coref.py
@@ -90,6 +90,8 @@ if __name__ == "__main__":
                                 "issues")
     argparser.add_argument("--disable_singletons", action="store_true",
                            help="don't predict singletons")
+    argparser.add_argument("--full_pairwise", action="store_true",
+                           help="use speaker and document embeddings")
     argparser.add_argument("--hidden_size", type=int,
                            help="Adjust the anaphoricity scorer hidden size")
     argparser.add_argument("--rough_k", type=int,
@@ -155,6 +157,8 @@ if __name__ == "__main__":
         config.rough_k = args.rough_k
     if args.log_norms is not None:
         config.log_norms = args.log_norms
+    if args.full_pairwise:
+        config.full_pairwise = args.full_pairwise
     if args.disable_singletons:
         config.singletons = False
     # if wandb, generate wandb configuration 

--- a/stanza/utils/datasets/coref/balance_languages.py
+++ b/stanza/utils/datasets/coref/balance_languages.py
@@ -1,0 +1,60 @@
+"""
+balance_concat.py
+create a test set from a dev set which is language balanced
+"""
+
+import json
+from collections import defaultdict
+
+from random import Random
+
+# fix random seed for reproducability
+R = Random(42)
+
+with open("./corefud_concat_v1_0_langid.train.json", 'r') as df:
+    raw = json.load(df)
+
+# calculate type of each class; then, we will select the one
+# which has the LOWEST counts as the sample rate
+lang_counts = defaultdict(int)
+for i in raw:
+    lang_counts[i["lang"]] += 1
+
+min_lang_count = min(lang_counts.values())
+
+# sample 20% of the smallest amount for test set
+# this will look like an obsurdly small number, but
+# remember this is DOCUMENTS not TOKENS or UTTERANCES
+# so its actually decent
+# also its per language
+test_set_size = int(0.1*min_lang_count)
+
+# sampling input by language
+raw_by_language = defaultdict(list)
+for i in raw:
+    raw_by_language[i["lang"]].append(i)
+languages = list(set(raw_by_language.keys()))
+
+train_set = []
+test_set = []
+for i in languages:
+    length = list(range(len(raw_by_language[i])))
+    choices = R.sample(length, test_set_size)
+
+    for indx,i in enumerate(raw_by_language[i]):
+        if indx in choices:
+            test_set.append(i)
+        else:
+            train_set.append(i)
+
+with open("./corefud_concat_v1_0_langid-bal.train.json", 'w') as df:
+    json.dump(train_set, df, indent=2)
+
+with open("./corefud_concat_v1_0_langid-bal.test.json", 'w') as df:
+    json.dump(test_set, df, indent=2)
+
+
+
+# raw_by_language["en"]
+
+

--- a/stanza/utils/datasets/coref/balance_languages.py
+++ b/stanza/utils/datasets/coref/balance_languages.py
@@ -23,7 +23,7 @@ for i in raw:
 min_lang_count = min(lang_counts.values())
 
 # sample 20% of the smallest amount for test set
-# this will look like an obsurdly small number, but
+# this will look like an absurdly small number, but
 # remember this is DOCUMENTS not TOKENS or UTTERANCES
 # so its actually decent
 # also its per language

--- a/stanza/utils/datasets/coref/convert_ontonotes.py
+++ b/stanza/utils/datasets/coref/convert_ontonotes.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from functools import lru_cache
 import json
 import os
 
@@ -8,65 +7,9 @@ import stanza
 from stanza.models.constituency import tree_reader
 from stanza.utils.default_paths import get_default_paths
 from stanza.utils.get_tqdm import get_tqdm
+from stanza.utils.datasets.coref.utils import find_cconj_head
 
 tqdm = get_tqdm()
-
-# TODO: move this to a utility module and try it on other languages
-class DynamicDepth():
-    """
-    Implements a cache + dynamic programming to find the relative depth of every word in a subphrase given the head word for every word.
-    """
-    def get_parse_depths(self, heads, start, end):
-        """Return the relative depth for every word
-
-        Args:
-            heads (list): List where each entry is the index of that entry's head word in the dependency parse
-            start (int): starting index of the heads for the subphrase
-            end (int): ending index of the heads for the subphrase
-
-        Returns:
-            list: Relative depth in the dependency parse for every word
-        """
-        self.heads = heads[start:end]
-        self.relative_heads = [h - start if h else -100 for h in self.heads] # -100 to deal with 'none' headwords
-
-        depths = [self._get_depth_recursive(h) for h in range(len(self.relative_heads))]
-
-        return depths
-
-    @lru_cache(maxsize=None)
-    def _get_depth_recursive(self, index):
-        """Recursively get the depths of every index using a cache and recursion
-
-        Args:
-            index (int): Index of the word for which to calculate the relative depth
-
-        Returns:
-            int: Relative depth of the word at the index
-        """
-        # if the head for the current index is outside the scope, this index is a relative root
-        if self.relative_heads[index] >= len(self.relative_heads) or self.relative_heads[index] < 0:
-            return 0
-        return self._get_depth_recursive(self.relative_heads[index]) + 1
-
-def find_cconj_head(heads, upos, start, end):
-    """
-    Finds how far each word is from the head of a span, then uses the closest CCONJ to the head as the new head
-
-    If no CCONJ is present, returns None
-    """
-    # use head information to extract parse depth
-    dynamicDepth = DynamicDepth()
-    depth = dynamicDepth.get_parse_depths(heads, start, end)
-    depth_limit = 2
-
-    # return first 'CCONJ' token above depth limit, if exists
-    # unlike the original paper, we expect the parses to use UPOS, hence CCONJ instead of CC
-    cc_indexes = [i for i in range(end - start) if upos[i+start] == 'CCONJ' and depth[i] < depth_limit]
-    if cc_indexes:
-        return cc_indexes[0] + start
-    return None
-
 
 def read_paragraphs(section):
     for doc in section:

--- a/stanza/utils/datasets/coref/convert_udcoref.py
+++ b/stanza/utils/datasets/coref/convert_udcoref.py
@@ -1,77 +1,18 @@
 from collections import defaultdict
-from functools import lru_cache
 import json
 import os
 import re
 import glob
 
-import stanza
-
-from stanza.models.constituency import tree_reader
 from stanza.utils.default_paths import get_default_paths
 from stanza.utils.get_tqdm import get_tqdm
+from stanza.utils.datasets.coref.utils import find_cconj_head
 
 from stanza.utils.conll import CoNLL
 
 tqdm = get_tqdm()
 IS_UDCOREF_FORMAT = True
 UDCOREF_ADDN = 0 if not IS_UDCOREF_FORMAT else 1
-
-# TODO: move this to a utility module and try it on other languages
-class DynamicDepth():
-    """
-    Implements a cache + dynamic programming to find the relative depth of every word in a subphrase given the head word for every word.
-    """
-    def get_parse_depths(self, heads, start, end):
-        """Return the relative depth for every word
-
-        Args:
-            heads (list): List where each entry is the index of that entry's head word in the dependency parse
-            start (int): starting index of the heads for the subphrase
-            end (int): ending index of the heads for the subphrase
-
-        Returns:
-            list: Relative depth in the dependency parse for every word
-        """
-        self.heads = heads[start:end]
-        self.relative_heads = [h - start if h else -100 for h in self.heads] # -100 to deal with 'none' headwords
-
-        depths = [self._get_depth_recursive(h) for h in range(len(self.relative_heads))]
-
-        return depths
-
-    @lru_cache(maxsize=None)
-    def _get_depth_recursive(self, index):
-        """Recursively get the depths of every index using a cache and recursion
-
-        Args:
-            index (int): Index of the word for which to calculate the relative depth
-
-        Returns:
-            int: Relative depth of the word at the index
-        """
-        # if the head for the current index is outside the scope, this index is a relative root
-        if self.relative_heads[index] >= len(self.relative_heads) or self.relative_heads[index] < 0:
-            return 0
-        return self._get_depth_recursive(self.relative_heads[index]) + 1
-
-def find_cconj_head(heads, upos, start, end):
-    """
-    Finds how far each word is from the head of a span, then uses the closest CCONJ to the head as the new head
-
-    If no CCONJ is present, returns None
-    """
-    # use head information to extract parse depth
-    dynamicDepth = DynamicDepth()
-    depth = dynamicDepth.get_parse_depths(heads, start, end)
-    depth_limit = 2
-
-    # return first 'CCONJ' token above depth limit, if exists
-    # unlike the original paper, we expect the parses to use UPOS, hence CCONJ instead of CC
-    cc_indexes = [i for i in range(end - start) if upos[i+start] == 'CCONJ' and depth[i] < depth_limit]
-    if cc_indexes:
-        return cc_indexes[0] + start
-    return None
 
 def process_documents(docs):
     processed_section = []

--- a/stanza/utils/datasets/coref/convert_udcoref.py
+++ b/stanza/utils/datasets/coref/convert_udcoref.py
@@ -1,0 +1,240 @@
+from collections import defaultdict
+from functools import lru_cache
+import json
+import os
+import re
+import glob
+
+import stanza
+
+from stanza.models.constituency import tree_reader
+from stanza.utils.default_paths import get_default_paths
+from stanza.utils.get_tqdm import get_tqdm
+
+from stanza.utils.conll import CoNLL
+
+tqdm = get_tqdm()
+IS_UDCOREF_FORMAT = True
+UDCOREF_ADDN = 0 if not IS_UDCOREF_FORMAT else 1
+
+# TODO: move this to a utility module and try it on other languages
+class DynamicDepth():
+    """
+    Implements a cache + dynamic programming to find the relative depth of every word in a subphrase given the head word for every word.
+    """
+    def get_parse_depths(self, heads, start, end):
+        """Return the relative depth for every word
+
+        Args:
+            heads (list): List where each entry is the index of that entry's head word in the dependency parse
+            start (int): starting index of the heads for the subphrase
+            end (int): ending index of the heads for the subphrase
+
+        Returns:
+            list: Relative depth in the dependency parse for every word
+        """
+        self.heads = heads[start:end]
+        self.relative_heads = [h - start if h else -100 for h in self.heads] # -100 to deal with 'none' headwords
+
+        depths = [self._get_depth_recursive(h) for h in range(len(self.relative_heads))]
+
+        return depths
+
+    @lru_cache(maxsize=None)
+    def _get_depth_recursive(self, index):
+        """Recursively get the depths of every index using a cache and recursion
+
+        Args:
+            index (int): Index of the word for which to calculate the relative depth
+
+        Returns:
+            int: Relative depth of the word at the index
+        """
+        # if the head for the current index is outside the scope, this index is a relative root
+        if self.relative_heads[index] >= len(self.relative_heads) or self.relative_heads[index] < 0:
+            return 0
+        return self._get_depth_recursive(self.relative_heads[index]) + 1
+
+def find_cconj_head(heads, upos, start, end):
+    """
+    Finds how far each word is from the head of a span, then uses the closest CCONJ to the head as the new head
+
+    If no CCONJ is present, returns None
+    """
+    # use head information to extract parse depth
+    dynamicDepth = DynamicDepth()
+    depth = dynamicDepth.get_parse_depths(heads, start, end)
+    depth_limit = 2
+
+    # return first 'CCONJ' token above depth limit, if exists
+    # unlike the original paper, we expect the parses to use UPOS, hence CCONJ instead of CC
+    cc_indexes = [i for i in range(end - start) if upos[i+start] == 'CCONJ' and depth[i] < depth_limit]
+    if cc_indexes:
+        return cc_indexes[0] + start
+    return None
+
+def process_documents(docs):
+    processed_section = []
+
+    for idx, (doc, doc_id, lang) in enumerate(tqdm(docs)):
+        # extract the entities
+        # get sentence words and lengths
+        sentences = [[j.text for j in i.words]
+                    for i in doc.sentences]
+        sentence_lens = [len(x.words) for x in doc.sentences]
+        cased_words = [y for x in sentences for y in x]
+        sent_id = [y for idx, sent_len in enumerate(sentence_lens) for y in [idx] * sent_len]
+
+        word_total = 0
+        heads = []
+        # TODO: does SD vs UD matter?
+        deprel = []
+        for sentence in doc.sentences:
+            for word in sentence.words:
+                deprel.append(word.deprel)
+                if word.head == 0:
+                    heads.append("null")
+                else:
+                    heads.append(word.head - 1 + word_total)
+            word_total += len(sentence.words)
+
+        span_clusters = defaultdict(list)
+        word_clusters = defaultdict(list)
+        head2span = []
+        word_total = 0
+        SPANS = re.compile("(\(\w+|[%\w]+\))")
+        for parsed_sentence in doc.sentences:
+            # spans regex
+            # parse the misc column, leaving on "Entity" entries
+            misc = [[k.split("=")
+                    for k in j
+                    if k.split("=")[0] == "Entity"]
+                    for i in parsed_sentence.words
+                    for j in [i.misc.split("|") if i.misc else []]]
+            # and extract the Entity entry values
+            entities = [i[0][1] if len(i) > 0 else None for i in misc]
+            # extract reference information
+            refs = [SPANS.findall(i) if i else [] for i in entities]
+            # and calculate spans: the basic rule is (e... begins a reference
+            # and ) without e before ends the most recent reference
+            # every single time we get a closing element, we pop it off
+            # the refdict and insert the pair to final_refs
+            refdict = defaultdict(list)
+            final_refs = defaultdict(list)
+            last_ref = None
+            for indx, i in enumerate(refs):
+                for j in i:
+                    # this is the beginning of a reference
+                    if j[0] == "(":
+                        refdict[j[1+UDCOREF_ADDN:]].append(indx)
+                        last_ref = j[1+UDCOREF_ADDN:]
+                    # at the end of a reference, if we got exxxxx, that ends
+                    # a particular refereenc; otherwise, it ends the last reference
+                    elif j[-1] == ")" and j[UDCOREF_ADDN:-1].isnumeric():
+                        if (not UDCOREF_ADDN) or j[0] == "e":
+                            try:
+                                final_refs[j[UDCOREF_ADDN:-1]].append((refdict[j[UDCOREF_ADDN:-1]].pop(-1), indx))
+                            except IndexError:
+                                # this is probably zero anaphora
+                                continue
+                    elif j[-1] == ")":
+                        final_refs[last_ref].append((refdict[last_ref].pop(-1), indx))
+                        last_ref = None
+            final_refs = dict(final_refs)
+            # convert it to the right format (specifically, in (ref, start, end) tuples)
+            coref_spans = []
+            for k, v in final_refs.items():
+                for i in v:
+                    coref_spans.append([int(k), i[0], i[1]])
+            sentence_upos = [x.upos for x in parsed_sentence.words]
+            sentence_heads = [x.head - 1 if x.head > 0 else None for x in parsed_sentence.words]
+            for span in coref_spans:
+                # input is expected to be start word, end word + 1
+                # counting from 0
+                # whereas the OntoNotes coref_span is [start_word, end_word] inclusive
+                span_start = span[1] + word_total
+                span_end = span[2] + word_total + 1
+                candidate_head = find_cconj_head(sentence_heads, sentence_upos, span[1], span[2]+1)
+                if candidate_head is None:
+                    for candidate_head in range(span[1], span[2] + 1):
+                        # stanza uses 0 to mark the head, whereas OntoNotes is counting
+                        # words from 0, so we have to subtract 1 from the stanza heads
+                        #print(span, candidate_head, parsed_sentence.words[candidate_head].head - 1)
+                        # treat the head of the phrase as the first word that has a head outside the phrase
+                        if (parsed_sentence.words[candidate_head].head - 1 < span[1] or
+                            parsed_sentence.words[candidate_head].head - 1 > span[2]):
+                            break
+                    else:
+                        # if none have a head outside the phrase (circular??)
+                        # then just take the first word
+                        candidate_head = span[1]
+                #print("----> %d" % candidate_head)
+                candidate_head += word_total
+                span_clusters[span[0]].append((span_start, span_end))
+                word_clusters[span[0]].append(candidate_head)
+                head2span.append((candidate_head, span_start, span_end))
+            word_total += len(parsed_sentence.words)
+        span_clusters = sorted([sorted(values) for _, values in span_clusters.items()])
+        word_clusters = sorted([sorted(values) for _, values in word_clusters.items()])
+        head2span = sorted(head2span)
+
+        processed = {
+            "document_id": doc_id,
+            "cased_words": cased_words,
+            "sent_id": sent_id,
+            "part_id": idx,
+            # "pos": pos,
+            "deprel": deprel,
+            "head": heads,
+            "span_clusters": span_clusters,
+            "word_clusters": word_clusters,
+            "head2span": head2span,
+            "lang": lang
+        }
+        processed_section.append(processed)
+    return processed_section
+
+SECTION_NAMES = ["train", "dev"]
+# , "test"
+SHORT_NAME = "corefud_concat_v1_0_langid"
+LANGUAGE = "multi"
+CONCAT = True
+
+def process_dataset(short_name, conllu_path, coref_output_path):
+
+    for section in SECTION_NAMES:
+        if not CONCAT:
+            load = os.path.join(conllu_path, f"{short_name}-{section}.conllu")
+            print("Processing %s from %s" % (section, load))
+            input_file = CoNLL.conll2multi_docs(load, return_doc_ids=True)
+            lang = load.split("/")[-1].split("_")[0]
+            input_file = (input_file[0],
+                          input_file[1],
+                          lang)
+        else:
+            loads = glob.glob(os.path.join(conllu_path, f"*{section}.conllu"))
+            input_file = []
+            for load in loads:
+                lang = load.split("/")[-1].split("_")[0]
+                print("Ingesting %s from %s of lang %s" % (section, load, lang))
+                docs = CoNLL.conll2multi_docs(load, return_doc_ids=True)
+                for i in docs:
+                    input_file.append((i[0], i[1], lang))
+            print("Ingested %d documents" % len(input_file))
+
+        converted_section = process_documents(input_file)
+
+        output_filename = os.path.join(coref_output_path, "%s.%s.json" % (short_name, section))
+        with open(output_filename, "w", encoding="utf-8") as fout:
+            json.dump(converted_section, fout, indent=2)
+
+def main():
+    paths = get_default_paths()
+    coref_input_path = paths['COREF_BASE']
+    conll_path = os.path.join(coref_input_path, LANGUAGE, SHORT_NAME)
+    coref_output_path = paths['COREF_DATA_DIR']
+    process_dataset(SHORT_NAME, conll_path, coref_output_path)
+
+if __name__ == '__main__':
+    main()
+

--- a/stanza/utils/datasets/coref/utils.py
+++ b/stanza/utils/datasets/coref/utils.py
@@ -1,0 +1,57 @@
+from functools import lru_cache
+
+class DynamicDepth():
+    """
+    Implements a cache + dynamic programming to find the relative depth of every word in a subphrase given the head word for every word.
+    """
+    def get_parse_depths(self, heads, start, end):
+        """Return the relative depth for every word
+
+        Args:
+            heads (list): List where each entry is the index of that entry's head word in the dependency parse
+            start (int): starting index of the heads for the subphrase
+            end (int): ending index of the heads for the subphrase
+
+        Returns:
+            list: Relative depth in the dependency parse for every word
+        """
+        self.heads = heads[start:end]
+        self.relative_heads = [h - start if h else -100 for h in self.heads] # -100 to deal with 'none' headwords
+
+        depths = [self._get_depth_recursive(h) for h in range(len(self.relative_heads))]
+
+        return depths
+
+    @lru_cache(maxsize=None)
+    def _get_depth_recursive(self, index):
+        """Recursively get the depths of every index using a cache and recursion
+
+        Args:
+            index (int): Index of the word for which to calculate the relative depth
+
+        Returns:
+            int: Relative depth of the word at the index
+        """
+        # if the head for the current index is outside the scope, this index is a relative root
+        if self.relative_heads[index] >= len(self.relative_heads) or self.relative_heads[index] < 0:
+            return 0
+        return self._get_depth_recursive(self.relative_heads[index]) + 1
+
+def find_cconj_head(heads, upos, start, end):
+    """
+    Finds how far each word is from the head of a span, then uses the closest CCONJ to the head as the new head
+
+    If no CCONJ is present, returns None
+    """
+    # use head information to extract parse depth
+    dynamicDepth = DynamicDepth()
+    depth = dynamicDepth.get_parse_depths(heads, start, end)
+    depth_limit = 2
+
+    # return first 'CCONJ' token above depth limit, if exists
+    # unlike the original paper, we expect the parses to use UPOS, hence CCONJ instead of CC
+    cc_indexes = [i for i in range(end - start) if upos[i+start] == 'CCONJ' and depth[i] < depth_limit]
+    if cc_indexes:
+        return cc_indexes[0] + start
+    return None
+


### PR DESCRIPTION
adds support for multilingual and singletons support through `xlm-roberta-large` and `t5-large`.

- adds Rn -> R1 projection anaphoricity scorer for start-of-chain in order to have singletons
- integrates newer PEFT architecture for FTing xlm-roberta with adaptors
- created adapter for CorefUD data
- training throughput fixes for long documents