### PR TITLE
add Python 3.13 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
Since spaCy now supports Python 3.13, I installed stanza and run all the tests in my Python 3.13 virtual environment—all of them passed.