### PR TITLE
Speakers

### DIFF
--- a/stanza/models/common/doc.py
+++ b/stanza/models/common/doc.py
@@ -230,6 +230,14 @@ class Document(StanzaObject):
                 # setting the sent_id on the sentence will automatically add the comment
                 sentence.sent_id = str(sentence.index)
 
+            # look for speaker in the comments
+            for comment in sentence_comments:
+                if comment.startswith("# speaker"):
+                    sentence.speaker = comment.split("=", 1)[-1].strip()
+                    break
+            else:
+                sentence.speaker = None
+
     def _count_words(self):
         """
         Count the number of tokens and words
@@ -679,6 +687,29 @@ class Sentence(StanzaObject):
                 break
         else: # this is intended to be a for/else loop
             self._comments.append(sent_id_comment)
+
+    @property
+    def speaker(self):
+        """ conll-style speaker - adopt the EN GUM formatting """
+        return self._speaker
+
+    @speaker.setter
+    def speaker(self, value):
+        """ Set the sentence's speaker value. """
+        self._speaker = value
+        speaker_comment = "# speaker = " + str(value)
+        if not value:
+            for comment_idx, comment in enumerate(self._comments):
+                if comment.startswith("# speaker = "):
+                    self._comments.pop(comment_idx)
+                    break
+        else:
+            for comment_idx, comment in enumerate(self._comments):
+                if comment.startswith("# speaker = "):
+                    self._comments[comment_idx] = speaker_comment
+                    break
+            else: # this is intended to be a for/else loop
+                self._comments.append(speaker_comment)
 
     @property
     def doc_id(self):

--- a/stanza/models/coref/pairwise_encoder.py
+++ b/stanza/models/coref/pairwise_encoder.py
@@ -80,8 +80,8 @@ class PairwiseEncoder(torch.nn.Module):
         
         # speaker string -> speaker id
         str2int = {s: i for i, s in enumerate(set(doc.get("speaker", ["speaker#1"
-                                                                      for _ in range(len(doc["deprel"]))])))}
+                                                                      for _ in range(len(doc["cased_words"]))])))}
 
         # word id -> speaker id
         return [str2int[s] for s in doc.get("speaker", ["speaker#1"
-                                                        for _ in range(len(doc["deprel"]))])]
+                                                        for _ in range(len(doc["cased_words"]))])]

--- a/stanza/models/coref/pairwise_encoder.py
+++ b/stanza/models/coref/pairwise_encoder.py
@@ -37,7 +37,7 @@ class PairwiseEncoder(torch.nn.Module):
         self.__full_pw = config.full_pairwise
 
         if self.__full_pw:
-            self.shape = emb_size * 3  # genre, distance, speaker\
+            self.shape = emb_size * 2  # distance, speaker
         else:
             self.shape = emb_size # distance only
 
@@ -68,14 +68,7 @@ class PairwiseEncoder(torch.nn.Module):
         same_speaker = (speaker_map[top_indices] == speaker_map.unsqueeze(1))
         same_speaker = self.speaker_emb(same_speaker.to(torch.long))
 
-
-        # if there is no genre information, use "wb" as the genre (which is what the
-        # Pipeline does
-        genre = torch.tensor(self.genre2int.get(doc["document_id"][:2], self.genre2int["wb"]),
-                             device=self.device).expand_as(top_indices)
-        genre = self.genre_emb(genre)
-
-        return self.dropout(torch.cat((same_speaker, distance, genre), dim=2))
+        return self.dropout(torch.cat((same_speaker, distance), dim=2))
 
     @staticmethod
     def _speaker_map(doc: Doc) -> List[int]:

--- a/stanza/pipeline/core.py
+++ b/stanza/pipeline/core.py
@@ -431,6 +431,11 @@ class Pipeline:
                 doc = process(doc)
         return doc
 
+    def process_conllu(self, doc, ignore_gapping=True, processors=None):
+        """ Convenience method: treat the doc as a conllu text, convert it, and process it accordingly """
+        doc = CoNLL.conll2doc(input_str=doc, ignore_gapping=ignore_gapping)
+        return self.process(doc, processors=processors)
+
     def bulk_process(self, docs, *args, **kwargs):
         """
         Run the pipeline in bulk processing mode

--- a/stanza/pipeline/core.py
+++ b/stanza/pipeline/core.py
@@ -433,6 +433,12 @@ class Pipeline:
 
     def process_conllu(self, doc, ignore_gapping=True, processors=None):
         """ Convenience method: treat the doc as a conllu text, convert it, and process it accordingly """
+        if processors is None:
+            processors = set(self.processors.keys())
+            if TOKENIZE in processors:
+                processors.remove(TOKENIZE)
+            if MWT in processors:
+                processors.remove(MWT)
         doc = CoNLL.conll2doc(input_str=doc, ignore_gapping=ignore_gapping)
         return self.process(doc, processors=processors)
 

--- a/stanza/pipeline/coref_processor.py
+++ b/stanza/pipeline/coref_processor.py
@@ -94,16 +94,22 @@ class CorefProcessor(UDProcessor):
         cased_words = []
         sent_ids = []
         word_pos = []
+        speaker = []
         for sent_idx, sentence in enumerate(sentences):
             for word_idx, word in enumerate(sentence.words):
                 cased_words.append(word.text)
                 sent_ids.append(sent_idx)
                 word_pos.append(word_idx)
+                if sentence.speaker:
+                    speaker.append(sentence.speaker)
+                else:
+                    speaker.append("_")
 
         coref_input = {
             "document_id": "wb_doc_1",
             "cased_words": cased_words,
-            "sent_id": sent_ids
+            "sent_id": sent_ids,
+            "speaker": speaker,
         }
         coref_input = self._model.build_doc(coref_input)
         results = self._model.run(coref_input)

--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -585,3 +585,34 @@ def test_line_numbers():
     for word_idx, word in enumerate(doc.sentences[0].words):
         # the test sentence has two comments in it
         assert word.line_number == word_idx + 2
+
+
+SPEAKER_EXAMPLE = """
+# sent_id = GUM_fiction_pag-57
+# speaker = Siri
+# addressee = Pag
+# text = "Sorry."
+1	"	"	PUNCT	``	_	2	punct	2:punct	Discourse=joint-sequence_m:130->128:1:_|SpaceAfter=No
+2	Sorry	sorry	ADJ	JJ	Degree=Pos	0	root	0:root	MSeg=Sorr-y|SpaceAfter=No
+3	.	.	PUNCT	.	_	2	punct	2:punct	SpaceAfter=No
+4	"	"	PUNCT	''	_	2	punct	2:punct	_
+""".lstrip()
+
+def test_speaker():
+    doc = CoNLL.conll2doc(input_str=SPEAKER_EXAMPLE)
+    assert len(doc.sentences) == 1
+    assert doc.sentences[0].speaker == 'Siri'
+    assert "# speaker = Siri" in doc.sentences[0].comments
+
+    doc.sentences[0].speaker = "foo"
+    assert doc.sentences[0].speaker == 'foo'
+    assert any(comment.startswith("# speaker") for comment in doc.sentences[0].comments)
+    assert "# speaker = foo" in doc.sentences[0].comments
+
+    doc.sentences[0].speaker = None
+    assert not any(comment.startswith("# speaker") for comment in doc.sentences[0].comments)
+    assert doc.sentences[0].speaker is None
+
+    doc.sentences[0].speaker = "Siri"
+    assert doc.sentences[0].speaker == 'Siri'
+    assert "# speaker = Siri" in doc.sentences[0].comments

--- a/stanza/tests/pipeline/test_english_pipeline.py
+++ b/stanza/tests/pipeline/test_english_pipeline.py
@@ -209,6 +209,13 @@ class TestEnglishPipeline:
     def test_conllu(self, processed_doc):
         assert "{:C}".format(processed_doc) == EN_DOC_CONLLU_GOLD
 
+    def test_process_conllu(self, pretokenized_pipeline):
+        """
+        process a conllu text directly - note that this uses the pretokenized pipeline
+        """
+        doc = pretokenized_pipeline.process_conllu(EN_DOC_CONLLU_GOLD)
+        result = "{:C}".format(doc)
+        assert result == EN_DOC_CONLLU_GOLD
 
     def test_tokens(self, processed_doc):
         assert "\n\n".join([sent.tokens_string() for sent in processed_doc.sentences]) == EN_DOC_TOKENS_GOLD

--- a/stanza/tests/pipeline/test_english_pipeline.py
+++ b/stanza/tests/pipeline/test_english_pipeline.py
@@ -209,11 +209,14 @@ class TestEnglishPipeline:
     def test_conllu(self, processed_doc):
         assert "{:C}".format(processed_doc) == EN_DOC_CONLLU_GOLD
 
-    def test_process_conllu(self, pretokenized_pipeline):
+    def test_process_conllu(self, pipeline):
         """
-        process a conllu text directly - note that this uses the pretokenized pipeline
+        Process a conllu text directly
+
+        This can use the pipeline which still uses tokenization, as
+        process_conllu skips the tokenize and mwt processors
         """
-        doc = pretokenized_pipeline.process_conllu(EN_DOC_CONLLU_GOLD)
+        doc = pipeline.process_conllu(EN_DOC_CONLLU_GOLD)
         result = "{:C}".format(doc)
         assert result == EN_DOC_CONLLU_GOLD
 


### PR DESCRIPTION
Allow `# speaker` as an annotation on sentences, then pass that along to the coref model if present.  Also add a convenience method which turns a CoNLLU text into a document as part of Pipeline processing.  Should make life easier for processing coref with speaker information available.  Of course, this does need a model which cares about speakers...

https://github.com/stanfordnlp/stanza/issues/1523