### PR TITLE
Add multi-document pipeline API and coreference utilities

### DIFF
--- a/stanza/core/__init__.py
+++ b/stanza/core/__init__.py
@@ -1,0 +1,8 @@
+"""
+Coreference and higher-level core utilities built on top of the main Stanza pipeline.
+"""
+
+from . import coref_utils
+
+__all__ = ["coref_utils"]
+

--- a/stanza/core/coref_utils.py
+++ b/stanza/core/coref_utils.py
@@ -1,0 +1,117 @@
+import collections
+
+from stanza.models.common.doc import Document
+
+
+def iter_coref_chains(doc):
+    """
+    Yield (chain_index, CorefChain) for each coreference chain in the document.
+    """
+    if not isinstance(doc, Document):
+        raise ValueError("iter_coref_chains expects a Document")
+    if not getattr(doc, "coref", None):
+        return
+    for chain in doc.coref:
+        yield chain.index, chain
+
+
+def coref_chains_as_dicts(doc):
+    """
+    Return coreference chains as a list of dictionaries with mention spans and representative text.
+    """
+    chains = []
+    for chain_index, chain in iter_coref_chains(doc):
+        mentions = []
+        for mention in chain.mentions:
+            mentions.append(
+                {
+                    "sentence": mention.sentence,
+                    "start": mention.start_word,
+                    "end": mention.end_word,
+                }
+            )
+        chains.append(
+            {
+                "index": chain_index,
+                "representative": chain.representative_text,
+                "mentions": mentions,
+            }
+        )
+    return chains
+
+
+def _build_token_lookup(doc):
+    """
+    Build a flat list of (sentence_idx, word_idx) pairs for all words in the document.
+    """
+    mapping = []
+    for sent_idx, sentence in enumerate(doc.sentences):
+        for word_idx, _ in enumerate(sentence.words):
+            mapping.append((sent_idx, word_idx))
+    return mapping
+
+
+def resolve_coref(doc, strategy="first_mention"):
+    """
+    Return a token list with coreferent mentions replaced by a representative string.
+
+    The default strategy replaces all non-representative mentions in a chain
+    with the chain's representative text, based on document order.
+    """
+    if not isinstance(doc, Document):
+        raise ValueError("resolve_coref expects a Document")
+
+    # If there is no coreference information, fall back to the raw tokens
+    if not getattr(doc, "coref", None):
+        return [word.text for sentence in doc.sentences for word in sentence.words]
+
+    # Flat sequence of tokens; we use this as our working copy
+    token_lookup = _build_token_lookup(doc)
+    tokens = [doc.sentences[sent_idx].words[word_idx].text for (sent_idx, word_idx) in token_lookup]
+
+    # Map from (sentence, start_word, end_word) to representative text
+    mention_to_rep = {}
+    for chain in doc.coref:
+        if not chain.mentions:
+            continue
+
+        if strategy == "first_mention":
+            # Use the earliest mention in document order as representative
+            rep = min(chain.mentions, key=lambda m: (m.sentence, m.start_word))
+        else:
+            # Fall back to the chain's stored representative, if available
+            rep = chain.mentions[chain.representative_index] if chain.representative_index is not None else chain.mentions[0]
+
+        rep_text = chain.representative_text
+        rep_key = (rep.sentence, rep.start_word, rep.end_word)
+
+        for mention in chain.mentions:
+            key = (mention.sentence, mention.start_word, mention.end_word)
+            if key == rep_key:
+                continue
+            mention_to_rep[key] = rep_text
+
+    # Apply replacements; for multi-word mentions we replace the span with a single token
+    resolved_tokens = []
+    idx = 0
+    while idx < len(token_lookup):
+        sent_idx, word_idx = token_lookup[idx]
+
+        # Find any mention starting at this position
+        replacement = None
+        replacement_span_len = 1
+        for (m_sent, m_start, m_end), rep_text in mention_to_rep.items():
+            if m_sent == sent_idx and m_start == word_idx:
+                replacement = rep_text
+                replacement_span_len = max(1, m_end - m_start)
+                break
+
+        if replacement is not None:
+            resolved_tokens.append(replacement)
+            idx += replacement_span_len
+        else:
+            resolved_tokens.append(tokens[idx])
+            idx += 1
+
+    return resolved_tokens
+

--- a/stanza/pipeline/core.py
+++ b/stanza/pipeline/core.py
@@ -442,6 +442,29 @@ class Pipeline:
         doc = CoNLL.conll2doc(input_str=doc, ignore_gapping=ignore_gapping)
         return self.process(doc, processors=processors)
 
+    def process_many(self, docs, *args, **kwargs):
+        """
+        Process a collection of documents or texts and return a list of Documents.
+
+        This is a convenience wrapper around the existing bulk processing logic which:
+          - Accepts any iterable of strings or Document objects
+          - Preserves the input order
+          - Always returns a list of Documents
+        """
+        if docs is None:
+            raise ValueError("docs must be an iterable of strings or Documents")
+        # Support any iterable, not just lists
+        if not isinstance(docs, collections.abc.Iterable) or isinstance(docs, (str, bytes)):
+            raise ValueError("docs must be an iterable of strings or Documents, not a single string")
+        docs = list(docs)
+        if len(docs) == 0:
+            return []
+        result = self.bulk_process(docs, *args, **kwargs)
+        # bulk_process already preserves Documents; ensure we always return a list
+        if isinstance(result, list):
+            return result
+        return list(result)
+
     def bulk_process(self, docs, *args, **kwargs):
         """
         Run the pipeline in bulk processing mode

--- a/stanza/tests/core/test_coref_utils.py
+++ b/stanza/tests/core/test_coref_utils.py
@@ -1,0 +1,86 @@
+import pytest
+
+from stanza.models.common.doc import Document
+from stanza.models.coref.coref_chain import CorefChain, CorefMention
+from stanza.core import coref_utils
+
+
+def build_doc_with_coref():
+    """
+    Build a minimal Document with two sentences and a simple coref chain.
+    """
+    sentences = [
+        [
+            {
+                "id": 1,
+                "text": "Barack",
+                "lemma": "Barack",
+                "upos": "PROPN",
+                "xpos": "NNP",
+                "feats": "_",
+                "head": 2,
+                "deprel": "compound",
+                "deps": "_",
+                "misc": "start_char=0|end_char=6",
+            },
+            {
+                "id": 2,
+                "text": "Obama",
+                "lemma": "Obama",
+                "upos": "PROPN",
+                "xpos": "NNP",
+                "feats": "_",
+                "head": 0,
+                "deprel": "root",
+                "deps": "_",
+                "misc": "start_char=7|end_char=12",
+            },
+        ],
+        [
+            {
+                "id": 1,
+                "text": "He",
+                "lemma": "he",
+                "upos": "PRON",
+                "xpos": "PRP",
+                "feats": "_",
+                "head": 0,
+                "deprel": "root",
+                "deps": "_",
+                "misc": "start_char=0|end_char=2",
+            }
+        ],
+    ]
+    doc = Document(sentences, text="Barack Obama\nHe")
+
+    # One chain: [Barack Obama] <-> [He]
+    mentions = [
+        CorefMention(sentence=0, start_word=0, end_word=2),
+        CorefMention(sentence=1, start_word=0, end_word=1),
+    ]
+    chain = CorefChain(index=0, mentions=mentions, representative_text="Barack Obama", representative_index=0)
+    doc.coref = [chain]
+    return doc
+
+
+def test_coref_chains_as_dicts():
+    doc = build_doc_with_coref()
+    chains = coref_utils.coref_chains_as_dicts(doc)
+
+    assert len(chains) == 1
+    chain = chains[0]
+    assert chain["index"] == 0
+    assert chain["representative"] == "Barack Obama"
+    assert len(chain["mentions"]) == 2
+    first, second = chain["mentions"]
+    assert first["sentence"] == 0 and first["start"] == 0 and first["end"] == 2
+    assert second["sentence"] == 1 and second["start"] == 0 and second["end"] == 1
+
+
+def test_resolve_coref_default_strategy():
+    doc = build_doc_with_coref()
+    tokens = coref_utils.resolve_coref(doc)
+
+    # The pronoun "He" should be replaced with the representative mention
+    assert tokens == ["Barack", "Obama", "Barack Obama"]
+

--- a/stanza/tests/pipeline/test_pipeline_multi_doc.py
+++ b/stanza/tests/pipeline/test_pipeline_multi_doc.py
@@ -1,0 +1,59 @@
+import pytest
+
+import stanza
+from stanza.tests import TEST_MODELS_DIR
+
+
+pytestmark = pytest.mark.pipeline
+
+
+def test_process_many_strings():
+    pipe = stanza.Pipeline(
+        lang="en",
+        dir=TEST_MODELS_DIR,
+        processors="tokenize,pos",
+        download_method=None,
+    )
+
+    texts = [
+        "Barack Obama was born in Hawaii.",
+        "He was elected president in 2008.",
+    ]
+    docs = pipe.process_many(texts)
+
+    assert isinstance(docs, list)
+    assert len(docs) == 2
+    assert all(doc.sentences for doc in docs)
+    assert all(
+        all(word.upos is not None for word in doc.sentences[0].words)
+        for doc in docs
+    )
+
+
+def test_process_many_documents():
+    base_pipe = stanza.Pipeline(
+        lang="en",
+        dir=TEST_MODELS_DIR,
+        processors="tokenize",
+        download_method=None,
+    )
+    docs = [base_pipe("This is a test."), base_pipe("Another one.")]
+
+    pipe = stanza.Pipeline(
+        lang="en",
+        dir=TEST_MODELS_DIR,
+        processors="tokenize,pos",
+        download_method=None,
+    )
+    processed = pipe.process_many(docs)
+
+    assert isinstance(processed, list)
+    assert len(processed) == 2
+    # Order should be preserved
+    assert processed[0].sentences[0].text.startswith("This")
+    assert processed[1].sentences[0].text.startswith("Another")
+    assert all(
+        all(word.upos is not None for word in doc.sentences[0].words)
+        for doc in processed
+    )
+


### PR DESCRIPTION
### Summary
- Add a `Pipeline.process_many` helper that processes an iterable of texts or `Document`s and returns a list of `Document`s, built on top of the existing bulk processing logic.
- Introduce `stanza.core.coref_utils` with utilities to inspect and consume coreference annotations (`iter_coref_chains`, `coref_chains_as_dicts`, and `resolve_coref`).
- Add tests for the new pipeline API and coref utilities (`test_pipeline_multi_doc.py`, `test_coref_utils.py`).

### Motivation
-  `Pipeline.process_many` provides a simple, explicit multi-document API on top of the existing `bulk_process`/`stream` mechanisms while preserving backwards compatibility.
- Stanza already exposes coreference annotations via `coref_processor`, but consuming them requires working directly with internal chain/mention objects. The new `stanza.core.coref_utils` module offers small, reusable helpers that make it easier to inspect clusters and obtain a token-level representation with mentions resolved to representative strings, without changing the underlying models.

## Authors
- Ireddi Rakshitha
- Yashwanth Devavarapu