### PR TITLE
Use platformdirs to avoid polluting HOME

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
     install_requires=[
         'emoji', 
         'numpy', 
+        'platformdirs',
         'protobuf>=3.15.0',
         'requests', 
         'networkx',

--- a/stanza/resources/common.py
+++ b/stanza/resources/common.py
@@ -14,6 +14,7 @@ import shutil
 import tempfile
 import zipfile
 
+from platformdirs import user_cache_dir
 from tqdm.auto import tqdm
 
 from stanza.utils.helper_func import make_table
@@ -25,7 +26,7 @@ from stanza._version import __resources_version__
 logger = logging.getLogger('stanza')
 
 # set home dir for default
-HOME_DIR = str(Path.home())
+USER_CACHE_DIR = user_cache_dir('stanza', 'StanfordNLP', __resources_version__)
 STANFORDNLP_RESOURCES_URL = 'https://nlp.stanford.edu/software/stanza/stanza-resources/'
 STANZA_RESOURCES_GITHUB = 'https://raw.githubusercontent.com/stanfordnlp/stanza-resources/'
 DEFAULT_RESOURCES_URL = os.getenv('STANZA_RESOURCES_URL', STANZA_RESOURCES_GITHUB + 'main')
@@ -36,7 +37,7 @@ DEFAULT_RESOURCES_VERSION = os.getenv(
 DEFAULT_MODEL_URL = os.getenv('STANZA_MODEL_URL', 'default')
 DEFAULT_MODEL_DIR = os.getenv(
     'STANZA_RESOURCES_DIR',
-    os.path.join(HOME_DIR, 'stanza_resources')
+    os.path.join(USER_CACHE_DIR, 'resources')
 )
 
 PRETRAIN_NAMES = ("pretrain", "forward_charlm", "backward_charlm")

--- a/stanza/resources/installation.py
+++ b/stanza/resources/installation.py
@@ -7,7 +7,7 @@ import logging
 import zipfile
 import shutil
 
-from stanza.resources.common import HOME_DIR, request_file, unzip, \
+from stanza.resources.common import USER_CACHE_DIR, request_file, unzip, \
     get_root_from_zipfile, set_logging_level
 
 logger = logging.getLogger('stanza')
@@ -25,7 +25,7 @@ DEFAULT_CORENLP_URL = os.getenv(
 
 DEFAULT_CORENLP_DIR = os.getenv(
     'CORENLP_HOME',
-    os.path.join(HOME_DIR, 'stanza_corenlp')
+    os.path.join(USER_CACHE_DIR, 'corenlp')
 )
 
 AVAILABLE_MODELS = set(['arabic', 'chinese', 'english-extra', 'english-kbp', 'french', 'german', 'hungarian', 'italian', 'spanish'])


### PR DESCRIPTION
## Description
It's not nice to have `$HOME/stanza_resources` et al.

## Unit test coverage
No change in coverage.


## Known breaking changes/behaviors
This will cause the data to be redownloaded for users not setting `$STANZA_RESOURCES_DIR` and/or `$CORENLP_HOME`.