### PR TITLE
run `raise_for_status` earlier when downloading file

### DIFF
--- a/stanza/resources/common.py
+++ b/stanza/resources/common.py
@@ -117,6 +117,8 @@ def download_file(url, path, proxies, raise_for_status=False):
     """
     verbose = logger.level in [0, 10, 20]
     r = requests.get(url, stream=True, proxies=proxies)
+    if raise_for_status:
+        r.raise_for_status()
     with open(path, 'wb') as f:
         file_size = int(r.headers.get('content-length'))
         default_chunk_size = 131072
@@ -128,8 +130,6 @@ def download_file(url, path, proxies, raise_for_status=False):
                     f.write(chunk)
                     f.flush()
                     pbar.update(len(chunk))
-    if raise_for_status:
-        r.raise_for_status()
     return r.status_code
 
 def request_file(url, path, proxies=None, md5=None, raise_for_status=False, log_info=True, alternate_md5=None):


### PR DESCRIPTION
## Description

The response `r.raise_for_status` in `stanza.resources.common.download_file` needs to happen earlier, otherwise the logic in `with open(...) as f` fails that uses the response `r`.

## Fixes Issues

This fixes an error that I occasionally see whereby a `TypeError` exception is thrown because `r.headers.get('content-length')` is `None` and not able to be casted as an `int`, hiding any real reason why `r` doesn't have a `content-length` header.

```
nlp/utils/stanza_model.py:7: in __init__
    self.model_stanza = stanza.Pipeline("de", processors="tokenize,ner")
../local/lib/python3.11/site-packages/stanza/pipeline/core.py:208: in __init__
    download_resources_json(self.dir,
../local/lib/python3.11/site-packages/stanza/resources/common.py:459: in download_resources_json
    request_file(
../local/lib/python3.11/site-packages/stanza/resources/common.py:157: in request_file
    download_file(url, temppath, proxies, raise_for_status)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
url = 'https://raw.githubusercontent.com/stanfordnlp/stanza-resources/main/resources_1.9.0.json'
path = '/tmp/stanza_resources/tmp3badal8y/resources.json', proxies = None
raise_for_status = True
    def download_file(url, path, proxies, raise_for_status=False):
        """
        Download a URL into a file as specified by `path`.
        """
        verbose = logger.level in [0, 10, 20]
        r = requests.get(url, stream=True, proxies=proxies)
        with open(path, 'wb') as f:
>           file_size = int(r.headers.get('content-length'))
E           TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
../local/lib/python3.11/site-packages/stanza/resources/common.py:121: TypeError
```

## Unit test coverage

Are there unit tests in place to make sure your code is functioning correctly? -> it doesn't seem so
## Known breaking changes/behaviors

It shouldn't since exceptions are raised anyway when a response isn't valid, this will just throw a more informative error.
