### PR TITLE
Faster bert

### DIFF
--- a/stanza/models/constituency/parser_training.py
+++ b/stanza/models/constituency/parser_training.py
@@ -13,6 +13,7 @@ from torch import nn
 from stanza.models.common import utils
 from stanza.models.common.foundation_cache import FoundationCache, NoTransformerFoundationCache
 from stanza.models.common.large_margin_loss import LargeMarginInSoftmaxLoss
+from stanza.models.common.utils import sort_with_indices, unsort
 from stanza.models.constituency import parse_transitions
 from stanza.models.constituency import transition_sequence
 from stanza.models.constituency import tree_reader
@@ -680,8 +681,10 @@ def run_dev_set(model, retagged_trees, original_trees, args, evaluator=None):
     num_generate = args.get('num_generate', 0)
     keep_scores = num_generate > 0
 
-    tree_iterator = iter(tqdm(retagged_trees))
+    sorted_trees, original_indices = sort_with_indices(retagged_trees, key=len, reverse=True)
+    tree_iterator = iter(tqdm(sorted_trees))
     treebank = model.parse_sentences_no_grad(tree_iterator, model.build_batch_from_trees, args['eval_batch_size'], model.predict, keep_scores=keep_scores)
+    treebank = unsort(treebank, original_indices)
     full_results = treebank
 
     if num_generate > 0:

--- a/stanza/pipeline/constituency_processor.py
+++ b/stanza/pipeline/constituency_processor.py
@@ -5,6 +5,7 @@ Processor that attaches a constituency tree to a sentence
 from stanza.models.constituency.trainer import Trainer
 
 from stanza.models.common import doc
+from stanza.models.common.utils import sort_with_indices, unsort
 from stanza.utils.get_tqdm import get_tqdm
 from stanza.pipeline._constants import *
 from stanza.pipeline.processor import UDProcessor, register_processor
@@ -54,10 +55,12 @@ class ConstituencyProcessor(UDProcessor):
             words = [[(w.text, w.xpos) for w in s.words] for s in sentences]
         else:
             words = [[(w.text, w.upos) for w in s.words] for s in sentences]
+        words, original_indices = sort_with_indices(words, key=len, reverse=True)
         if self._tqdm:
             words = tqdm(words)
 
         trees = self._model.parse_tagged_words(words, self._batch_size)
+        trees = unsort(trees, original_indices)
         document.set(CONSTITUENCY, trees, to_sentence=True)
         return document
 

--- a/stanza/tests/common/test_bert_embedding.py
+++ b/stanza/tests/common/test_bert_embedding.py
@@ -1,0 +1,33 @@
+import pytest
+import torch
+
+from stanza.models.common.bert_embedding import load_bert, extract_bert_embeddings
+
+pytestmark = [pytest.mark.travis, pytest.mark.pipeline]
+
+BERT_MODEL = "hf-internal-testing/tiny-bert"
+
+@pytest.fixture(scope="module")
+def tiny_bert():
+    m, t = load_bert(BERT_MODEL)
+    return m, t
+
+def test_load_bert(tiny_bert):
+    """
+    Empty method that just tests loading the bert
+    """
+    m, t = tiny_bert
+
+def test_run_bert(tiny_bert):
+    m, t = tiny_bert
+    device = next(m.parameters()).device
+    extract_bert_embeddings(BERT_MODEL, t, m, [["This", "is", "a", "test"]], device, True)
+
+def test_run_bert_empty_word(tiny_bert):
+    m, t = tiny_bert
+    device = next(m.parameters()).device
+    foo = extract_bert_embeddings(BERT_MODEL, t, m, [["This", "is", "-", "a", "test"]], device, True)
+    bar = extract_bert_embeddings(BERT_MODEL, t, m, [["This", "is", "", "a", "test"]], device, True)
+
+    assert len(foo) == 1
+    assert torch.allclose(foo[0], bar[0])


### PR DESCRIPTION
A couple updates to the usage of bert, especially in the constituency parser - doesn't double tokenize, sort sentences by length to keep larger bert requests together