### PR TITLE
fix json serialization in convert_hebrew_mixed

### DIFF
--- a/stanza/utils/datasets/coref/convert_hebrew_mixed.py
+++ b/stanza/utils/datasets/coref/convert_hebrew_mixed.py
@@ -35,7 +35,7 @@ def main():
             udcoref_train = json.load(fin)
         mixed_train = hebrew_train + udcoref_train
         with open(os.path.join(coref_output_path, "he_mixed.train.json"), "w", encoding="utf-8") as fout:
-            json.dump(mixed_train, fout, indent=2, ensure_ascii=False))
+            json.dump(mixed_train, fout, indent=2, ensure_ascii=False)
 
         shutil.copyfile(os.path.join(temp_dir_path, hebrew_filenames[1]),
                         os.path.join(coref_output_path, "he_mixed.dev.json"))


### PR DESCRIPTION
**BEFORE YOU START**: please make sure your pull request is against the `dev` branch. 
We cannot accept pull requests against the `main` branch. 
See our [contributing guide](https://github.com/stanfordnlp/stanza/blob/main/CONTRIBUTING.md) for details.

## Description
> A brief and concise description of what your pull request is trying to accomplish.

fix an extra parenthesis:

```
 │ │   Building wheel for stanza (setup.py): finished with status 'done'
 │ │   Created wheel for stanza: filename=stanza-1.11.0-py3-none-any.whl size=1706081 sha256=a87b1747d290c37de888e0509c8f780abefd0ad6416a5bab9c5189e0142d5d95
 │ │   Stored in directory: /tmp/pip-ephem-wheel-cache-i63sk5yw/wheels/dd/b9/c7/13724a794698dae55b558f4f72ed736f017ad45e44e91fc563
 │ │ Successfully built stanza
 │ │ Installing collected packages: stanza
 │ │   *** Error compiling '$PREFIX/lib/python3.10/site-packages/stanza/utils/datasets/coref/convert_hebrew_mixed.py'...
 │ │     File "$PREFIX/lib/python3.10/site-packages/stanza/utils/datasets/coref/convert_hebrew_mixed.py", line 38
 │ │       json.dump(mixed_train, fout, indent=2, ensure_ascii=False))
 │ │                                                                 ^
 │ │   SyntaxError: unmatched ')'
 │ │   
```

## Fixes Issues
> A list of issues/bugs with # references. (e.g., #123)

- n/a

## Unit test coverage
Are there unit tests in place to make sure your code is functioning correctly?
(see [here](https://github.com/stanfordnlp/stanza/blob/master/tests/test_tagger.py) for a simple example)

- n/a

## Known breaking changes/behaviors
> Does this break anything in Stanza's existing user interface? If so, what is it and how is it addressed?

- n/a