### PR TITLE
Use the same fields for token and word to_dict - should just ignore t…

### DIFF
--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -305,6 +305,55 @@ def test_mwt_ner_conversion():
     conll = "{:C}".format(doc)
     assert conll == MWT_NER
 
+ALL_OFFSETS_CONLLU = """
+# text = This makes John's headache worse
+# sent_id = 0
+1	This	_	_	_	_	0	_	_	start_char=0|end_char=4
+2	makes	_	_	_	_	1	_	_	start_char=5|end_char=10
+3-4	John's	_	_	_	_	_	_	_	start_char=11|end_char=17
+3	John	_	_	_	_	2	_	_	start_char=11|end_char=15
+4	's	_	_	_	_	3	_	_	start_char=15|end_char=17
+5	headache	_	_	_	_	4	_	_	start_char=18|end_char=26
+6	worse	_	_	_	_	5	_	_	SpaceAfter=No|start_char=27|end_char=32
+""".strip()
+
+NO_OFFSETS_CONLLU = """
+# text = This makes John's headache worse
+# sent_id = 0
+1	This	_	_	_	_	0	_	_	_
+2	makes	_	_	_	_	1	_	_	_
+3-4	John's	_	_	_	_	_	_	_	_
+3	John	_	_	_	_	2	_	_	_
+4	's	_	_	_	_	3	_	_	_
+5	headache	_	_	_	_	4	_	_	_
+6	worse	_	_	_	_	5	_	_	SpaceAfter=No
+""".strip()
+
+NO_COMMENTS_NO_OFFSETS_CONLLU = """
+1	This	_	_	_	_	0	_	_	_
+2	makes	_	_	_	_	1	_	_	_
+3-4	John's	_	_	_	_	_	_	_	_
+3	John	_	_	_	_	2	_	_	_
+4	's	_	_	_	_	3	_	_	_
+5	headache	_	_	_	_	4	_	_	_
+6	worse	_	_	_	_	5	_	_	SpaceAfter=No
+""".strip()
+
+
+def test_no_offsets_output():
+    doc = CoNLL.conll2doc(input_str=ALL_OFFSETS_CONLLU)
+    assert len(doc.sentences) == 1
+    sentence = doc.sentences[0]
+    assert len(sentence.tokens) == 5
+
+    conll = "{:C}".format(doc)
+    assert conll == ALL_OFFSETS_CONLLU
+
+    conll = "{:C-o}".format(doc)
+    assert conll == NO_OFFSETS_CONLLU
+
+    conll = "{:c-o}".format(doc)
+    assert conll == NO_COMMENTS_NO_OFFSETS_CONLLU
 
 # A random sentence from et_ewt-ud-train.conllu
 # which we use to test the deps conversion for multiple deps


### PR DESCRIPTION
Use the same fields for token and word to_dict - should just ignore the ones which aren't part of that particular unit

Add an option to turn off the character offsets when outputting conllu format Documents

Add a test of the option to not include offsets in the document output

New format option available:

"{:C-o}"

Need to consider whether this is better or worse than having the default be without offsets