### PR TITLE
fix: correct 'seperate' to 'separate' in comments

### DIFF
--- a/stanza/models/common/utils.py
+++ b/stanza/models/common/utils.py
@@ -279,7 +279,7 @@ def get_optimizer(name, model, lr, betas=(0.9, 0.999), eps=1e-8, momentum=0, wei
     return dispatch_optimizer(name, parameters, opt_logger=opt_logger, lr=lr, betas=betas, eps=eps, momentum=momentum, **extra_args)
 
 def get_split_optimizer(name, model, lr, betas=(0.9, 0.999), eps=1e-8, momentum=0, weight_decay=None, bert_learning_rate=0.0, bert_weight_decay=None, charlm_learning_rate=0.0, is_peft=False, bert_finetune_layers=None):
-    """Same as `get_optimizer`, but splits the optimizer for Bert into a seperate optimizer"""
+    """Same as `get_optimizer`, but splits the optimizer for Bert into a separate optimizer"""
     base_parameters = [p for n, p in model.named_parameters()
                        if p.requires_grad and not n.startswith("bert_model.")
                        and not n.startswith("charmodel_forward.") and not n.startswith("charmodel_backward.")]

--- a/stanza/models/tagger.py
+++ b/stanza/models/tagger.py
@@ -207,7 +207,7 @@ def load_training_data(args, pretrain):
         raise RuntimeError("Training data for the tagger is empty: %s" % args['train_file'])
     # we want to ensure that the model is able te output _ for empty columns,
     # but create batches whereby if a doc has upos/xpos tags we include them all.
-    # therefore, we create seperate datasets and loaders for each input training file,
+    # therefore, we create separate datasets and loaders for each input training file,
     # which will ensure the system be able to see batches with both upos available
     # and upos unavailable depending on what the availability in the file is.
     vocab = Dataset.init_vocab(train_docs, args)

--- a/stanza/models/tokenization/utils.py
+++ b/stanza/models/tokenization/utils.py
@@ -359,7 +359,7 @@ def postprocess_doc(doc, postprocessor, orig_text=None):
     # perform correction with the postprocessor
     postprocessor_return = postprocessor(words)
 
-    # collect the words and MWTs seperately
+    # collect the words and MWTs separately
     corrected_words = []
     corrected_mwts = []
     corrected_expansions = []
@@ -383,7 +383,7 @@ def postprocess_doc(doc, postprocessor, orig_text=None):
                 else:
                     sent_words.append(word[0])
                     sent_mwts.append(True)
-                    # expansions are marked in a space-seperated list, which
+                    # expansions are marked in a space-separated list, which
                     # `stanza.common.doc.set_mwt_expansions` reads and splits again
                     # by splitting by spaces. Therefore, to serialize the users' supplied MWT
                     # information, we join them by spaces to be split later by

--- a/stanza/utils/datasets/coref/convert_ontonotes.py
+++ b/stanza/utils/datasets/coref/convert_ontonotes.py
@@ -182,7 +182,7 @@ def extract_chains_from_conll(gold_coref_conll):
     """
     with open(gold_coref_conll, 'r') as df:
         gold_coref_conll = df.readlines()
-    # we want to first seperate the document into sentence-level
+    # we want to first separate the document into sentence-level
     # chunks; we assume that the ordering of the sentences are correct in the
     # gold document
     sections = []
@@ -237,7 +237,7 @@ def process_dataset(short_name, ontonotes_path, coref_output_path, use_singleton
     pipe = stanza.Pipeline("en", processors="tokenize,pos,lemma,depparse", package="default_accurate", tokenize_pretokenized=True)
 
     # if the cache directory doesn't yet exist, we make it
-    # we store the cache in a seperate subfolder to distinguish from the
+    # we store the cache in a separate subfolder to distinguish from the
     # possible Singleton conlls that maybe in the folder
     (Path(ontonotes_path) / "cache").mkdir(exist_ok=True)
 


### PR DESCRIPTION
Fixed typo 'seperate' → 'separate' in comments and docstrings across multiple files.