### PR TITLE
Mwt unks

### DIFF
--- a/stanza/models/common/utils.py
+++ b/stanza/models/common/utils.py
@@ -800,3 +800,17 @@ def attach_bert_model(model, bert_model, bert_tokenizer, use_peft, force_bert_sa
     else:
         model.bert_model = None
     model.add_unsaved_module('bert_tokenizer', bert_tokenizer)
+
+def build_save_each_filename(base_filename):
+    """
+    If the given name doesn't have %d in it, add %4d at the end of the filename
+
+    This way, there's something to count how many models have been saved
+    """
+    try:
+        base_filename % 1
+    except TypeError:
+        # so models.pt -> models_0001.pt, etc
+        pieces = os.path.splitext(model_save_each_file)
+        base_filename = pieces[0] + "_%04d" + pieces[1]
+    return base_filename

--- a/stanza/models/common/vocab.py
+++ b/stanza/models/common/vocab.py
@@ -96,6 +96,32 @@ class BaseVocab:
     def size(self):
         return len(self)
 
+class DeltaVocab(BaseVocab):
+    """
+    A vocab that starts off with a BaseVocab, then possibly adds more tokens based on the text in the given data
+
+    Currently meant only for characters, such as built by MWT
+
+    Expected data format is a list of list of strings
+    """
+    def __init__(self, data, orig_vocab):
+        self.orig_vocab = orig_vocab
+        super().__init__(data=data, lang=orig_vocab.lang, idx=orig_vocab.idx, cutoff=orig_vocab.cutoff, lower=orig_vocab.lower)
+
+    def build_vocab(self):
+        allchars = "".join([word for sentence in self.data for word in sentence])
+
+        unk = [c for c in allchars if c not in self.orig_vocab._unit2id]
+        if len(unk) > 0:
+            unk = sorted(set(unk))
+            self._id2unit = self.orig_vocab._id2unit + unk
+            self._unit2id = dict(self.orig_vocab._unit2id)
+            for c in unk:
+                self._unit2id[c] = len(self._unit2id)
+        else:
+            self._id2unit = self.orig_vocab._id2unit
+            self._unit2id = self.orig_vocab._unit2id
+
 class CompositeVocab(BaseVocab):
     ''' Vocabulary class that handles parsing and printing composite values such as
     compositional XPOS and universal morphological features (UFeats).

--- a/stanza/models/common/vocab.py
+++ b/stanza/models/common/vocab.py
@@ -100,16 +100,19 @@ class DeltaVocab(BaseVocab):
     """
     A vocab that starts off with a BaseVocab, then possibly adds more tokens based on the text in the given data
 
-    Currently meant only for characters, such as built by MWT
+    Currently meant only for characters, such as built by MWT or Lemma
 
-    Expected data format is a list of list of strings
+    Expected data format is either a list of strings, or a list of list of strings
     """
     def __init__(self, data, orig_vocab):
         self.orig_vocab = orig_vocab
         super().__init__(data=data, lang=orig_vocab.lang, idx=orig_vocab.idx, cutoff=orig_vocab.cutoff, lower=orig_vocab.lower)
 
     def build_vocab(self):
-        allchars = "".join([word for sentence in self.data for word in sentence])
+        if all(isinstance(word, str) for word in self.data):
+            allchars = "".join(self.data)
+        else:
+            allchars = "".join([word for sentence in self.data for word in sentence])
 
         unk = [c for c in allchars if c not in self.orig_vocab._unit2id]
         if len(unk) > 0:

--- a/stanza/models/constituency_parser.py
+++ b/stanza/models/constituency_parser.py
@@ -790,12 +790,7 @@ def parse_args(args=None):
 
     if args['save_each_name']:
         model_save_each_file = os.path.join(args['save_dir'], args['save_each_name'])
-        try:
-            model_save_each_file % 1
-        except TypeError:
-            # so models.pt -> models_0001.pt, etc
-            pieces = os.path.splitext(model_save_each_file)
-            model_save_each_file = pieces[0] + "_%04d" + pieces[1]
+        model_save_each_file = utils.build_save_each_filename(model_save_each_file)
         args['save_each_name'] = model_save_each_file
     else:
         # in the event that there is a start epoch setting,

--- a/stanza/models/lemma/data.py
+++ b/stanza/models/lemma/data.py
@@ -7,6 +7,7 @@ import torch
 
 import stanza.models.common.seq2seq_constant as constant
 from stanza.models.common.data import map_to_ids, get_long_tensor, get_float_tensor, sort_all
+from stanza.models.common.vocab import DeltaVocab
 from stanza.models.lemma.vocab import Vocab, MultiVocab
 from stanza.models.lemma import edit
 from stanza.models.common.doc import *
@@ -14,7 +15,7 @@ from stanza.models.common.doc import *
 logger = logging.getLogger('stanza')
 
 class DataLoader:
-    def __init__(self, doc, batch_size, args, vocab=None, evaluation=False, conll_only=False, skip=None):
+    def __init__(self, doc, batch_size, args, vocab=None, evaluation=False, conll_only=False, skip=None, expand_unk_vocab=False):
         self.batch_size = batch_size
         self.args = args
         self.eval = evaluation
@@ -32,7 +33,12 @@ class DataLoader:
 
         # handle vocab
         if vocab is not None:
-            self.vocab = vocab
+            if expand_unk_vocab:
+                pos_vocab = vocab['pos']
+                char_vocab = DeltaVocab(data, vocab['char'])
+                self.vocab = MultiVocab({'char': char_vocab, 'pos': pos_vocab})
+            else:
+                self.vocab = vocab
         else:
             self.vocab = dict()
             char_vocab, pos_vocab = self.init_vocab(data)

--- a/stanza/models/lemma/trainer.py
+++ b/stanza/models/lemma/trainer.py
@@ -98,7 +98,10 @@ class Trainer(object):
         self.optimizer.step()
         return loss_val
 
-    def predict(self, batch, beam_size=1):
+    def predict(self, batch, beam_size=1, vocab=None):
+        if vocab is None:
+            vocab = self.vocab
+
         device = next(self.model.parameters()).device
         inputs, orig_idx, text = unpack_batch(batch, device)
         src, src_mask, tgt, tgt_mask, pos, edits = inputs
@@ -106,7 +109,7 @@ class Trainer(object):
         self.model.eval()
         batch_size = src.size(0)
         preds, edit_logits = self.model.predict(src, src_mask, pos=pos, beam_size=beam_size, raw=text)
-        pred_seqs = [self.vocab['char'].unmap(ids) for ids in preds] # unmap to tokens
+        pred_seqs = [vocab['char'].unmap(ids) for ids in preds] # unmap to tokens
         pred_seqs = utils.prune_decoded_seqs(pred_seqs)
         pred_tokens = ["".join(seq) for seq in pred_seqs] # join chars to be tokens
         pred_tokens = utils.unsort(pred_tokens, orig_idx)

--- a/stanza/models/mwt/character_classifier.py
+++ b/stanza/models/mwt/character_classifier.py
@@ -1,0 +1,65 @@
+"""
+Classify characters based on an LSTM with learned character representations
+"""
+
+import logging
+
+import torch
+from torch import nn
+
+import stanza.models.common.seq2seq_constant as constant
+
+logger = logging.getLogger('stanza')
+
+class CharacterClassifier(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+
+        self.vocab_size = args['vocab_size']
+        self.emb_dim = args['emb_dim']
+        self.hidden_dim = args['hidden_dim']
+        self.nlayers = args['num_layers'] # lstm encoder layers
+        self.pad_token = constant.PAD_ID
+        self.enc_hidden_dim = self.hidden_dim // 2   # since it is bidirectional
+
+        self.num_outputs = 2
+
+        self.args = args
+
+        self.emb_dropout = args.get('emb_dropout', 0.0)
+        self.emb_drop = nn.Dropout(self.emb_dropout)
+        self.dropout = args['dropout']
+
+        self.embedding = nn.Embedding(self.vocab_size, self.emb_dim, self.pad_token)
+        self.input_dim = self.emb_dim
+        self.encoder = nn.LSTM(self.input_dim, self.enc_hidden_dim, self.nlayers, \
+                               bidirectional=True, batch_first=True, dropout=self.dropout if self.nlayers > 1 else 0)
+
+        self.output_layer = nn.Sequential(
+            nn.Linear(self.hidden_dim, self.hidden_dim),
+            nn.ReLU(),
+            nn.Linear(self.hidden_dim, self.num_outputs))
+
+    def encode(self, enc_inputs, lens):
+        """ Encode source sequence. """
+        packed_inputs = nn.utils.rnn.pack_padded_sequence(enc_inputs, lens, batch_first=True)
+        packed_h_in, (hn, cn) = self.encoder(packed_inputs)
+        return packed_h_in
+
+    def embed(self, src, src_mask):
+        # the input data could have characters outside the known range
+        # of characters in cases where the vocabulary was temporarily
+        # expanded (note that this model does nothing with those chars)
+        embed_src = src.clone()
+        embed_src[embed_src >= self.vocab_size] = constant.UNK_ID
+        enc_inputs = self.emb_drop(self.embedding(embed_src))
+        batch_size = enc_inputs.size(0)
+        src_lens = list(src_mask.data.eq(self.pad_token).long().sum(1))
+        return enc_inputs, batch_size, src_lens, src_mask
+
+    def forward(self, src, src_mask):
+        enc_inputs, batch_size, src_lens, src_mask = self.embed(src, src_mask)
+        encoded = self.encode(enc_inputs, src_lens)
+        encoded, _ = nn.utils.rnn.pad_packed_sequence(encoded, batch_first=True)
+        logits = self.output_layer(encoded)
+        return logits

--- a/stanza/models/mwt/data.py
+++ b/stanza/models/mwt/data.py
@@ -7,13 +7,13 @@ import torch
 
 import stanza.models.common.seq2seq_constant as constant
 from stanza.models.common.data import map_to_ids, get_long_tensor, get_float_tensor, sort_all
-from stanza.models.mwt.vocab import Vocab
+from stanza.models.mwt.vocab import Vocab, MWTDeltaVocab
 from stanza.models.common.doc import Document
 
 logger = logging.getLogger('stanza')
 
 class DataLoader:
-    def __init__(self, doc, batch_size, args, vocab=None, evaluation=False):
+    def __init__(self, doc, batch_size, args, vocab=None, evaluation=False, expand_unk_vocab=False):
         self.batch_size = batch_size
         self.args = args
         self.eval = evaluation
@@ -25,6 +25,8 @@ class DataLoader:
         # handle vocab
         if vocab is None:
             self.vocab = self.init_vocab(data)
+        elif expand_unk_vocab:
+            self.vocab = MWTDeltaVocab(data, vocab)
         else:
             self.vocab = vocab
 

--- a/stanza/models/mwt/data.py
+++ b/stanza/models/mwt/data.py
@@ -7,7 +7,8 @@ import torch
 
 import stanza.models.common.seq2seq_constant as constant
 from stanza.models.common.data import map_to_ids, get_long_tensor, get_float_tensor, sort_all
-from stanza.models.mwt.vocab import Vocab, MWTDeltaVocab
+from stanza.models.common.vocab import DeltaVocab
+from stanza.models.mwt.vocab import Vocab
 from stanza.models.common.doc import Document
 
 logger = logging.getLogger('stanza')
@@ -26,7 +27,7 @@ class DataLoader:
         if vocab is None:
             self.vocab = self.init_vocab(data)
         elif expand_unk_vocab:
-            self.vocab = MWTDeltaVocab(data, vocab)
+            self.vocab = DeltaVocab(data, vocab)
         else:
             self.vocab = vocab
 

--- a/stanza/models/mwt/trainer.py
+++ b/stanza/models/mwt/trainer.py
@@ -65,7 +65,10 @@ class Trainer(BaseTrainer):
         self.optimizer.step()
         return loss_val
 
-    def predict(self, batch, unsort=True, never_decode_unk=False):
+    def predict(self, batch, unsort=True, never_decode_unk=False, vocab=None):
+        if vocab is None:
+            vocab = self.vocab
+
         device = next(self.model.parameters()).device
         inputs, orig_text, orig_idx = unpack_batch(batch, device)
         src, src_mask, tgt, tgt_mask = inputs
@@ -73,7 +76,7 @@ class Trainer(BaseTrainer):
         self.model.eval()
         batch_size = src.size(0)
         preds, _ = self.model.predict(src, src_mask, self.args['beam_size'], never_decode_unk=never_decode_unk)
-        pred_seqs = [self.vocab.unmap(ids) for ids in preds] # unmap to tokens
+        pred_seqs = [vocab.unmap(ids) for ids in preds] # unmap to tokens
         pred_seqs = utils.prune_decoded_seqs(pred_seqs)
         if self.args.get('force_exact_pieces', False):
             # TODO we should be able to do all this with numpy or something similar

--- a/stanza/models/mwt/trainer.py
+++ b/stanza/models/mwt/trainer.py
@@ -114,7 +114,10 @@ class Trainer(BaseTrainer):
             # if any tokens are predicted to expand to blank,
             # that is likely an error.  use the original text
             # this originally came up with the Spanish model turning 's' into a blank
-            pred_tokens = [x if x else y for x, y in zip(pred_tokens, orig_text)]
+            # furthermore, if there are no spaces predicted by the seq2seq,
+            # might as well use the original in case the seq2seq went crazy
+            # this particular error came up training a Hebrew MWT
+            pred_tokens = [x if x and ' ' in x else y for x, y in zip(pred_tokens, orig_text)]
         if unsort:
             pred_tokens = utils.unsort(pred_tokens, orig_idx)
         return pred_tokens

--- a/stanza/models/mwt/trainer.py
+++ b/stanza/models/mwt/trainer.py
@@ -65,14 +65,14 @@ class Trainer(BaseTrainer):
         self.optimizer.step()
         return loss_val
 
-    def predict(self, batch, unsort=True):
+    def predict(self, batch, unsort=True, never_decode_unk=False):
         device = next(self.model.parameters()).device
         inputs, orig_text, orig_idx = unpack_batch(batch, device)
         src, src_mask, tgt, tgt_mask = inputs
 
         self.model.eval()
         batch_size = src.size(0)
-        preds, _ = self.model.predict(src, src_mask, self.args['beam_size'])
+        preds, _ = self.model.predict(src, src_mask, self.args['beam_size'], never_decode_unk=never_decode_unk)
         pred_seqs = [self.vocab.unmap(ids) for ids in preds] # unmap to tokens
         pred_seqs = utils.prune_decoded_seqs(pred_seqs)
         if self.args.get('force_exact_pieces', False):

--- a/stanza/models/mwt/vocab.py
+++ b/stanza/models/mwt/vocab.py
@@ -11,3 +11,22 @@ class Vocab(BaseVocab):
 
         self._id2unit = constant.VOCAB_PREFIX + list(sorted(list(counter.keys()), key=lambda k: counter[k], reverse=True))
         self._unit2id = {w:i for i, w in enumerate(self._id2unit)}
+
+class MWTDeltaVocab(BaseVocab):
+    def __init__(self, data, orig_vocab):
+        self.orig_vocab = orig_vocab
+        super().__init__(data=data, lang=orig_vocab.lang, idx=orig_vocab.idx, cutoff=orig_vocab.cutoff, lower=orig_vocab.lower)
+
+    def build_vocab(self):
+        allchars = "".join([word for sentence in self.data for word in sentence])
+
+        unk = [c for c in allchars if c not in self.orig_vocab._unit2id]
+        if len(unk) > 0:
+            unk = sorted(set(unk))
+            self._id2unit = self.orig_vocab._id2unit + unk
+            self._unit2id = dict(self.orig_vocab._unit2id)
+            for c in unk:
+                self._unit2id[c] = len(self._unit2id)
+        else:
+            self._id2unit = self.orig_vocab._id2unit
+            self._unit2id = self.orig_vocab._unit2id

--- a/stanza/models/mwt/vocab.py
+++ b/stanza/models/mwt/vocab.py
@@ -11,22 +11,3 @@ class Vocab(BaseVocab):
 
         self._id2unit = constant.VOCAB_PREFIX + list(sorted(list(counter.keys()), key=lambda k: counter[k], reverse=True))
         self._unit2id = {w:i for i, w in enumerate(self._id2unit)}
-
-class MWTDeltaVocab(BaseVocab):
-    def __init__(self, data, orig_vocab):
-        self.orig_vocab = orig_vocab
-        super().__init__(data=data, lang=orig_vocab.lang, idx=orig_vocab.idx, cutoff=orig_vocab.cutoff, lower=orig_vocab.lower)
-
-    def build_vocab(self):
-        allchars = "".join([word for sentence in self.data for word in sentence])
-
-        unk = [c for c in allchars if c not in self.orig_vocab._unit2id]
-        if len(unk) > 0:
-            unk = sorted(set(unk))
-            self._id2unit = self.orig_vocab._id2unit + unk
-            self._unit2id = dict(self.orig_vocab._unit2id)
-            for c in unk:
-                self._unit2id[c] = len(self._unit2id)
-        else:
-            self._id2unit = self.orig_vocab._id2unit
-            self._unit2id = self.orig_vocab._unit2id

--- a/stanza/models/mwt_expander.py
+++ b/stanza/models/mwt_expander.py
@@ -258,8 +258,9 @@ def evaluate(args):
     # file paths
     system_pred_file = args['output_file']
     gold_file = args['gold_file']
-    save_name = args['save_name'] if args['save_name'] else '{}_mwt_expander.pt'.format(args['shorthand'])
-    model_file = os.path.join(args['save_dir'], save_name)
+    model_file = args['save_name'] if args['save_name'] else '{}_mwt_expander.pt'.format(args['shorthand'])
+    if args['save_dir'] and not model_file.startswith(args['save_dir']) and not os.path.exists(model_file):
+        model_file = os.path.join(args['save_dir'], model_file)
 
     # load model
     trainer = Trainer(model_file=model_file, device=args['device'])

--- a/stanza/models/mwt_expander.py
+++ b/stanza/models/mwt_expander.py
@@ -53,7 +53,7 @@ def build_argparse():
 
     parser.add_argument('--hidden_dim', type=int, default=100)
     parser.add_argument('--emb_dim', type=int, default=50)
-    parser.add_argument('--num_layers', type=int, default=1)
+    parser.add_argument('--num_layers', type=int, default=None, help='Number of layers in model encoder.  Defaults to 1 for seq2seq, 2 for classifier')
     parser.add_argument('--emb_dropout', type=float, default=0.5)
     parser.add_argument('--dropout', type=float, default=0.5)
     parser.add_argument('--max_dec_len', type=int, default=50)
@@ -152,6 +152,12 @@ def train(args):
         vocab = train_batch.vocab
         args['vocab_size'] = vocab.size
         dev_batch = BinaryDataLoader(dev_doc, args['batch_size'], args, vocab=vocab, evaluation=True)
+
+    if args['num_layers'] is None:
+        if args['force_exact_pieces']:
+            args['num_layers'] = 2
+        else:
+            args['num_layers'] = 1
 
     # train a dictionary-based MWT expander
     trainer = Trainer(args=args, vocab=vocab, device=args['device'])

--- a/stanza/models/mwt_expander.py
+++ b/stanza/models/mwt_expander.py
@@ -75,6 +75,7 @@ def build_argparse():
     parser.add_argument('--log_step', type=int, default=20, help='Print log every k steps.')
     parser.add_argument('--save_dir', type=str, default='saved_models/mwt', help='Root dir for saving models.')
     parser.add_argument('--save_name', type=str, default=None, help="File name to save the model")
+    parser.add_argument('--save_each_name', type=str, default=None, help="Save each model in sequence to this pattern.  Mostly for testing")
 
     parser.add_argument('--seed', type=int, default=1234)
     utils.add_device_args(parser)
@@ -119,6 +120,11 @@ def train(args):
     utils.ensure_dir(args['save_dir'])
     save_name = args['save_name'] if args['save_name'] else '{}_mwt_expander.pt'.format(args['shorthand'])
     model_file = os.path.join(args['save_dir'], save_name)
+
+    save_each_name = None
+    if args['save_each_name']:
+        save_each_name = os.path.join(args['save_dir'], args['save_each_name'])
+        save_each_name = utils.build_save_each_filename(save_each_name)
 
     # pred and gold path
     system_pred_file = args['output_file']
@@ -192,6 +198,10 @@ def train(args):
                     duration = time.time() - start_time
                     logger.info(format_str.format(datetime.now().strftime("%Y-%m-%d %H:%M:%S"), global_step,\
                                                   max_steps, epoch, args['num_epoch'], loss, duration, current_lr))
+
+            if save_each_name:
+                trainer.save(save_each_name % epoch)
+                logger.info("Saved epoch %d model to %s" % (epoch, save_each_name % epoch))
 
             # eval on dev
             logger.info("Evaluating on dev set...")

--- a/stanza/pipeline/lemma_processor.py
+++ b/stanza/pipeline/lemma_processor.py
@@ -65,7 +65,7 @@ class LemmaProcessor(UDProcessor):
 
     def process(self, document):
         if not self.use_identity:
-            batch = DataLoader(document, self.config['batch_size'], self.config, vocab=self.vocab, evaluation=True)
+            batch = DataLoader(document, self.config['batch_size'], self.config, vocab=self.vocab, evaluation=True, expand_unk_vocab=True)
         else:
             batch = DataLoader(document, self.config['batch_size'], self.config, evaluation=True, conll_only=True)
         if self.use_identity:
@@ -80,7 +80,7 @@ class LemmaProcessor(UDProcessor):
                 # it shows up in the config which gets passed to the DataLoader,
                 # possibly affecting its results
                 seq2seq_batch = DataLoader(document, self.config['batch_size'], self.config, vocab=self.vocab,
-                                           evaluation=True, skip=skip)
+                                           evaluation=True, skip=skip, expand_unk_vocab=True)
             else:
                 seq2seq_batch = batch
 
@@ -88,7 +88,7 @@ class LemmaProcessor(UDProcessor):
                 preds = []
                 edits = []
                 for i, b in enumerate(seq2seq_batch):
-                    ps, es = self.trainer.predict(b, self.config['beam_size'])
+                    ps, es = self.trainer.predict(b, self.config['beam_size'], seq2seq_batch.vocab)
                     preds += ps
                     if es is not None:
                         edits += es

--- a/stanza/pipeline/mwt_processor.py
+++ b/stanza/pipeline/mwt_processor.py
@@ -23,7 +23,7 @@ class MWTProcessor(UDProcessor):
         self._trainer = Trainer(model_file=config['model_path'], device=device)
 
     def process(self, document):
-        batch = DataLoader(document, self.config['batch_size'], self.config, vocab=self.vocab, evaluation=True)
+        batch = DataLoader(document, self.config['batch_size'], self.config, vocab=self.vocab, evaluation=True, expand_unk_vocab=True)
 
         # process the rest
         expansions = batch.doc.get_mwt_expansions(evaluation=True)
@@ -35,7 +35,7 @@ class MWTProcessor(UDProcessor):
                 with torch.no_grad():
                     preds = []
                     for i, b in enumerate(batch):
-                        preds += self.trainer.predict(b, never_decode_unk=True)
+                        preds += self.trainer.predict(b, never_decode_unk=True, vocab=batch.vocab)
 
                 if self.config.get('ensemble_dict', False):
                     preds = self.trainer.ensemble(expansions, preds)

--- a/stanza/pipeline/mwt_processor.py
+++ b/stanza/pipeline/mwt_processor.py
@@ -22,8 +22,11 @@ class MWTProcessor(UDProcessor):
     def _set_up_model(self, config, pipeline, device):
         self._trainer = Trainer(model_file=config['model_path'], device=device)
 
+    def build_batch(self, document):
+        return DataLoader(document, self.config['batch_size'], self.config, vocab=self.vocab, evaluation=True, expand_unk_vocab=True)
+
     def process(self, document):
-        batch = DataLoader(document, self.config['batch_size'], self.config, vocab=self.vocab, evaluation=True, expand_unk_vocab=True)
+        batch = self.build_batch(document)
 
         # process the rest
         expansions = batch.doc.get_mwt_expansions(evaluation=True)

--- a/stanza/pipeline/mwt_processor.py
+++ b/stanza/pipeline/mwt_processor.py
@@ -35,7 +35,7 @@ class MWTProcessor(UDProcessor):
                 with torch.no_grad():
                     preds = []
                     for i, b in enumerate(batch):
-                        preds += self.trainer.predict(b)
+                        preds += self.trainer.predict(b, never_decode_unk=True)
 
                 if self.config.get('ensemble_dict', False):
                     preds = self.trainer.ensemble(expansions, preds)

--- a/stanza/tests/mwt/test_character_classifier.py
+++ b/stanza/tests/mwt/test_character_classifier.py
@@ -1,0 +1,92 @@
+import os
+import pytest
+
+from stanza.models import mwt_expander
+from stanza.models.mwt.character_classifier import CharacterClassifier
+from stanza.models.mwt.data import DataLoader
+from stanza.models.mwt.trainer import Trainer
+from stanza.utils.conll import CoNLL
+
+pytestmark = [pytest.mark.pipeline, pytest.mark.travis]
+
+ENG_TRAIN = """
+# text = Elena's motorcycle tour
+1-2	Elena's	_	_	_	_	_	_	_	_
+1	Elena	Elena	PROPN	NNP	Number=Sing	4	nmod:poss	4:nmod:poss	_
+2	's	's	PART	POS	_	1	case	1:case	_
+3	motorcycle	motorcycle	NOUN	NN	Number=Sing	4	compound	4:compound	_
+4	tour	tour	NOUN	NN	Number=Sing	0	root	0:root	_
+
+
+# text = women's reproductive health
+1-2	women's	_	_	_	_	_	_	_	_
+1	women	woman	NOUN	NNS	Number=Plur	4	nmod:poss	4:nmod:poss	_
+2	's	's	PART	POS	_	1	case	1:case	_
+3	reproductive	reproductive	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
+4	health	health	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+
+
+# text = The Chernobyl Children's Project
+1	The	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
+2	Chernobyl	Chernobyl	PROPN	NNP	Number=Sing	3	compound	3:compound	_
+3-4	Children's	_	_	_	_	_	_	_	_
+3	Children	Children	PROPN	NNP	Number=Sing	5	nmod:poss	5:nmod:poss	_
+4	's	's	PART	POS	_	3	case	3:case	_
+5	Project	Project	PROPN	NNP	Number=Sing	0	root	0:root	_
+
+""".lstrip()
+
+ENG_DEV = """
+# text = The Chernobyl Children's Project
+1	The	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
+2	Chernobyl	Chernobyl	PROPN	NNP	Number=Sing	3	compound	3:compound	_
+3-4	Children's	_	_	_	_	_	_	_	_
+3	Children	Children	PROPN	NNP	Number=Sing	5	nmod:poss	5:nmod:poss	_
+4	's	's	PART	POS	_	3	case	3:case	_
+5	Project	Project	PROPN	NNP	Number=Sing	0	root	0:root	_
+
+""".lstrip()
+
+def test_train(tmp_path):
+    test_train = str(os.path.join(tmp_path, "en_test.train.conllu"))
+    with open(test_train, "w") as fout:
+        fout.write(ENG_TRAIN)
+
+    test_dev = str(os.path.join(tmp_path, "en_test.dev.conllu"))
+    with open(test_dev, "w") as fout:
+        fout.write(ENG_DEV)
+
+    test_output = str(os.path.join(tmp_path, "en_test.dev.pred.conllu"))
+    model_name = "en_test_mwt.pt"
+
+    args = [
+        "--data_dir", str(tmp_path),
+        "--train_file", test_train,
+        "--eval_file", test_dev,
+        "--gold_file", test_dev,
+        "--lang", "en",
+        "--shorthand", "en_test",
+        "--output_file", test_output,
+        "--save_dir", str(tmp_path),
+        "--save_name", model_name,
+        "--num_epoch", "10",
+    ]
+
+    mwt_expander.main(args=args)
+
+    model = Trainer(model_file=os.path.join(tmp_path, model_name))
+    assert model.model is not None
+    assert isinstance(model.model, CharacterClassifier)
+
+    doc = CoNLL.conll2doc(input_str=ENG_DEV)
+    dataloader = DataLoader(doc, 10, model.args, vocab=model.vocab, evaluation=True, expand_unk_vocab=True)
+    preds = []
+    for i, batch in enumerate(dataloader):
+        assert i == 0 # there should only be one batch
+        preds += model.predict(batch, never_decode_unk=True, vocab=dataloader.vocab)
+    assert len(preds) == 1
+    # it is possible to make a version of the test where this happens almost every time
+    # for example, running for 100 epochs makes the model succeed 30 times in a row
+    # (never saw a failure)
+    # but the one time that failure happened, it would be really annoying
+    #assert preds[0] == "Children 's"

--- a/stanza/tests/pipeline/test_pipeline_mwt_expander.py
+++ b/stanza/tests/pipeline/test_pipeline_mwt_expander.py
@@ -82,3 +82,21 @@ def test_mwt():
          for sent in doc.sentences for word in sent.words]).strip()
     assert token_to_words == FR_MWT_TOKEN_TO_WORDS_GOLD
     assert word_to_token == FR_MWT_WORD_TO_TOKEN_GOLD
+
+def test_unknown_character():
+    """
+    The MWT processor has a mechanism to temporarily add unknown characters to the vocab
+
+    Here we check that it is properly adding the characters from a test case a user sent us
+    """
+    pipeline = stanza.Pipeline(processors='tokenize,mwt', dir=TEST_MODELS_DIR, lang='en', download_method=None)
+    text = "Björkängshallen's"
+    mwt_processor = pipeline.processors["mwt"]
+    trainer = mwt_processor.trainer
+    # verify that the test case is still valid
+    # (perhaps an updated MWT model will have all of these characters in the future)
+    assert not all(x in trainer.vocab._unit2id for x in text)
+    doc = pipeline(text)
+    batch = mwt_processor.build_batch(doc)
+    # the vocab used in this batch should have the missing characters
+    assert all(x in batch.vocab._unit2id for x in text)


### PR DESCRIPTION
A couple improvements to the MWT and Lemmatizer to avoid weird or useless results when faced with UNK characters

- seq2seq now supports an expanded vocab with OOV entries.  This allows for the copy gate to copy characters which would otherwise be unknown, producing them in the MWT and Lemmatizer outputs
- there is also an option to forbid ever outputting UNK directly, which helps with preventing the Lemmatizer not operating or the MWT bizarrely producing output with <UNK> in it
- for languages where the tokens are always composed of the subwords (currently EN and HE, likely others as well), a classifier over the characters now outputs the exact positions to split.  This makes it so the MWT cannot possibly hallucinate, since it splits the exact characters at the predicted locations.  Not necessarily correct, but the accuracy is on par with the seq2seq for EN and HE