### PR TITLE
Update parse_transitions.py

### DIFF
--- a/stanza/models/constituency/parse_transitions.py
+++ b/stanza/models/constituency/parse_transitions.py
@@ -319,7 +319,7 @@ class Dummy():
         if spec is None or spec == '' or spec == 'O':
             return "(%s ...)" % self.label
         if spec == 'T':
-            return "\Tree [.%s ? ]" % self.label
+            return r"\Tree [.%s ? ]" % self.label
         raise ValueError("Unhandled spec: %s" % spec)
 
     def __str__(self):


### PR DESCRIPTION
Addresses the new warning Python 3.12 throws:

```
stanza/models/constituency/parse_transitions.py:322: SyntaxWarning: invalid escape sequence '\T'
  return "\Tree [.%s ? ]" % self.label
```