### PR TITLE
Update tomli version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         'protobuf>=3.15.0',
         'requests', 
         'networkx',
-        'tomli;python_version<"3.12"',
+        'tomli;python_version<"3.11"',
         'torch>=1.13.0',
         'tqdm',
     ],


### PR DESCRIPTION
## Description
This PR updates the Python version requirement for the 3rd-party library `tomli`.

## Fixes Issues
The standard library `tomllib` was [added](https://peps.python.org/pep-0680/) in Python 3.11, so the 3rd-party `tomli` is only need for Python < 3.11.

## Unit test coverage
None.

## Known breaking changes/behaviors
None.
