### PR TITLE
Multidoc tokenize

### DIFF
--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -2,6 +2,7 @@
 Processor for performing tokenization
 """
 
+import copy
 import io
 import logging
 
@@ -128,8 +129,18 @@ class TokenizeProcessor(UDProcessor):
         if self.config.get('pretokenized'):
             res = []
             for document in docs:
-                raw_text, document = self.process_pre_tokenized_text(document.text)
-                res.append(doc.Document(document, raw_text))
+                if len(document.sentences) > 0:
+                    # perhaps this is a document already tokenized,
+                    # being sent back in for more analysis / reparsing / etc?
+                    # in that case, no need to try to tokenize it
+                    # based on whitespace tokenizing the document text
+                    # which, interestingly, may not even exist depending on
+                    # how the document was created)
+                    # by making a whole deepcopy, the original Document is unchanged
+                    res.append(copy.deepcopy(document))
+                else:
+                    raw_text, document = self.process_pre_tokenized_text(document.text)
+                    res.append(doc.Document(document, raw_text))
             return res
 
         combined_text = '\n\n'.join([thisdoc.text for thisdoc in docs])

--- a/stanza/tests/pipeline/test_english_pipeline.py
+++ b/stanza/tests/pipeline/test_english_pipeline.py
@@ -96,8 +96,8 @@ EN_DOC_CONLLU_GOLD = """
 3	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux:pass	_	start_char=13|end_char=16|ner=O
 4	born	bear	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	start_char=17|end_char=21|ner=O
 5	in	in	ADP	IN	_	6	case	_	start_char=22|end_char=24|ner=O
-6	Hawaii	Hawaii	PROPN	NNP	Number=Sing	4	obl	_	start_char=25|end_char=31|ner=S-GPE|SpaceAfter=No
-7	.	.	PUNCT	.	_	4	punct	_	start_char=31|end_char=32|ner=O|SpacesAfter=\\s\\s
+6	Hawaii	Hawaii	PROPN	NNP	Number=Sing	4	obl	_	SpaceAfter=No|start_char=25|end_char=31|ner=S-GPE
+7	.	.	PUNCT	.	_	4	punct	_	SpacesAfter=\\s\\s|start_char=31|end_char=32|ner=O
 
 # text = He was elected president in 2008.
 # sent_id = 1
@@ -108,8 +108,8 @@ EN_DOC_CONLLU_GOLD = """
 3	elected	elect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	start_char=41|end_char=48|ner=O
 4	president	president	NOUN	NN	Number=Sing	3	xcomp	_	start_char=49|end_char=58|ner=O
 5	in	in	ADP	IN	_	6	case	_	start_char=59|end_char=61|ner=O
-6	2008	2008	NUM	CD	NumForm=Digit|NumType=Card	3	obl	_	start_char=62|end_char=66|ner=S-DATE|SpaceAfter=No
-7	.	.	PUNCT	.	_	3	punct	_	start_char=66|end_char=67|ner=O|SpacesAfter=\\s\\s
+6	2008	2008	NUM	CD	NumForm=Digit|NumType=Card	3	obl	_	SpaceAfter=No|start_char=62|end_char=66|ner=S-DATE
+7	.	.	PUNCT	.	_	3	punct	_	SpacesAfter=\\s\\s|start_char=66|end_char=67|ner=O
 
 # text = Obama attended Harvard.
 # sent_id = 2
@@ -117,8 +117,8 @@ EN_DOC_CONLLU_GOLD = """
 # sentiment = 1
 1	Obama	Obama	PROPN	NNP	Number=Sing	2	nsubj	_	start_char=69|end_char=74|ner=S-PERSON
 2	attended	attend	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	start_char=75|end_char=83|ner=O
-3	Harvard	Harvard	PROPN	NNP	Number=Sing	2	obj	_	start_char=84|end_char=91|ner=S-ORG|SpaceAfter=No
-4	.	.	PUNCT	.	_	2	punct	_	start_char=91|end_char=92|ner=O|SpaceAfter=No
+3	Harvard	Harvard	PROPN	NNP	Number=Sing	2	obj	_	SpaceAfter=No|start_char=84|end_char=91|ner=S-ORG
+4	.	.	PUNCT	.	_	2	punct	_	SpaceAfter=No|start_char=91|end_char=92|ner=O
 """.strip()
 
 EN_DOC_CONLLU_GOLD_MULTIDOC = """
@@ -131,8 +131,8 @@ EN_DOC_CONLLU_GOLD_MULTIDOC = """
 3	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux:pass	_	start_char=13|end_char=16|ner=O
 4	born	bear	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	start_char=17|end_char=21|ner=O
 5	in	in	ADP	IN	_	6	case	_	start_char=22|end_char=24|ner=O
-6	Hawaii	Hawaii	PROPN	NNP	Number=Sing	4	obl	_	start_char=25|end_char=31|ner=S-GPE|SpaceAfter=No
-7	.	.	PUNCT	.	_	4	punct	_	start_char=31|end_char=32|ner=O|SpaceAfter=No
+6	Hawaii	Hawaii	PROPN	NNP	Number=Sing	4	obl	_	SpaceAfter=No|start_char=25|end_char=31|ner=S-GPE
+7	.	.	PUNCT	.	_	4	punct	_	SpaceAfter=No|start_char=31|end_char=32|ner=O
 
 # text = He was elected president in 2008.
 # sent_id = 1
@@ -143,8 +143,8 @@ EN_DOC_CONLLU_GOLD_MULTIDOC = """
 3	elected	elect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	_	start_char=7|end_char=14|ner=O
 4	president	president	NOUN	NN	Number=Sing	3	xcomp	_	start_char=15|end_char=24|ner=O
 5	in	in	ADP	IN	_	6	case	_	start_char=25|end_char=27|ner=O
-6	2008	2008	NUM	CD	NumForm=Digit|NumType=Card	3	obl	_	start_char=28|end_char=32|ner=S-DATE|SpaceAfter=No
-7	.	.	PUNCT	.	_	3	punct	_	start_char=32|end_char=33|ner=O|SpaceAfter=No
+6	2008	2008	NUM	CD	NumForm=Digit|NumType=Card	3	obl	_	SpaceAfter=No|start_char=28|end_char=32|ner=S-DATE
+7	.	.	PUNCT	.	_	3	punct	_	SpaceAfter=No|start_char=32|end_char=33|ner=O
 
 # text = Obama attended Harvard.
 # sent_id = 2
@@ -152,14 +152,50 @@ EN_DOC_CONLLU_GOLD_MULTIDOC = """
 # sentiment = 1
 1	Obama	Obama	PROPN	NNP	Number=Sing	2	nsubj	_	start_char=0|end_char=5|ner=S-PERSON
 2	attended	attend	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	start_char=6|end_char=14|ner=O
-3	Harvard	Harvard	PROPN	NNP	Number=Sing	2	obj	_	start_char=15|end_char=22|ner=S-ORG|SpaceAfter=No
-4	.	.	PUNCT	.	_	2	punct	_	start_char=22|end_char=23|ner=O|SpaceAfter=No
+3	Harvard	Harvard	PROPN	NNP	Number=Sing	2	obj	_	SpaceAfter=No|start_char=15|end_char=22|ner=S-ORG
+4	.	.	PUNCT	.	_	2	punct	_	SpaceAfter=No|start_char=22|end_char=23|ner=O
+""".strip()
+
+PRETOKENIZED_TEXT = "Jennifer has lovely blue antennae ."
+
+PRETOKENIZED_PIECES = [PRETOKENIZED_TEXT.split()]
+
+EXPECTED_TOKENIZED_ONLY_CONLLU = """
+# text = Jennifer has lovely blue antennae .
+# sent_id = 0
+1	Jennifer	_	_	_	_	0	_	_	start_char=0|end_char=8
+2	has	_	_	_	_	1	_	_	start_char=9|end_char=12
+3	lovely	_	_	_	_	2	_	_	start_char=13|end_char=19
+4	blue	_	_	_	_	3	_	_	start_char=20|end_char=24
+5	antennae	_	_	_	_	4	_	_	start_char=25|end_char=33
+6	.	_	_	_	_	5	_	_	SpaceAfter=No|start_char=34|end_char=35
+""".strip()
+
+EXPECTED_PRETOKENIZED_CONLLU = """
+# text = Jennifer has lovely blue antennae .
+# sent_id = 0
+# constituency = (ROOT (S (NP (NNP Jennifer)) (VP (VBZ has) (NP (JJ lovely) (JJ blue) (NNS antennae))) (. .)))
+# sentiment = 2
+1	Jennifer	Jennifer	PROPN	NNP	Number=Sing	2	nsubj	_	start_char=0|end_char=8|ner=S-PERSON
+2	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	start_char=9|end_char=12|ner=O
+3	lovely	lovely	ADJ	JJ	Degree=Pos	5	amod	_	start_char=13|end_char=19|ner=O
+4	blue	blue	ADJ	JJ	Degree=Pos	5	amod	_	start_char=20|end_char=24|ner=O
+5	antennae	antenna	NOUN	NNS	Number=Plur	2	obj	_	start_char=25|end_char=33|ner=O
+6	.	.	PUNCT	.	_	2	punct	_	SpaceAfter=No|start_char=34|end_char=35|ner=O
 """.strip()
 
 class TestEnglishPipeline:
     @pytest.fixture(scope="class")
     def pipeline(self):
         return stanza.Pipeline(dir=TEST_MODELS_DIR, download_method=None)
+
+    @pytest.fixture(scope="class")
+    def pretokenized_pipeline(self):
+        return stanza.Pipeline(dir=TEST_MODELS_DIR, tokenize_pretokenized=True, download_method=None)
+
+    @pytest.fixture(scope="class")
+    def tokenizer_pipeline(self):
+        return stanza.Pipeline(dir=TEST_MODELS_DIR, processors="tokenize", download_method=None)
 
     @pytest.fixture(scope="class")
     def processed_doc(self, pipeline):
@@ -206,6 +242,20 @@ class TestEnglishPipeline:
         """ Previously we had a bug where an empty document list would cause a crash """
         processed = pipeline.bulk_process([])
         assert processed == []
+
+    def test_pretokenized(self, pretokenized_pipeline, tokenizer_pipeline):
+        doc = pretokenized_pipeline(PRETOKENIZED_PIECES)
+        conllu = "{:C}".format(doc).strip()
+        assert conllu == EXPECTED_PRETOKENIZED_CONLLU
+
+        doc = tokenizer_pipeline(PRETOKENIZED_TEXT)
+        conllu = "{:C}".format(doc).strip()
+        assert conllu == EXPECTED_TOKENIZED_ONLY_CONLLU
+
+        # putting a doc with tokens into the pipeline should also work
+        reparsed = pretokenized_pipeline(doc)
+        conllu = "{:C}".format(reparsed).strip()
+        assert conllu == EXPECTED_PRETOKENIZED_CONLLU
 
     def test_stream(self, pipeline):
         """ Test the streaming interface to the Pipeline """

--- a/stanza/tests/pipeline/test_english_pipeline.py
+++ b/stanza/tests/pipeline/test_english_pipeline.py
@@ -257,6 +257,31 @@ class TestEnglishPipeline:
         conllu = "{:C}".format(reparsed).strip()
         assert conllu == EXPECTED_PRETOKENIZED_CONLLU
 
+    def test_bulk_pretokenized(self, pretokenized_pipeline, tokenizer_pipeline):
+        doc = tokenizer_pipeline(PRETOKENIZED_TEXT)
+        conllu = "{:C}".format(doc).strip()
+        assert conllu == EXPECTED_TOKENIZED_ONLY_CONLLU
+
+        docs = pretokenized_pipeline([doc, doc])
+        assert len(docs) == 2
+        for doc in docs:
+            conllu = "{:C}".format(doc).strip()
+            assert conllu == EXPECTED_PRETOKENIZED_CONLLU
+
+    def test_conll2doc_pretokenized(self, pretokenized_pipeline):
+        doc = CoNLL.conll2doc(input_str=EXPECTED_TOKENIZED_ONLY_CONLLU)
+        # this was bug from version 1.10.1 sent to us from a user
+        # the pretokenized tokenize_processor would try to whitespace tokenize a document
+        # even if the document already had sentences & words & stuff
+        # not only would that be wrong if the text wouldn't whitespace tokenize into the words
+        # (such as with punctuation and SpaceAfter=No),
+        # it wouldn't even work in the case of conll2doc, since the document.text wasn't set
+        docs = pretokenized_pipeline([doc, doc])
+        assert len(docs) == 2
+        for doc in docs:
+            conllu = "{:C}".format(doc).strip()
+            assert conllu == EXPECTED_PRETOKENIZED_CONLLU
+
     def test_stream(self, pipeline):
         """ Test the streaming interface to the Pipeline """
         # Test all of the documents in one batch

--- a/stanza/tests/tokenization/test_spaces.py
+++ b/stanza/tests/tokenization/test_spaces.py
@@ -8,21 +8,21 @@ from stanza.tests import TEST_MODELS_DIR
 EXPECTED_NO_MWT = """
 # text = Jennifer has nice antennae.
 # sent_id = 0
-1	Jennifer	_	_	_	_	0	_	_	start_char=2|end_char=10|SpacesBefore=\\s\\s
+1	Jennifer	_	_	_	_	0	_	_	SpacesBefore=\\s\\s|start_char=2|end_char=10
 2	has	_	_	_	_	1	_	_	start_char=11|end_char=14
 3	nice	_	_	_	_	2	_	_	start_char=15|end_char=19
-4	antennae	_	_	_	_	3	_	_	start_char=20|end_char=28|SpaceAfter=No
-5	.	_	_	_	_	4	_	_	start_char=28|end_char=29|SpacesAfter=\\s\\s
+4	antennae	_	_	_	_	3	_	_	SpaceAfter=No|start_char=20|end_char=28
+5	.	_	_	_	_	4	_	_	SpacesAfter=\\s\\s|start_char=28|end_char=29
 
 # text = Not very nice person, though.
 # sent_id = 1
 1	Not	_	_	_	_	0	_	_	start_char=31|end_char=34
 2	very	_	_	_	_	1	_	_	start_char=35|end_char=39
 3	nice	_	_	_	_	2	_	_	start_char=40|end_char=44
-4	person	_	_	_	_	3	_	_	start_char=45|end_char=51|SpaceAfter=No
+4	person	_	_	_	_	3	_	_	SpaceAfter=No|start_char=45|end_char=51
 5	,	_	_	_	_	4	_	_	start_char=51|end_char=52
-6	though	_	_	_	_	5	_	_	start_char=53|end_char=59|SpaceAfter=No
-7	.	_	_	_	_	6	_	_	start_char=59|end_char=60|SpacesAfter=\\s\\s
+6	though	_	_	_	_	5	_	_	SpaceAfter=No|start_char=53|end_char=59
+7	.	_	_	_	_	6	_	_	SpacesAfter=\\s\\s|start_char=59|end_char=60
 """.strip()
 
 def test_spaces_no_mwt():
@@ -38,18 +38,18 @@ def test_spaces_no_mwt():
 EXPECTED_MWT = """
 # text = She's not a nice person.
 # sent_id = 0
-1-2	She's	_	_	_	_	_	_	_	start_char=2|end_char=7|SpacesBefore=\\s\\s
+1-2	She's	_	_	_	_	_	_	_	SpacesBefore=\\s\\s|start_char=2|end_char=7
 1	She	_	_	_	_	0	_	_	start_char=2|end_char=5
 2	's	_	_	_	_	1	_	_	start_char=5|end_char=7
 3	not	_	_	_	_	2	_	_	start_char=8|end_char=11
 4	a	_	_	_	_	3	_	_	start_char=12|end_char=13
 5	nice	_	_	_	_	4	_	_	start_char=14|end_char=18
-6	person	_	_	_	_	5	_	_	start_char=19|end_char=25|SpaceAfter=No
-7	.	_	_	_	_	6	_	_	start_char=25|end_char=26|SpacesAfter=\\s\\s
+6	person	_	_	_	_	5	_	_	SpaceAfter=No|start_char=19|end_char=25
+7	.	_	_	_	_	6	_	_	SpacesAfter=\\s\\s|start_char=25|end_char=26
 
 # text = However, the best antennae on the Cerritos are Jennifer's.
 # sent_id = 1
-1	However	_	_	_	_	0	_	_	start_char=28|end_char=35|SpaceAfter=No
+1	However	_	_	_	_	0	_	_	SpaceAfter=No|start_char=28|end_char=35
 2	,	_	_	_	_	1	_	_	start_char=35|end_char=36
 3	the	_	_	_	_	2	_	_	start_char=37|end_char=40
 4	best	_	_	_	_	3	_	_	start_char=41|end_char=45
@@ -58,10 +58,10 @@ EXPECTED_MWT = """
 7	the	_	_	_	_	6	_	_	start_char=58|end_char=61
 8	Cerritos	_	_	_	_	7	_	_	start_char=62|end_char=70
 9	are	_	_	_	_	8	_	_	start_char=71|end_char=74
-10-11	Jennifer's	_	_	_	_	_	_	_	start_char=75|end_char=85|SpaceAfter=No
+10-11	Jennifer's	_	_	_	_	_	_	_	SpaceAfter=No|start_char=75|end_char=85
 10	Jennifer	_	_	_	_	9	_	_	start_char=75|end_char=83
 11	's	_	_	_	_	10	_	_	start_char=83|end_char=85
-12	.	_	_	_	_	11	_	_	start_char=85|end_char=86|SpacesAfter=\\s\\s
+12	.	_	_	_	_	11	_	_	SpacesAfter=\\s\\s|start_char=85|end_char=86
 """.strip()
 
 def test_spaces_mwt():


### PR DESCRIPTION
When a document is already tokenized, and the TokenizeProcessor is set to `pretokenized=True`, it is not necessary to try to retokenize the text of the document.  In fact, it might not even be possible if the complete document text isn't available

Addresses https://github.com/stanfordnlp/stanza/issues/1464