### PR TITLE
Fix typo of missing backslach that tiggers runtime SyntaxWarning

### DIFF
--- a/stanza/models/constituency/parse_transitions.py
+++ b/stanza/models/constituency/parse_transitions.py
@@ -319,7 +319,7 @@ class Dummy():
         if spec is None or spec == '' or spec == 'O':
             return "(%s ...)" % self.label
         if spec == 'T':
-            return r"\Tree [.%s ? ]" % self.label
+            return r"\\Tree [.%s ? ]" % self.label
         raise ValueError("Unhandled spec: %s" % spec)
 
     def __str__(self):


### PR DESCRIPTION
## Description

Add missing backslacsh to properly escape "\Tree ..." -> "\\Tree ...".

This fixes the following runtime warning:
```
/virtualenvs/app-tNTrAeIV-py3.12/lib/python3.12/site-packages/stanza/models/constituency/parse_transitions.py:322:
SyntaxWarning: invalid escape sequence '\T'
  return "\Tree [.%s ? ]" % self.label
```

## Fixes Issues

https://github.com/stanfordnlp/stanza/issues/1512

## Unit test coverage

Don't know

## Known breaking changes/behaviors

No
