### PR TITLE
fix: only set logging level when explicitly requested

### DIFF
--- a/stanza/pipeline/core.py
+++ b/stanza/pipeline/core.py
@@ -198,8 +198,9 @@ class Pipeline:
         if model_dir is not None and dir == DEFAULT_MODEL_DIR:
             self.dir = model_dir
 
-        # set global logging level
-        set_logging_level(logging_level, verbose)
+        # Only adjust logging if the caller explicitly requested it
+        if logging_level is not None or verbose is not None:
+            set_logging_level(logging_level, verbose)
 
         self.download_method = normalize_download_method(download_method)
         if (self.download_method is DownloadMethod.DOWNLOAD_RESOURCES or

--- a/stanza/resources/common.py
+++ b/stanza/resources/common.py
@@ -567,8 +567,12 @@ def download(
         proxies=None,
         download_json=True
     ):
-    # set global logging level
-    set_logging_level(logging_level, verbose)
+    # Only set global logging level if the caller explicitly requested it.
+    # Previously this was called unconditionally, which meant a simple
+    # stanza.download('en') would reset the user's logging configuration
+    # as a side effect.  See https://github.com/stanfordnlp/stanza/issues/1418
+    if logging_level is not None or verbose is not None:
+        set_logging_level(logging_level, verbose)
     # process different pipeline parameters
     lang, model_dir, package, processors = process_pipeline_parameters(
         lang, model_dir, package, processors

--- a/stanza/resources/installation.py
+++ b/stanza/resources/installation.py
@@ -98,7 +98,8 @@ def install_corenlp(dir=DEFAULT_CORENLP_DIR, url=DEFAULT_CORENLP_URL, logging_le
         logging_level: logging level to use during installation
     """
     dir = os.path.expanduser(dir)
-    set_logging_level(logging_level=logging_level, verbose=None)
+    if logging_level is not None:
+        set_logging_level(logging_level=logging_level, verbose=None)
     if os.path.exists(dir) and len(os.listdir(dir)) > 0:
         logger.warn(
             f"Directory {dir} already exists. "


### PR DESCRIPTION
## Summary

`download()`, `install_corenlp()`, and `Pipeline.__init__()` all called `set_logging_level()` unconditionally, even when the caller passed neither `logging_level` nor `verbose`. This caused `set_logging_level(None, None)` to reset the stanza logger to `INFO` as a side effect, overriding any logging configuration the user had set up.

Closes #1418

## Problem

```python
import logging
import stanza

# User configures logging to WARNING
stanza.logger.setLevel('WARNING')

# This silently resets it to INFO
stanza.download('en')

# User's WARNING level is gone
print(stanza.logger.level)  # 20 (INFO), not 30 (WARNING)
```

## Fix

Guard all three call sites so `set_logging_level()` is only invoked when the caller explicitly passes `logging_level` or `verbose`:

```python
# Before (always called, even with defaults):
set_logging_level(logging_level, verbose)

# After (only when user requested):
if logging_level is not None or verbose is not None:
    set_logging_level(logging_level, verbose)
```

### Files changed

| File | Call site |
|------|----------|
| `stanza/resources/common.py` | `download()` |
| `stanza/resources/installation.py` | `install_corenlp()` |
| `stanza/pipeline/core.py` | `Pipeline.__init__()` |

## Backward compatibility

- Users who pass `logging_level='DEBUG'` or `verbose=True` get the same behavior as before
- Users who don't pass either argument no longer have their logging silently reset
- `stanza.download('en', logging_level='ERROR')` still works