### PR TITLE
fix: correct typos 'recieved', 'seperate', and 'occured'

### DIFF
--- a/stanza/models/common/utils.py
+++ b/stanza/models/common/utils.py
@@ -279,7 +279,7 @@ def get_optimizer(name, model, lr, betas=(0.9, 0.999), eps=1e-8, momentum=0, wei
     return dispatch_optimizer(name, parameters, opt_logger=opt_logger, lr=lr, betas=betas, eps=eps, momentum=momentum, **extra_args)
 
 def get_split_optimizer(name, model, lr, betas=(0.9, 0.999), eps=1e-8, momentum=0, weight_decay=None, bert_learning_rate=0.0, bert_weight_decay=None, charlm_learning_rate=0.0, is_peft=False, bert_finetune_layers=None):
-    """Same as `get_optimizer`, but splits the optimizer for Bert into a seperate optimizer"""
+    """Same as `get_optimizer`, but splits the optimizer for Bert into a separate optimizer"""
     base_parameters = [p for n, p in model.named_parameters()
                        if p.requires_grad and not n.startswith("bert_model.")
                        and not n.startswith("charmodel_forward.") and not n.startswith("charmodel_backward.")]

--- a/stanza/models/constituency/utils.py
+++ b/stanza/models/constituency/utils.py
@@ -329,7 +329,7 @@ def check_constituents(train_constituents, trees, treebank_name, fail=True):
                     num_errors += 1
                     if first_error is None:
                         first_error = tree_idx
-            error = "Found constituent label {} in the {} set which don't exist in the train set.  This constituent label occured in {} trees, with the first tree index at {} counting from 1\nThe error tree (which may have POS tags changed from the retagger and may be missing functional tags or empty nodes) is:\n{:P}".format(con, treebank_name, num_errors, (first_error+1), trees[first_error])
+            error = "Found constituent label {} in the {} set which don't exist in the train set.  This constituent label occurred in {} trees, with the first tree index at {} counting from 1\nThe error tree (which may have POS tags changed from the retagger and may be missing functional tags or empty nodes) is:\n{:P}".format(con, treebank_name, num_errors, (first_error+1), trees[first_error])
             if fail:
                 raise RuntimeError(error)
             else:

--- a/stanza/models/pos/data.py
+++ b/stanza/models/pos/data.py
@@ -129,7 +129,7 @@ class Dataset:
 
         Retrieves a sample from the dataset. This function, for the
         most part, is spent performing ad-hoc data augmentation and
-        restoration. It recieves a DataSample object from the storage,
+        restoration. It receives a DataSample object from the storage,
         and returns an almost-identical DataSample object that may
         have been augmented with /possibly/ (depending on augment_punct
         settings) PUNCT chopped.

--- a/stanza/models/tagger.py
+++ b/stanza/models/tagger.py
@@ -207,7 +207,7 @@ def load_training_data(args, pretrain):
         raise RuntimeError("Training data for the tagger is empty: %s" % args['train_file'])
     # we want to ensure that the model is able te output _ for empty columns,
     # but create batches whereby if a doc has upos/xpos tags we include them all.
-    # therefore, we create seperate datasets and loaders for each input training file,
+    # therefore, we create separate datasets and loaders for each input training file,
     # which will ensure the system be able to see batches with both upos available
     # and upos unavailable depending on what the availability in the file is.
     vocab = Dataset.init_vocab(train_docs, args)

--- a/stanza/models/tokenization/utils.py
+++ b/stanza/models/tokenization/utils.py
@@ -359,7 +359,7 @@ def postprocess_doc(doc, postprocessor, orig_text=None):
     # perform correction with the postprocessor
     postprocessor_return = postprocessor(words)
 
-    # collect the words and MWTs seperately
+    # collect the words and MWTs separately
     corrected_words = []
     corrected_mwts = []
     corrected_expansions = []
@@ -383,7 +383,7 @@ def postprocess_doc(doc, postprocessor, orig_text=None):
                 else:
                     sent_words.append(word[0])
                     sent_mwts.append(True)
-                    # expansions are marked in a space-seperated list, which
+                    # expansions are marked in a space-separated list, which
                     # `stanza.common.doc.set_mwt_expansions` reads and splits again
                     # by splitting by spaces. Therefore, to serialize the users' supplied MWT
                     # information, we join them by spaces to be split later by

--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -52,7 +52,7 @@ class TokenizeProcessor(UDProcessor):
         elif not postprocessor:
             self._postprocessor = None
         else:
-            raise ValueError("Tokenizer recieved 'postprocessor' option of unrecognized type; postprocessor must be callable. Got %s" % postprocessor)
+            raise ValueError("Tokenizer received 'postprocessor' option of unrecognized type; postprocessor must be callable. Got %s" % postprocessor)
 
     def process_pre_tokenized_text(self, input_src):
         """

--- a/stanza/utils/datasets/coref/convert_ontonotes.py
+++ b/stanza/utils/datasets/coref/convert_ontonotes.py
@@ -182,7 +182,7 @@ def extract_chains_from_conll(gold_coref_conll):
     """
     with open(gold_coref_conll, 'r') as df:
         gold_coref_conll = df.readlines()
-    # we want to first seperate the document into sentence-level
+    # we want to first separate the document into sentence-level
     # chunks; we assume that the ordering of the sentences are correct in the
     # gold document
     sections = []
@@ -237,7 +237,7 @@ def process_dataset(short_name, ontonotes_path, coref_output_path, use_singleton
     pipe = stanza.Pipeline("en", processors="tokenize,pos,lemma,depparse", package="default_accurate", tokenize_pretokenized=True)
 
     # if the cache directory doesn't yet exist, we make it
-    # we store the cache in a seperate subfolder to distinguish from the
+    # we store the cache in a separate subfolder to distinguish from the
     # possible Singleton conlls that maybe in the folder
     (Path(ontonotes_path) / "cache").mkdir(exist_ok=True)
 


### PR DESCRIPTION
Fixed several common typos in docstrings and comments: 'recieved' to 'received', 'seperate' to 'separate', and 'occured' to 'occurred'.