### PR TITLE
Add multi-document pipeline API

### DIFF
--- a/stanza/pipeline/core.py
+++ b/stanza/pipeline/core.py
@@ -441,6 +441,29 @@ class Pipeline:
         doc = CoNLL.conll2doc(input_str=doc, ignore_gapping=ignore_gapping)
         return self.process(doc, processors=processors)
 
+    def process_many(self, docs, *args, **kwargs):
+        """
+        Process a collection of documents or texts and return a list of Documents.
+
+        This is a convenience wrapper around the existing bulk processing logic which:
+          - Accepts any iterable of strings or Document objects
+          - Preserves the input order
+          - Always returns a list of Documents
+        """
+        if docs is None:
+            raise ValueError("docs must be an iterable of strings or Documents")
+        # Support any iterable, not just lists
+        if not isinstance(docs, collections.abc.Iterable) or isinstance(docs, (str, bytes)):
+            raise ValueError("docs must be an iterable of strings or Documents, not a single string")
+        docs = list(docs)
+        if len(docs) == 0:
+            return []
+        result = self.bulk_process(docs, *args, **kwargs)
+        # bulk_process already preserves Documents; ensure we always return a list
+        if isinstance(result, list):
+            return result
+        return list(result)
+
     def bulk_process(self, docs, *args, **kwargs):
         """
         Run the pipeline in bulk processing mode

--- a/stanza/tests/pipeline/test_pipeline_multi_doc.py
+++ b/stanza/tests/pipeline/test_pipeline_multi_doc.py
@@ -1,0 +1,59 @@
+import pytest
+
+import stanza
+from stanza.tests import TEST_MODELS_DIR
+
+
+pytestmark = pytest.mark.pipeline
+
+
+def test_process_many_strings():
+    pipe = stanza.Pipeline(
+        lang="en",
+        dir=TEST_MODELS_DIR,
+        processors="tokenize,pos",
+        download_method=None,
+    )
+
+    texts = [
+        "Barack Obama was born in Hawaii.",
+        "He was elected president in 2008.",
+    ]
+    docs = pipe.process_many(texts)
+
+    assert isinstance(docs, list)
+    assert len(docs) == 2
+    assert all(doc.sentences for doc in docs)
+    assert all(
+        all(word.upos is not None for word in doc.sentences[0].words)
+        for doc in docs
+    )
+
+
+def test_process_many_documents():
+    base_pipe = stanza.Pipeline(
+        lang="en",
+        dir=TEST_MODELS_DIR,
+        processors="tokenize",
+        download_method=None,
+    )
+    docs = [base_pipe("This is a test."), base_pipe("Another one.")]
+
+    pipe = stanza.Pipeline(
+        lang="en",
+        dir=TEST_MODELS_DIR,
+        processors="tokenize,pos",
+        download_method=None,
+    )
+    processed = pipe.process_many(docs)
+
+    assert isinstance(processed, list)
+    assert len(processed) == 2
+    # Order should be preserved
+    assert processed[0].sentences[0].text.startswith("This")
+    assert processed[1].sentences[0].text.startswith("Another")
+    assert all(
+        all(word.upos is not None for word in doc.sentences[0].words)
+        for doc in processed
+    )
+


### PR DESCRIPTION
### Summary
- Add a Pipeline.process_many helper that processes an iterable of texts or Documents and returns a list of Documents, built on top of the existing bulk processing logic.
- Add tests for the new pipeline API

### Motivation
-  `Pipeline.process_many` provides a simple, explicit multi-document API on top of the existing `bulk_process`/`stream` mechanisms while preserving backwards compatibility.

### Authors
- Ireddi Rakshitha
- Yashwanth Devavarapu
