### PR TITLE
Refine tests

### DIFF
--- a/stanza/models/common/char_model.py
+++ b/stanza/models/common/char_model.py
@@ -330,7 +330,7 @@ class CharacterLanguageModelTrainer():
         params = [param for param in model.parameters() if param.requires_grad]
         optimizer = torch.optim.SGD(params, lr=args['lr0'], momentum=args['momentum'], weight_decay=args['weight_decay'])
         criterion = torch.nn.CrossEntropyLoss()
-        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, verbose=True, factor=args['anneal'], patience=args['patience'])
+        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, factor=args['anneal'], patience=args['patience'])
         return cls(model, params, optimizer, criterion, scheduler)
 
 
@@ -353,7 +353,7 @@ class CharacterLanguageModelTrainer():
         criterion = torch.nn.CrossEntropyLoss()
         if 'criterion' in state: criterion.load_state_dict(state['criterion'])
 
-        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, verbose=True, factor=args['anneal'], patience=args['patience'])
+        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, factor=args['anneal'], patience=args['patience'])
         if 'scheduler' in state: scheduler.load_state_dict(state['scheduler'])
 
         epoch = state.get('epoch', 1)

--- a/stanza/models/ner_tagger.py
+++ b/stanza/models/ner_tagger.py
@@ -308,7 +308,7 @@ def train(args):
         # learning rate changes on plateau -- no improvement on model for patience number of epochs
         # change is made as a factor of the learning rate decay
         scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(trainer.optimizer, mode='max', factor=args['lr_decay'],
-                                                               patience=args['patience'], verbose=True, min_lr=args['min_lr'])
+                                                               patience=args['patience'], min_lr=args['min_lr'])
     else:
         scheduler = None
 


### PR DESCRIPTION
## Fixes Issues
#1484 

## Unit test coverage
All tests passed except these, because I live in China and usually encounters SSLError because of GFW or proxy. The john issue is that `tests/lemma` are somewhat hard-coded with some John's files. 
```
    # stanza/tests/lemma, # john issue
    # stanza/tests/pipeline, # network unstable
    # stanza/tests/server, # network unstable
    # stanza/tests/resources, # network unstable
    # stanza/tests/tokenization, # network unstable
```

## Known breaking changes/behaviors
Some schedulers do not output verbose learning rates any more, but I checked all code using the schedulers and found out they  print learning rate themselves.