### PR TITLE
fix: correct typos 'recieved' and 'occured'

### DIFF
--- a/stanza/models/constituency/utils.py
+++ b/stanza/models/constituency/utils.py
@@ -329,7 +329,7 @@ def check_constituents(train_constituents, trees, treebank_name, fail=True):
                     num_errors += 1
                     if first_error is None:
                         first_error = tree_idx
-            error = "Found constituent label {} in the {} set which don't exist in the train set.  This constituent label occured in {} trees, with the first tree index at {} counting from 1\nThe error tree (which may have POS tags changed from the retagger and may be missing functional tags or empty nodes) is:\n{:P}".format(con, treebank_name, num_errors, (first_error+1), trees[first_error])
+            error = "Found constituent label {} in the {} set which don't exist in the train set.  This constituent label occurred in {} trees, with the first tree index at {} counting from 1\nThe error tree (which may have POS tags changed from the retagger and may be missing functional tags or empty nodes) is:\n{:P}".format(con, treebank_name, num_errors, (first_error+1), trees[first_error])
             if fail:
                 raise RuntimeError(error)
             else:

--- a/stanza/models/pos/data.py
+++ b/stanza/models/pos/data.py
@@ -129,7 +129,7 @@ class Dataset:
 
         Retrieves a sample from the dataset. This function, for the
         most part, is spent performing ad-hoc data augmentation and
-        restoration. It recieves a DataSample object from the storage,
+        restoration. It receives a DataSample object from the storage,
         and returns an almost-identical DataSample object that may
         have been augmented with /possibly/ (depending on augment_punct
         settings) PUNCT chopped.

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -52,7 +52,7 @@ class TokenizeProcessor(UDProcessor):
         elif not postprocessor:
             self._postprocessor = None
         else:
-            raise ValueError("Tokenizer recieved 'postprocessor' option of unrecognized type; postprocessor must be callable. Got %s" % postprocessor)
+            raise ValueError("Tokenizer received 'postprocessor' option of unrecognized type; postprocessor must be callable. Got %s" % postprocessor)
 
     def process_pre_tokenized_text(self, input_src):
         """


### PR DESCRIPTION
Corrects spelling errors in three files:
- tokenize_processor.py: 'recieved' → 'received'
- pos/data.py: 'recieves' → 'receives'
- constituency/utils.py: 'occured' → 'occurred'