### PR TITLE
Contextual tokenizer

### DIFF
--- a/stanza/models/tokenization/model.py
+++ b/stanza/models/tokenization/model.py
@@ -32,7 +32,7 @@ class SentenceAnalyzer(nn.Module):
 
     def forward(self, x):
         # map the vocab to pretrain IDs
-        embs = self.embeddings(torch.tensor([[self.vocab[j] for j in i] for i in x],
+        embs = self.embeddings(torch.tensor([[self.vocab[j.strip()] for j in i] for i in x],
                                            device=self.device))
         net = self.emb_proj(embs)
         net = self.conv(net.permute(0,2,1)).permute(0,2,1)

--- a/stanza/models/tokenization/model.py
+++ b/stanza/models/tokenization/model.py
@@ -36,7 +36,7 @@ class SentenceAnalyzer(nn.Module):
         embs = self.embeddings(torch.tensor(token_ids, device=self.device))
         net = self.emb_proj(embs) 
         net = self.lstm(net)[0]
-        return self.final_proj @ net
+        return net @ self.final_proj
 
 
 class Tokenizer(nn.Module):

--- a/stanza/models/tokenization/model.py
+++ b/stanza/models/tokenization/model.py
@@ -138,7 +138,10 @@ class Tokenizer(nn.Module):
         if self.args["sentence_second_pass"]:
             # these are the draft predictions for only token-level decisinos
             # which we can use to slice the text
-            draft_preds = torch.cat([nontok, tok+nonmwt, tok+mwt], 2).argmax(dim=2)
+            if self.args['use_mwt']:
+                draft_preds = torch.cat([nontok, tok+nonmwt, tok+mwt], 2).argmax(dim=2)
+            else:
+                draft_preds = torch.cat([nontok, tok], 2).argmax(dim=2)
             draft_preds = (draft_preds > 0)
             # we add a prefix zero
             # TODO inefficient / how to parallelize this?

--- a/stanza/models/tokenization/model.py
+++ b/stanza/models/tokenization/model.py
@@ -20,26 +20,16 @@ class SentenceAnalyzer(nn.Module):
         self.lstm = nn.LSTM(hidden_dim, hidden_dim, bidirectional=True,
                               batch_first=True, num_layers=args['rnn_layers'])
 
-        self.ffnn = nn.Sequential(
-            nn.Linear(hidden_dim*2, hidden_dim*4),
-            nn.ReLU(),
-            nn.Linear(hidden_dim*4, hidden_dim),
-            nn.LayerNorm(hidden_dim),
-            nn.ReLU(),
-            nn.Linear(hidden_dim, hidden_dim),
-            nn.ReLU(),
-            nn.Linear(hidden_dim, 1)
-        )
+        self.ffnn = nn.Linear(hidden_dim*2, 1, bias=False)
 
     @property
     def device(self):
         return next(self.parameters()).device
 
-    def forward(self, x):
+    def forward(self, x, s0):
         # map the vocab to pretrain IDs
         token_ids = [[self.vocab[j.strip()] for j in i] for i in x]
-        embs = self.embeddings(torch.tensor(token_ids,
-                                           device=self.device))
+        embs = self.embeddings(torch.tensor(token_ids, device=self.device))
         net = self.emb_proj(embs)
         net = self.lstm(net)[0]
         return self.ffnn(net)
@@ -82,6 +72,8 @@ class Tokenizer(nn.Module):
 
         if args['sentence_second_pass']:
             self.sent_2nd_pass_clf = SentenceAnalyzer(args, pretrain, hidden_dim)
+            self.sent_2nd_smoother = nn.Conv1d(1, 1, args["sentence_analyzer_kernel"], padding="same", padding_mode="replicate")
+            self.sent_2nd_mix = nn.Parameter(torch.full((1,), 0.0), requires_grad=True)
 
         self.dropout = nn.Dropout(dropout)
         self.dropout_feat = nn.Dropout(feat_dropout)
@@ -187,7 +179,7 @@ class Tokenizer(nn.Module):
                 batch_tokens_isntpad.append([True for _ in range(len(i))] +
                                             [False for _ in range(max_size-len(i))])
 
-            second_pass_scores = self.sent_2nd_pass_clf(batch_tokens_padded)
+            second_pass_scores = self.sent_2nd_pass_clf(batch_tokens_padded, sent0[draft_preds])
 
             # # we only add scores for slots for which we have a possible word ending
             # # i.e. its not padding and its also not a middle of rough score's resulting
@@ -195,7 +187,12 @@ class Tokenizer(nn.Module):
             second_pass_chars_align = torch.zeros_like(sent0)
             second_pass_chars_align[draft_preds] = second_pass_scores[torch.tensor(batch_tokens_isntpad)]
 
-            sent0 += second_pass_chars_align
+            mix = F.sigmoid(self.sent_2nd_mix)
+            smoothed = self.sent_2nd_smoother(
+                second_pass_chars_align.permute(0,2,1)
+            ).permute(0,2,1)
+
+            sent0 = (1-mix)*sent0 + mix*smoothed
 
         nonsent = F.logsigmoid(-sent0)
         sent = F.logsigmoid(sent0)

--- a/stanza/models/tokenization/model.py
+++ b/stanza/models/tokenization/model.py
@@ -1,12 +1,50 @@
 import torch
 import torch.nn.functional as F
 import torch.nn as nn
+from itertools import tee
+
+from stanza.models.common.seq2seq_constant import PAD, UNK, UNK_ID
+
+class SentenceAnalyzer(nn.Module):
+    def __init__(self, args, pretrain, hidden_dim, device=None):
+        super().__init__()
+
+        assert pretrain != None, "2nd pass sentence anayzer is missing pretrain word vectors"
+
+        self.args = args
+        self.vocab = pretrain.vocab
+        self.embeddings = nn.Embedding.from_pretrained(
+            torch.from_numpy(pretrain.emb), freeze=True)
+
+        self.emb_proj = nn.Linear(pretrain.emb.shape[1], hidden_dim)
+        self.conv = nn.Conv1d(hidden_dim, hidden_dim,
+                              args["sentence_analyzer_kernel"], padding="same",
+                              padding_mode="circular")
+        self.ffnn = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1)
+        )
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    def forward(self, x):
+        # map the vocab to pretrain IDs
+        embs = self.embeddings(torch.tensor([[self.vocab[j] for j in i] for i in x],
+                                           device=self.device))
+        net = self.emb_proj(embs)
+        net = self.conv(net.permute(0,2,1)).permute(0,2,1)
+        return self.ffnn(net)
+
 
 class Tokenizer(nn.Module):
-    def __init__(self, args, nchars, emb_dim, hidden_dim, dropout, feat_dropout):
+    def __init__(self, args, nchars, emb_dim, hidden_dim, dropout, feat_dropout, pretrain=None):
         super().__init__()
 
         self.args = args
+        self.pretrain = pretrain
         feat_dim = args['feat_dim']
 
         self.embeddings = nn.Embedding(nchars, emb_dim, padding_idx=0)
@@ -36,12 +74,15 @@ class Tokenizer(nn.Module):
             if self.args['use_mwt']:
                 self.mwt_clf2 = nn.Linear(hidden_dim * 2, 1, bias=False)
 
+        if args['sentence_second_pass']:
+            self.sent_2nd_pass_clf = SentenceAnalyzer(args, pretrain, hidden_dim)
+
         self.dropout = nn.Dropout(dropout)
         self.dropout_feat = nn.Dropout(feat_dropout)
 
         self.toknoise = nn.Dropout(self.args['tok_noise'])
 
-    def forward(self, x, feats):
+    def forward(self, x, feats, text):
         emb = self.embeddings(x)
         emb = self.dropout(emb)
         feats = self.dropout_feat(feats)
@@ -87,11 +128,85 @@ class Tokenizer(nn.Module):
 
         nontok = F.logsigmoid(-tok0)
         tok = F.logsigmoid(tok0)
-        nonsent = F.logsigmoid(-sent0)
-        sent = F.logsigmoid(sent0)
         if self.args['use_mwt']:
             nonmwt = F.logsigmoid(-mwt0)
             mwt = F.logsigmoid(mwt0)
+
+        # use the rough predictions from the char tokenizer to create word tokens
+        # then use those word tokens + contextual/fixed word embeddings to refine
+        # sentence predictions
+        if self.args["sentence_second_pass"]:
+            # these are the draft predictions for only token-level decisinos
+            # which we can use to slice the text
+            draft_preds = torch.cat([nontok, tok+nonmwt, tok+mwt], 2).argmax(dim=2)
+            draft_preds = (draft_preds > 0)
+            # we add a prefix zero
+            # TODO inefficient / how to parallelize this?
+            token_locations = [[-1] + i.nonzero().squeeze(1).cpu().tolist()
+                               for i in draft_preds]
+
+            # both: batch x seq x [variable: text token count]
+            batch_tokens = [] # str tokens 
+            batch_tokenid_locations = [] # id locations for the *end* of each str token
+                                         # corresponding to char token
+            for location,chars, toks in zip(token_locations, text, x):
+                # we append len(chars)-1 to append  the last token which wouldn't
+                # necessearily have been captured by the splits; though in theory
+                # the model should put a token at the end of each sentence so this
+                # should be less of a problem
+
+                a,b = tee(location+[len(chars)-1])
+                tokens = []
+                tokenid_locations = []
+                next(b) # because we want to start iterating on the NEXT id to create pairs
+                j = -1
+                for i,j in zip(a,b):
+                    split = chars[i+1:j+1]
+                    # if the entire unit is UNK, leave as UNK into the predictor
+                    is_unk = ((toks[i+1:j+1]) == UNK_ID).all().cpu().item()
+                    if set(split) == set([PAD]):
+                        continue
+                    tokenid_locations.append(j)
+
+                    if not is_unk:
+                        tokens.append("".join(split).replace(PAD, ""))
+                    else:
+                        tokens.append(UNK)
+
+                batch_tokens.append(tokens)
+                batch_tokenid_locations.append(tokenid_locations)
+
+            # dynamically pad the batch tokens to size
+            # why max 5? our 
+            max_size = max(max([len(i) for i in batch_tokens]),
+                           self.args["sentence_analyzer_kernel"])
+            batch_tokens_padded = []
+            batch_tokens_isntpad = []
+            for i in batch_tokens:
+                batch_tokens_padded.append(i + [PAD for _ in range(max_size-len(i))])
+                batch_tokens_isntpad.append([True for _ in range(len(i))] +
+                                            [False for _ in range(max_size-len(i))])
+
+            ##### TODO EVERYTHING BELOW THIS LINE IS UNTESTED #####
+            second_pass_scores = self.sent_2nd_pass_clf(batch_tokens_padded)
+
+            # we only add scores for slots for which we have a possible word ending
+            # i.e. its not padding and its also not a middle of rough score's resulting
+            # words
+            second_pass_chars_align = torch.zeros_like(sent0)
+            token_location_selectors = torch.tensor([[i,k] for i,j in
+                                                     enumerate(batch_tokenid_locations)
+                                                     for k in j])
+
+            second_pass_chars_align[
+                token_location_selectors[:,0],
+                token_location_selectors[:,1]
+            ] = second_pass_scores[torch.tensor(batch_tokens_isntpad)]
+
+            sent0 += second_pass_chars_align
+
+        nonsent = F.logsigmoid(-sent0)
+        sent = F.logsigmoid(sent0)
 
         if self.args['use_mwt']:
             pred = torch.cat([nontok, tok+nonsent+nonmwt, tok+sent+nonmwt, tok+nonsent+mwt, tok+sent+mwt], 2)

--- a/stanza/models/tokenization/model.py
+++ b/stanza/models/tokenization/model.py
@@ -27,13 +27,12 @@ class SentenceAnalyzer(nn.Module):
     def device(self):
         return next(self.parameters()).device
 
-    def forward(self, x, inp0, pad_mask):
+    def forward(self, x):
         # map the vocab to pretrain IDs
         token_ids = [[self.vocab[j.strip()] for j in i] for i in x]
         embs = self.embeddings(torch.tensor(token_ids, device=self.device))
         net = self.emb_proj(embs) 
         net = self.lstm(net)[0]
-        net[pad_mask] += inp0
         return self.ffnn(net)
 
 
@@ -184,7 +183,7 @@ class Tokenizer(nn.Module):
                                             [False for _ in range(max_size-len(i))])
 
             pad_mask = torch.tensor(batch_tokens_isntpad)
-            second_pass_scores = self.sent_2nd_pass_clf(batch_tokens_padded, inp[draft_preds], pad_mask)
+            second_pass_scores = self.sent_2nd_pass_clf(batch_tokens_padded)
 
             # # we only add scores for slots for which we have a possible word ending
             # # i.e. its not padding and its also not a middle of rough score's resulting

--- a/stanza/models/tokenization/trainer.py
+++ b/stanza/models/tokenization/trainer.py
@@ -15,9 +15,7 @@ logger = logging.getLogger('stanza')
 
 class Trainer(BaseTrainer):
     def __init__(self, args=None, vocab=None, lexicon=None, dictionary=None, model_file=None, device=None, pretrain=None):
-        if args["sentence_second_pass"]:
-            assert bool(pretrain), "context-aware sentence analysis requires pretrained wordvectors; download them!"
-
+        self.pretrain = pretrain
         if model_file is not None:
             # load everything from file
             self.load(model_file)
@@ -28,6 +26,10 @@ class Trainer(BaseTrainer):
             self.lexicon = lexicon
             self.dictionary = dictionary
             self.model = Tokenizer(self.args, self.args['vocab_size'], self.args['emb_dim'], self.args['hidden_dim'], dropout=self.args['dropout'], feat_dropout=self.args['feat_dropout'], pretrain=pretrain)
+
+        if self.args["sentence_second_pass"]:
+            assert bool(pretrain), "context-aware sentence analysis requires pretrained wordvectors; download them!"
+
         self.model = self.model.to(device)
         self.criterion = nn.CrossEntropyLoss(ignore_index=-1).to(device)
         self.optimizer = utils.get_optimizer("adam", self.model, lr=self.args['lr0'], betas=(.9, .9), weight_decay=self.args['weight_decay'])
@@ -92,7 +94,7 @@ class Trainer(BaseTrainer):
             # Default to True as many currently saved models
             # were built with mwt layers
             self.args['use_mwt'] = True
-        self.model = Tokenizer(self.args, self.args['vocab_size'], self.args['emb_dim'], self.args['hidden_dim'], dropout=self.args['dropout'], feat_dropout=self.args['feat_dropout'])
+        self.model = Tokenizer(self.args, self.args['vocab_size'], self.args['emb_dim'], self.args['hidden_dim'], dropout=self.args['dropout'], feat_dropout=self.args['feat_dropout'], pretrain=self.pretrain)
         self.model.load_state_dict(checkpoint['model'])
         self.vocab = Vocab.load_state_dict(checkpoint['vocab'])
         self.lexicon = checkpoint['lexicon']

--- a/stanza/models/tokenizer.py
+++ b/stanza/models/tokenizer.py
@@ -64,7 +64,7 @@ def build_argparse():
     parser.add_argument('--no-residual', dest='residual', action='store_false', help="Add linear residual connections")
     parser.add_argument('--no-hierarchical', dest='hierarchical', action='store_false', help="\"Hierarchical\" RNN tokenizer")
     parser.add_argument('--no_sentence_second_pass', dest='sentence_second_pass', action='store_false', help="predict the sentences together with tokens instead of after")
-    parser.add_argument('--second_pass_start_steps', type=int, help="when (how many steps) to start training the second pass classifier", default=256)
+    parser.add_argument('--second_pass_start_steps', type=int, help="when (how many steps) to start training the second pass classifier", default=5000)
     parser.add_argument('--hier_invtemp', type=float, default=0.5, help="Inverse temperature used in propagating tokenization predictions between RNN layers")
     parser.add_argument('--input_dropout', action='store_true', help="Dropout input embeddings as well")
     parser.add_argument('--conv_res', type=str, default=None, help="Convolutional residual layers for the RNN")

--- a/stanza/models/tokenizer.py
+++ b/stanza/models/tokenizer.py
@@ -64,6 +64,7 @@ def build_argparse():
     parser.add_argument('--no-residual', dest='residual', action='store_false', help="Add linear residual connections")
     parser.add_argument('--no-hierarchical', dest='hierarchical', action='store_false', help="\"Hierarchical\" RNN tokenizer")
     parser.add_argument('--no_sentence_second_pass', dest='sentence_second_pass', action='store_false', help="predict the sentences together with tokens instead of after")
+    parser.add_argument('--second_pass_start_steps', type=int, help="when (how many steps) to start training the second pass classifier", default=256)
     parser.add_argument('--hier_invtemp', type=float, default=0.5, help="Inverse temperature used in propagating tokenization predictions between RNN layers")
     parser.add_argument('--input_dropout', action='store_true', help="Dropout input embeddings as well")
     parser.add_argument('--conv_res', type=str, default=None, help="Convolutional residual layers for the RNN")
@@ -214,6 +215,10 @@ def train(args):
         batch = train_batches.next(unit_dropout=args['unit_dropout'], feat_unit_dropout = args['feat_unit_dropout'])
 
         loss = trainer.update(batch)
+
+        if trainer.steps > args["second_pass_start_steps"]:
+            trainer.train_2nd_pass = True
+
         if step % args['report_steps'] == 0:
             logger.info("Step {:6d}/{:6d} Loss: {:.3f}".format(step, steps, loss))
             if args['wandb']:

--- a/stanza/models/tokenizer.py
+++ b/stanza/models/tokenizer.py
@@ -214,10 +214,10 @@ def train(args):
     for step in range(1, steps+1):
         batch = train_batches.next(unit_dropout=args['unit_dropout'], feat_unit_dropout = args['feat_unit_dropout'])
 
-        loss = trainer.update(batch)
-
         if trainer.steps > args["second_pass_start_steps"]:
             trainer.train_2nd_pass = True
+
+        loss = trainer.update(batch)
 
         if step % args['report_steps'] == 0:
             logger.info("Step {:6d}/{:6d} Loss: {:.3f}".format(step, steps, loss))

--- a/stanza/models/tokenizer.py
+++ b/stanza/models/tokenizer.py
@@ -53,7 +53,7 @@ def build_argparse():
     parser.add_argument('--wordvec_pretrain_file', type=str, default=None, help='Exact name of the pretrain file to read')
     parser.add_argument('--pretrain_max_vocab', type=int, default=250000)
 
-    parser.add_argument('--sentence-analyzer-kernel', type=int, default=4)
+    parser.add_argument('--sentence_analyzer_kernel', type=int, default=4)
 
     parser.add_argument('--mode', default='train', choices=['train', 'predict'])
     parser.add_argument('--skip_newline', action='store_true', help="Whether to skip newline characters in input. Particularly useful for languages like Chinese.")
@@ -63,7 +63,7 @@ def build_argparse():
     parser.add_argument('--conv_filters', type=str, default="1,9", help="Configuration of conv filters. ,, separates layers and , separates filter sizes in the same layer.")
     parser.add_argument('--no-residual', dest='residual', action='store_false', help="Add linear residual connections")
     parser.add_argument('--no-hierarchical', dest='hierarchical', action='store_false', help="\"Hierarchical\" RNN tokenizer")
-    parser.add_argument('--no-sentence-second-pass', dest='sentence_second_pass', action='store_false', help="predict the sentences together with tokens instead of after")
+    parser.add_argument('--no_sentence_second_pass', dest='sentence_second_pass', action='store_false', help="predict the sentences together with tokens instead of after")
     parser.add_argument('--hier_invtemp', type=float, default=0.5, help="Inverse temperature used in propagating tokenization predictions between RNN layers")
     parser.add_argument('--input_dropout', action='store_true', help="Dropout input embeddings as well")
     parser.add_argument('--conv_res', type=str, default=None, help="Convolutional residual layers for the RNN")

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -37,11 +37,14 @@ class TokenizeProcessor(UDProcessor):
     MAX_SEQ_LENGTH_DEFAULT = 1000
 
     def _set_up_model(self, config, pipeline, device):
+        # get pretrained word vectors
+        self._pretrain = pipeline.foundation_cache.load_pretrain(config['pretrain_path']) if 'pretrain_path' in config else None
+
         # set up trainer
         if config.get('pretokenized'):
             self._trainer = None
         else:
-            self._trainer = Trainer(model_file=config['model_path'], device=device)
+            self._trainer = Trainer(model_file=config['model_path'], device=device, pretrain=self.pretrain)
 
         # get and typecheck the postprocessor
         postprocessor = config.get('postprocessor')


### PR DESCRIPTION
create a second tokenization stage which uses contextual *word* embeddings as well token embeddings to be more accurate. Doesn't seem to help for languages with clearly delinated orthographies but in Thai it helps a lot on dev and a smidge on test.

On `UD_Thai-TUD`:

New, test:

```
 Tokens Sentences     Words
    90.02     15.02     90.02
```

Old, test:

```
   Tokens Sentences     Words
    90.22     14.59     90.22
```

-----

New, dev:

```
   Tokens Sentences     Words
    90.57     19.14     90.57
```

Old, test:

```
   Tokens Sentences     Words
    90.08     15.67     90.08
```
