### PR TITLE
Packed tokenizer

### DIFF
--- a/stanza/models/tokenization/data.py
+++ b/stanza/models/tokenization/data.py
@@ -397,7 +397,7 @@ class SortedDataset(Dataset):
         super().__init__()
 
         self.dataset = dataset
-        self.data, self.indices = sort_with_indices(self.dataset.data, key=len)
+        self.data, self.indices = sort_with_indices(self.dataset.data, key=len, reverse=True)
 
     def __len__(self):
         return len(self.data)

--- a/stanza/models/tokenization/trainer.py
+++ b/stanza/models/tokenization/trainer.py
@@ -33,14 +33,15 @@ class Trainer(BaseTrainer):
 
     def update(self, inputs):
         self.model.train()
-        units, labels, features, _ = inputs
+        units, labels, features, text = inputs
+        lengths = [len(x) for x in text]
 
         device = next(self.model.parameters()).device
         units = units.to(device)
         labels = labels.to(device)
         features = features.to(device)
 
-        pred = self.model(units, features)
+        pred = self.model(units, features, lengths)
 
         self.optimizer.zero_grad()
         classes = pred.size(2)
@@ -54,13 +55,14 @@ class Trainer(BaseTrainer):
 
     def predict(self, inputs):
         self.model.eval()
-        units, _, features, _ = inputs
+        units, _, features, text = inputs
+        lengths = [len(x) for x in text]
 
         device = next(self.model.parameters()).device
         units = units.to(device)
         features = features.to(device)
 
-        pred = self.model(units, features)
+        pred = self.model(units, features, lengths)
 
         return pred.data.cpu().numpy()
 

--- a/stanza/models/tokenization/utils.py
+++ b/stanza/models/tokenization/utils.py
@@ -258,8 +258,8 @@ def predict(trainer, data_generator, batch_size, max_seqlen, use_regex_tokens, n
     dataloader = TorchDataLoader(sorted_data, batch_size=batch_size, collate_fn=sorted_data.collate, num_workers=num_workers)
     for batch_idx, batch in enumerate(dataloader):
         num_sentences = len(batch[3])
-        # being sorted by length, we need to use -1 as the longest sentence
-        N = len(batch[3][-1])
+        # being sorted by descending length, we need to use 0 as the longest sentence
+        N = len(batch[3][0])
         for paragraph in batch[3]:
             all_raw.append(list(paragraph))
 


### PR DESCRIPTION
Use a PackedSequence in the tokenizer.  Somehow it's substantially slower...

however, it would address the tokenization not being consistent based on batch size:

https://github.com/stanfordnlp/stanza/issues/1472