### PR TITLE
Drop the Python 3.8 support

### DIFF
--- a/demo/CONLL_Dependency_Visualizer_Example.ipynb
+++ b/demo/CONLL_Dependency_Visualizer_Example.ipynb
@@ -62,7 +62,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.9.22"
   }
  },
  "nbformat": 4,

--- a/demo/Dependency_Visualization_Testing.ipynb
+++ b/demo/Dependency_Visualization_Testing.ipynb
@@ -70,7 +70,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.9.22"
   }
  },
  "nbformat": 4,

--- a/demo/NER_Visualization.ipynb
+++ b/demo/NER_Visualization.ipynb
@@ -80,7 +80,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.9.22"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -90,7 +89,7 @@ setup(
     ],
 
     # List required Python versions
-    python_requires='>=3.8',
+    python_requires='>=3.9',
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Fixes #1481 

By the way you could update the PyPI description as it still claims that it supports Python 3.6.