### PR TITLE
Fix UnboundLocalError in process_pre_tokenized_text for CoNLL documents

### DIFF
--- a/stanza/pipeline/tokenize_processor.py
+++ b/stanza/pipeline/tokenize_processor.py
@@ -69,6 +69,8 @@ class TokenizeProcessor(UDProcessor):
             sentences = [sent.strip().split() for sent in input_src.strip().split('\n') if len(sent.strip()) > 0]
         elif isinstance(input_src, list):
             sentences = input_src
+        else:
+            sentences = []
         idx = 0
         for sentence in sentences:
             sent = []


### PR DESCRIPTION
## Summary
- Fixes `UnboundLocalError: local variable 'sentences' referenced before assignment` when calling `bulk_process` on CoNLL-U Documents (issue #1464)
- In `process_pre_tokenized_text`, the code only handled `str` and `list` inputs, leaving `sentences` undefined when `input_src` is `None` (as with CoNLL documents that have no raw text)
- Added an `else` branch that defaults `sentences` to an empty list, preventing the crash

## Test plan
- [ ] Verify `bulk_process` with CoNLL-U Documents no longer throws `UnboundLocalError`
- [ ] Verify existing tokenization behavior for `str` and `list` inputs is unchanged

Fixes #1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)