### PR TITLE
Spanish tokenizer check

### DIFF
--- a/stanza/models/tokenization/data.py
+++ b/stanza/models/tokenization/data.py
@@ -529,7 +529,7 @@ class DataLoader(TokenizationDataset):
 
             if augment_final_punct_prob > 0.0:
                 for sentence_idx, sentence in enumerate(sentences):
-                    if random.random() < split_mwt_prob:
+                    if random.random() < augment_final_punct_prob:
                         new_sentence = self.augment_final_punct(sentence)
                         if new_sentence is not None:
                             sentences[sentence_idx] = new_sentence[0]

--- a/stanza/models/tokenization/data.py
+++ b/stanza/models/tokenization/data.py
@@ -24,6 +24,9 @@ def filter_consecutive_whitespaces(para):
 
     return filtered
 
+# control characters not covered by \s, but still not part of normal text
+# for example, U+0097 was reported as being stuck on a token in this issue:
+# https://github.com/stanfordnlp/stanza/issues/1257
 NEWLINE_WHITESPACE_RE = re.compile(r'\n[\s\u0080-\u009f]*\n')
 # this was (r'^([\d]+[,\.]*)+$')
 # but the runtime on that can explode exponentially

--- a/stanza/models/tokenization/data.py
+++ b/stanza/models/tokenization/data.py
@@ -264,6 +264,16 @@ def build_known_mwt(data, mwt_expansions):
             known_mwts.add(mwt)
     return known_mwts
 
+
+# Pairs of (existing, replacement) for mid-sentence punctuation augmentation.
+# The existing character must appear in the training data and the replacement
+# must not, otherwise the pair is skipped (checked in augment_vocab).
+MID_SENT_AUGMENT_PAIRS = [
+    (",", "\u2013"),   # comma -> en dash
+    (",", "\u2014"),   # comma -> em dash
+]
+
+
 class DataLoader(TokenizationDataset):
     """
     This is the training version of the dataset.
@@ -312,11 +322,15 @@ class DataLoader(TokenizationDataset):
                              ("!", "‼"),]
             for orig, target in AUGMENT_PAIRS:
                 if self.augment_vocab(self.vocab, self.data, orig, target):
-                    logger.debug('Based on the training data, augmenting |%s| to |%s|' % (orig, target))
+                    logger.debug('Based on the training data, augmenting final |%s| to |%s|' % (orig, target))
                     self.augmentations[orig].append(target)
                 if self.augment_vocab(self.vocab, self.data, target, orig):
-                    logger.debug('Based on the training data, augmenting |%s| to |%s|' % (target, orig))
+                    logger.debug('Based on the training data, augmenting final |%s| to |%s|' % (target, orig))
                     self.augmentations[target].append(orig)
+
+        augment_mid_punct_prob = 0.0 if evaluation else args.get('augment_mid_punct_prob', 0.0)
+        if augment_mid_punct_prob > 0.0:
+            self.mid_sent_augmentations = self.build_mid_sent_augmentations(self.vocab, self.data, MID_SENT_AUGMENT_PAIRS)
 
     def __len__(self):
         return len(self.sentence_ids)
@@ -326,17 +340,21 @@ class DataLoader(TokenizationDataset):
         return vocab
 
     @staticmethod
-    def augment_vocab(vocab, data, existing_unit, new_unit):
+    def augment_vocab(vocab, data, existing_unit, new_unit, final=True):
         if existing_unit not in vocab:
             return False
         new_unit_count = 0
         existing_unit_count = 0
         for sentence in data:
-            unit = sentence[-1][0]
-            if unit == new_unit:
-                new_unit_count += 1
-            elif unit == existing_unit:
-                existing_unit_count += 1
+            if final:
+                units = [sentence[-1][0]]
+            else:
+                units = [x[0] for x in sentence]
+            for unit in units:
+                if unit == new_unit:
+                    new_unit_count += 1
+                elif unit == existing_unit:
+                    existing_unit_count += 1
         if existing_unit_count == 0:
             return False
         if new_unit_count > 0:
@@ -345,6 +363,22 @@ class DataLoader(TokenizationDataset):
             vocab.append(new_unit)
         logger.debug("Found %d |%s| and %d |%s|", new_unit_count, new_unit, existing_unit_count, existing_unit)
         return True
+
+    @staticmethod
+    def build_mid_sent_augmentations(vocab, data, pairs):
+        """
+        For each (existing, replacement) pair, check whether the substitution
+        is appropriate for this dataset (existing present, replacement absent)
+        using the same augment_vocab logic as augment_final_punct.  Returns a
+        dict mapping each source character to a list of valid replacement
+        characters.
+        """
+        augmentations = defaultdict(list)
+        for orig, target in pairs:
+            if DataLoader.augment_vocab(vocab, data, orig, target, final=False):
+                logger.debug('Mid-sentence augmentation: will substitute |%s| with |%s|', orig, target)
+                augmentations[orig].append(target)
+        return augmentations
 
     def init_sent_ids(self):
         self.sentence_ids = []
@@ -446,6 +480,86 @@ class DataLoader(TokenizationDataset):
         encoded = self.para_to_sentences(new_units)
         return encoded
 
+    def augment_mid_sent_punct(self, sentence):
+        """
+        With some probability (controlled externally by the caller), replace
+        one mid-sentence punctuation character with an augmented alternative
+        drawn from self.mid_sent_augmentations.
+
+        Because en/em dashes appear in text with varying spacing conventions,
+        the substitution also randomly adjusts the spaces immediately
+        surrounding the replacement character:
+
+          original (comma style):  "A, B"   -> chars: A , ' ' B
+          possible outputs:
+            spaced both sides:     "A – B"  -> A ' ' – ' ' B
+            attached left:         "A– B"   -> A     – ' ' B
+            attached right:        "A –B"   -> A ' ' –     B
+            attached both sides:   "A–B"    -> A     –     B
+
+        Returns a re-encoded sentence list, or None if no eligible position
+        was found.
+        """
+        if not hasattr(self, 'mid_sent_augmentations') or not self.mid_sent_augmentations:
+            return None
+
+        if len(sentence[3]) <= 2 or len(sentence[3]) >= self.args['max_seqlen'] - 2:
+            return None
+
+        eligible = [
+            idx for idx, (char, label) in enumerate(zip(sentence[3], sentence[1]))
+            if char in self.mid_sent_augmentations
+            and 0 < idx < len(sentence[3]) - 1
+            and label != 0
+            and sentence[1][idx - 1] != 0
+        ]
+
+        if not eligible:
+            return None
+
+        idx = random.choice(eligible)
+        orig_char = sentence[3][idx]
+        new_char = random.choice(self.mid_sent_augmentations[orig_char])
+
+        all_units = [(x, int(y)) for x, y in zip(sentence[3], sentence[1])]
+
+        # Replace the character itself.
+        new_units = list(all_units)
+        new_units[idx] = (new_char, all_units[idx][1])
+
+        # Determine current spacing around the punctuation character.
+        has_space_before = idx > 0 and all_units[idx - 1][0] == ' '
+        has_space_after  = idx < len(all_units) - 1 and all_units[idx + 1][0] == ' '
+
+        # Four spacing styles, chosen uniformly at random:
+        #   0: spaced both sides  "A – B"
+        #   1: attached left      "A– B"   (drop space before)
+        #   2: attached right     "A –B"   (drop space after)
+        #   3: attached both      "A–B"
+        spacing_style = random.randint(0, 3)
+
+        want_space_before = spacing_style in (0, 2)
+        want_space_after  = spacing_style in (0, 1)
+
+        # Adjust space before the dash.
+        if has_space_before and not want_space_before:
+            del new_units[idx - 1]
+            idx -= 1   # keep idx pointing at the dash after deletion
+        elif not has_space_before and want_space_before:
+            new_units.insert(idx, (' ', 0))
+            idx += 1
+
+        # Adjust space after the dash (idx still points at the dash).
+        if has_space_after and not want_space_after:
+            del new_units[idx + 1]
+        elif not has_space_after and want_space_after:
+            new_units.insert(idx + 1, (' ', 0))
+
+        encoded = self.para_to_sentences(new_units)
+        if not encoded:
+            return None
+        return encoded
+
     def augment_final_punct(self, sentence):
         if len(sentence[3]) > 1 and len(sentence[3]) < self.args['max_seqlen']:
             if sentence[3][-1] in self.augmentations:
@@ -474,6 +588,7 @@ class DataLoader(TokenizationDataset):
             move_last_char_prob = 0.0 if self.eval else self.args.get('last_char_move_prob', 0.0)
             move_punct_back_prob = 0.0 if self.eval else self.args.get('punct_move_back_prob', 0.0)
             split_mwt_prob = 0.0 if self.eval else self.args.get('split_mwt_prob', 0.0)
+            augment_mid_punct_prob = 0.0 if self.eval else self.args.get('augment_mid_punct_prob', 0.0)
             augment_final_punct_prob = 0.0 if self.eval else self.args.get('augment_final_punct_prob', 0.0)
 
             pid, sid = id_pair if self.eval else random.choice(self.sentence_ids)
@@ -531,6 +646,13 @@ class DataLoader(TokenizationDataset):
                 for sentence_idx, sentence in enumerate(sentences):
                     if random.random() < augment_final_punct_prob:
                         new_sentence = self.augment_final_punct(sentence)
+                        if new_sentence is not None:
+                            sentences[sentence_idx] = new_sentence[0]
+
+            if augment_mid_punct_prob > 0.0:
+                for sentence_idx, sentence in enumerate(sentences):
+                    if random.random() < augment_mid_punct_prob:
+                        new_sentence = self.augment_mid_sent_punct(sentence)
                         if new_sentence is not None:
                             sentences[sentence_idx] = new_sentence[0]
 

--- a/stanza/models/tokenization/data.py
+++ b/stanza/models/tokenization/data.py
@@ -24,12 +24,12 @@ def filter_consecutive_whitespaces(para):
 
     return filtered
 
-NEWLINE_WHITESPACE_RE = re.compile(r'\n\s*\n')
+NEWLINE_WHITESPACE_RE = re.compile(r'\n[\s\u0080-\u009f]*\n')
 # this was (r'^([\d]+[,\.]*)+$')
 # but the runtime on that can explode exponentially
 # for example, on 111111111111111111111111a
 NUMERIC_RE = re.compile(r'^[\d]+([,\.]+[\d]+)*[,\.]*$')
-WHITESPACE_RE = re.compile(r'\s')
+WHITESPACE_RE = re.compile(r'[\s\u0080-\u009f]')
 
 class TokenizationDataset:
     def __init__(self, tokenizer_args, input_files={'txt': None, 'label': None}, input_text=None, vocab=None, evaluation=False, dictionary=None, *args, **kwargs):

--- a/stanza/models/tokenization/data.py
+++ b/stanza/models/tokenization/data.py
@@ -1,3 +1,97 @@
+"""
+Data loading and training augmentation for the Stanza neural tokenizer.
+
+The tokenizer treats tokenization and sentence segmentation as a character-level
+tagging problem.  Each character in the input is assigned one of the following
+labels:
+
+  0  continuation  – character is inside a token (not its last character)
+  1  word end      – last character of a token / word
+  2  sentence end  – last character of the final token in a sentence
+  3  MWT end       – last character of a multi-word token (e.g. "ocultándolo")
+  4  MWT+sent end  – last character of an MWT that also ends a sentence
+
+Note that languages with no MWT layer only use 0,1,2.
+
+The central classes are:
+
+TokenizationDataset
+    Base class.  Reads raw text (and optionally a parallel label file) from
+    disk or a string, normalises whitespace (including C1 control characters
+    such as U+0097 which are invisible but would otherwise attach to tokens),
+    splits on blank lines into paragraphs, and stores the result as a list of
+    (character, label) pairs per paragraph.  Also provides character-level
+    feature extraction (space_before, capitalized, numeric, dictionary look-up)
+    used as auxiliary input to the neural model.
+
+DataLoader(TokenizationDataset)
+    Training-time subclass.  Builds a vocabulary, wraps the data into fixed-
+    length windows suitable for batched GPU training, and applies a suite of
+    data augmentation techniques (described below) to improve generalisation.
+
+SortedDataset(Dataset)
+    Thin wrapper around TokenizationDataset that sorts paragraphs by length and
+    exposes a collate() method so that a torch DataLoader can efficiently batch
+    them with minimal padding during evaluation.
+
+--------------------------------------------------------------------------------
+Training augmentations
+--------------------------------------------------------------------------------
+
+All augmentations are applied stochastically at batch-construction time inside
+DataLoader.next() / strings_starting(), so the model sees a different
+perturbation of each sentence on each training pass.  Each is gated by a
+probability argument (default 0.0, i.e. off unless explicitly enabled).
+
+move_last_char  (last_char_move_prob)
+    Moves the sentence-final punctuation character one position to the right,
+    inserting a space before it.  Teaches the tokenizer that a space-separated
+    sentence-final punct still ends the sentence, which is useful for languages
+    where the training data always has the punct attached.
+
+move_punct_back  (punct_move_back_prob)
+    The inverse of move_last_char: removes the space before a punctuation character
+    that appears space-separated from the preceding word anywhere in the sentence.
+    Teaches the tokenizer that punctuation can appear attached to the preceding
+    word, which is important for languages such as Vietnamese where the dataset
+    may always space-separate them.  The eligible punctuation set is determined
+    automatically from the training data via build_move_punct_set().
+
+split_mwt  (split_mwt_prob)
+    Randomly selects an MWT in a sentence and replaces it with the two
+    space-separated words it expands to (both labelled as ordinary word ends).
+    Teaches the tokenizer not to over-generate MWT labels when the constituent
+    words appear separately.  The eligible MWT set is determined from the
+    training data and the MWT expansion dictionary via build_known_mwt().
+
+augment_final_punct  (augment_final_punct_prob)
+    Replaces the sentence-final punctuation character with a typographic
+    variant (e.g. ASCII '?' <-> fullwidth '？').  Useful for datasets that use
+    only one form, so that the model generalises to the other.  Eligible pairs
+    are checked against the vocabulary via augment_vocab() to ensure the source
+    exists and the target is absent before activating the substitution.
+
+augment_mid_sent_punct  (augment_mid_punct_prob)
+    Replaces a mid-sentence punctuation character (currently comma) with a
+    typographic alternative (en dash U+2013 or em dash U+2014).  Intended for
+    languages whose training data contains no dashes, so that the model learns
+    to tokenize them correctly without retraining from scratch.  Unlike
+    augment_final_punct, the substitution also randomly varies the surrounding
+    whitespace, producing all four spacing styles (spaced both sides, attached
+    left, attached right, attached both sides) with equal probability, since
+    dashes appear in real text with all of these conventions.  Eligible pairs
+    are checked via augment_vocab(..., final=False).
+
+drop_last_char  (last_char_drop_prob)
+    Drops the final character of a training window with some probability,
+    relabelling the new final character as a sentence end.  Teaches the model
+    to handle documents that end without sentence-final punctuation.
+
+sent_drop  (sent_drop_prob)
+    Drops a suffix of the concatenated sentences in a training window.  Also
+    teaches the model to handle incomplete input.
+"""
+
 from bisect import bisect_right
 from collections import defaultdict
 from copy import copy

--- a/stanza/models/tokenization/utils.py
+++ b/stanza/models/tokenization/utils.py
@@ -13,7 +13,7 @@ from stanza.models.common.utils import ud_scores, harmonic_mean
 from stanza.models.common.doc import Document
 from stanza.utils.conll import CoNLL
 from stanza.models.common.doc import *
-from stanza.models.tokenization.data import SortedDataset
+from stanza.models.tokenization.data import SortedDataset, WHITESPACE_RE
 
 logger = logging.getLogger('stanza')
 paths = default_paths.get_default_paths()
@@ -247,10 +247,6 @@ def update_pred_regex(raw, pred):
 
     return pred
 
-# control characters not covered by \s, but still not part of normal text
-# for example, U+0097 was reported as being stuck on a token in this issue:
-# https://github.com/stanfordnlp/stanza/issues/1257
-SPACE_RE = re.compile(r'[\s\u0080-\u009f]')
 SPACE_SPLIT_RE = re.compile(r'( *[^ ]+)')
 
 def predict(trainer, data_generator, batch_size, max_seqlen, use_regex_tokens, num_workers):
@@ -480,7 +476,7 @@ def decode_predictions(vocab, mwt_dict, orig_text, all_raw, all_preds, no_ssplit
     oov_count = 0
     doc = []
 
-    text = SPACE_RE.sub(' ', orig_text) if orig_text is not None else None
+    text = WHITESPACE_RE.sub(' ', orig_text) if orig_text is not None else None
     char_offset = 0
 
     if vocab is not None:

--- a/stanza/models/tokenization/utils.py
+++ b/stanza/models/tokenization/utils.py
@@ -247,7 +247,10 @@ def update_pred_regex(raw, pred):
 
     return pred
 
-SPACE_RE = re.compile(r'\s')
+# control characters not covered by \s, but still not part of normal text
+# for example, U+0097 was reported as being stuck on a token in this issue:
+# https://github.com/stanfordnlp/stanza/issues/1257
+SPACE_RE = re.compile(r'[\s\u0080-\u009f]')
 SPACE_SPLIT_RE = re.compile(r'( *[^ ]+)')
 
 def predict(trainer, data_generator, batch_size, max_seqlen, use_regex_tokens, num_workers):

--- a/stanza/models/tokenizer.py
+++ b/stanza/models/tokenizer.py
@@ -75,6 +75,7 @@ def build_argparse():
     parser.add_argument('--punct_move_back_prob', type=float, default=0.02, help="Probability to move a comma in the sentence one over, removing the previous space, during training.  Idea is to teach the tokenizer that commas can appear next to words even in languages where the dataset doesn't allow it, such as Vietnamese")
     parser.add_argument('--split_mwt_prob', type=float, default=0.01, help="Probably to split an MWT into its component pieces and turn it into separate words")
     parser.add_argument('--augment_final_punct_prob', type=float, default=0.02, help="Probability to replace a ? with a ？ or other similar augmentations")
+    parser.add_argument('--augment_mid_punct_prob', type=float, default=0.02, help="Probability to replace a , with a – or other similar augmentations")
     parser.add_argument('--weight_decay', type=float, default=0.0, help="Weight decay")
     parser.add_argument('--max_seqlen', type=int, default=100, help="Maximum sequence length to consider at a time")
     parser.add_argument('--batch_size', type=int, default=32, help="Batch size to use")

--- a/stanza/models/tokenizer.py
+++ b/stanza/models/tokenizer.py
@@ -74,7 +74,7 @@ def build_argparse():
     parser.add_argument('--last_char_move_prob', type=float, default=0.02, help="Probability to move the sentence final punctuation of a sentence during training, uniformly at random.  Idea is to teach the tokenizer that a space separated sentence final punct still ends the sentence")
     parser.add_argument('--punct_move_back_prob', type=float, default=0.02, help="Probability to move a comma in the sentence one over, removing the previous space, during training.  Idea is to teach the tokenizer that commas can appear next to words even in languages where the dataset doesn't allow it, such as Vietnamese")
     parser.add_argument('--split_mwt_prob', type=float, default=0.01, help="Probably to split an MWT into its component pieces and turn it into separate words")
-    parser.add_argument('--augment_final_punct_prob', type=float, default=0.05, help="Probability to replace a ? with a ？ or other similar augmentations")
+    parser.add_argument('--augment_final_punct_prob', type=float, default=0.02, help="Probability to replace a ? with a ？ or other similar augmentations")
     parser.add_argument('--weight_decay', type=float, default=0.0, help="Weight decay")
     parser.add_argument('--max_seqlen', type=int, default=100, help="Maximum sequence length to consider at a time")
     parser.add_argument('--batch_size', type=int, default=32, help="Batch size to use")

--- a/stanza/tests/tokenization/test_spanish_tokenize.py
+++ b/stanza/tests/tokenization/test_spanish_tokenize.py
@@ -91,6 +91,22 @@ CASES = [
             ["Y", "felices", "no", "estaban", "…"],
         ],
     ),
+    SpanishTokenizeCase(
+        # Em and en dashes attached to words (no surrounding spaces) should be
+        # tokenized as their own tokens.  The model learns this via the
+        # comma->dash augmentation in data.py since neither GSD nor AnCora
+        # contains examples of these dashes.
+        text="[Daniel Alarcón]: Esto es Radio Ambulante—desde NPR.",
+        sentences=[
+            ["[", "Daniel", "Alarcón", "]", ":", "Esto", "es", "Radio", "Ambulante", "—", "desde", "NPR", "."],
+        ],
+    ),
+    SpanishTokenizeCase(
+        text="[Daniel Alarcón]: Esto es Radio Ambulante–desde NPR.",
+        sentences=[
+            ["[", "Daniel", "Alarcón", "]", ":", "Esto", "es", "Radio", "Ambulante", "–", "desde", "NPR", "."],
+        ],
+    ),
 ]
 
 

--- a/stanza/tests/tokenization/test_spanish_tokenize.py
+++ b/stanza/tests/tokenization/test_spanish_tokenize.py
@@ -13,6 +13,10 @@ Each test case is a SpanishTokenizeCase namedtuple:
 
 If `words` is None, it is assumed to equal `sentences` (no MWTs present).
 If `mwts` is None, it is assumed to be empty.
+
+Also tested is the reconstruction of the original text, assuring that
+unusual whitespace characters (see the GUARDED test) are kept
+as part of the final document.
 """
 
 import pytest
@@ -110,6 +114,20 @@ def _run(pipeline, case):
     return doc, resolved_words, resolved_mwts
 
 
+def _reconstruct(sentence):
+    """
+    Reconstruct the original text for one sentence by concatenating each
+    token's text with its trailing spaces_after string.  The first token's
+    spaces_before is prepended so that any leading whitespace or control
+    characters are accounted for as well.
+    """
+    parts = [sentence.tokens[0].spaces_before or ""]
+    for token in sentence.tokens:
+        parts.append(token.text)
+        parts.append(token.spaces_after or "")
+    return "".join(parts)
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -134,6 +152,25 @@ class TestSpanishTokenize:
             assert actual == expected_tokens, (
                 f"Sentence {sent_idx}: token mismatch"
             )
+
+    def test_text_reconstruction(self, es_tokenize_pipeline, case):
+        """
+        Concatenating token texts and spaces_after (with spaces_before on the
+        first token) must reproduce the original text exactly, sentence by
+        sentence.  This ensures that whitespace and control characters such as
+        U+0097 are preserved in the document structure even when they are not
+        part of any token.
+        """
+        doc, _, _ = _run(es_tokenize_pipeline, case)
+        # Reconstruct the full document text from all sentences and compare
+        # against the original.  We join sentences with whatever whitespace
+        # separated them (spaces_after of the last token of each sentence
+        # already captures the inter-sentence gap, so simple concatenation
+        # suffices).
+        reconstructed = "".join(_reconstruct(s) for s in doc.sentences)
+        assert reconstructed == case.text, (
+            f"Reconstruction mismatch:\n  original:      {case.text!r}\n  reconstructed: {reconstructed!r}"
+        )
 
     def test_word_texts(self, es_tokenize_pipeline, case):
         """Word texts (after MWT expansion) match for every sentence."""

--- a/stanza/tests/tokenization/test_spanish_tokenize.py
+++ b/stanza/tests/tokenization/test_spanish_tokenize.py
@@ -84,6 +84,13 @@ CASES = [
             ["Ronald", "ya", "no", "pudo", "seguir", "."],
         ],
     ),
+    # test spaces_before
+    SpanishTokenizeCase(
+        text="     Y felices no estaban…",
+        sentences=[
+            ["Y", "felices", "no", "estaban", "…"],
+        ],
+    ),
 ]
 
 

--- a/stanza/tests/tokenization/test_spanish_tokenize.py
+++ b/stanza/tests/tokenization/test_spanish_tokenize.py
@@ -66,6 +66,20 @@ CASES = [
             ["Y", "felices", "no", "estaban", "…"],
         ],
     ),
+    SpanishTokenizeCase(
+        # Tab character should be split
+        text="Ronald\tya no pudo seguir.",
+        sentences=[
+            ["Ronald", "ya", "no", "pudo", "seguir", "."],
+        ],
+    ),
+    SpanishTokenizeCase(
+        # U+0097 (END OF GUARDED AREA) between words should not attach to a token
+        text="Ronald\u0097ya no pudo seguir.",
+        sentences=[
+            ["Ronald", "ya", "no", "pudo", "seguir", "."],
+        ],
+    ),
 ]
 
 

--- a/stanza/tests/tokenization/test_spanish_tokenize.py
+++ b/stanza/tests/tokenization/test_spanish_tokenize.py
@@ -1,0 +1,144 @@
+"""
+Tests for Spanish tokenization, including MWT handling and edge cases
+that were previously reported as issues.
+
+Each test case is a SpanishTokenizeCase namedtuple:
+  text:            the raw input string
+  sentences:       list of sentences; each sentence is a list of token strings
+                   (for MWT tokens, use the *surface* form, e.g. "ocultándolo")
+  words:           list of sentences; each sentence is a list of word strings
+                   (MWT tokens are expanded, e.g. "ocultando", "lo")
+  mwts:            list of (surface_token, [expanded_words]) for every MWT
+                   across the whole document, in order
+
+If `words` is None, it is assumed to equal `sentences` (no MWTs present).
+If `mwts` is None, it is assumed to be empty.
+"""
+
+import pytest
+from collections import namedtuple
+
+import stanza
+from stanza.tests import TEST_MODELS_DIR
+
+pytestmark = pytest.mark.pipeline
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+SpanishTokenizeCase = namedtuple(
+    "SpanishTokenizeCase",
+    ["text", "sentences", "words", "mwts"],
+    defaults=[None, None],        # words and mwts default to None
+)
+
+CASES = [
+    SpanishTokenizeCase(
+        text="[Daniel Alarcón]: Esto es Radio Ambulante, desde NPR. Soy Daniel Alarcón.",
+        sentences=[
+            ["[", "Daniel", "Alarcón", "]", ":", "Esto", "es", "Radio", "Ambulante", ",", "desde", "NPR", "."],
+            ["Soy", "Daniel", "Alarcón", "."],
+        ],
+    ),
+    SpanishTokenizeCase(
+        text="Ronald ya no pudo seguir ocultándolo… se lo mostró a su mamá.",
+        sentences=[
+            ["Ronald", "ya", "no", "pudo", "seguir", "ocultándolo", "…", "se", "lo", "mostró", "a", "su", "mamá", "."],
+        ],
+        words=[
+            ["Ronald", "ya", "no", "pudo", "seguir", "ocultando", "lo", "…", "se", "lo", "mostró", "a", "su", "mamá", "."],
+        ],
+        mwts=[
+            ("ocultándolo", ["ocultando", "lo"]),
+        ],
+    ),
+    SpanishTokenizeCase(
+        text="Y felices no estaban",
+        sentences=[
+            ["Y", "felices", "no", "estaban"],
+        ],
+    ),
+    SpanishTokenizeCase(
+        text="Y felices no estaban…",
+        sentences=[
+            ["Y", "felices", "no", "estaban", "…"],
+        ],
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def es_tokenize_pipeline():
+    """Tokenize-only Spanish pipeline (no MWT, pos, etc.)."""
+    return stanza.Pipeline(
+        "es",
+        dir=TEST_MODELS_DIR,
+        download_method=None,
+        processors="tokenize",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(pipeline, case):
+    """Return (doc, resolved_words, resolved_mwts) for a test case."""
+    doc = pipeline(case.text)
+    resolved_words = case.words if case.words is not None else case.sentences
+    resolved_mwts  = case.mwts  if case.mwts  is not None else []
+    return doc, resolved_words, resolved_mwts
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("case", CASES, ids=[c.text[:40] for c in CASES])
+class TestSpanishTokenize:
+
+    def test_sentence_count(self, es_tokenize_pipeline, case):
+        doc, _, _ = _run(es_tokenize_pipeline, case)
+        assert len(doc.sentences) == len(case.sentences), (
+            f"Expected {len(case.sentences)} sentence(s), "
+            f"got {len(doc.sentences)}: {[s.text for s in doc.sentences]}"
+        )
+
+    def test_token_texts(self, es_tokenize_pipeline, case):
+        """Surface token texts match for every sentence."""
+        doc, _, _ = _run(es_tokenize_pipeline, case)
+        for sent_idx, (sentence, expected_tokens) in enumerate(
+            zip(doc.sentences, case.sentences)
+        ):
+            actual = [token.text for token in sentence.tokens]
+            assert actual == expected_tokens, (
+                f"Sentence {sent_idx}: token mismatch"
+            )
+
+    def test_word_texts(self, es_tokenize_pipeline, case):
+        """Word texts (after MWT expansion) match for every sentence."""
+        doc, resolved_words, _ = _run(es_tokenize_pipeline, case)
+        for sent_idx, (sentence, expected_words) in enumerate(
+            zip(doc.sentences, resolved_words)
+        ):
+            actual = [word.text for word in sentence.words]
+            assert actual == expected_words, (
+                f"Sentence {sent_idx}: word mismatch"
+            )
+
+    def test_mwts(self, es_tokenize_pipeline, case):
+        """MWT tokens expand to the expected word sequences."""
+        doc, _, resolved_mwts = _run(es_tokenize_pipeline, case)
+        actual_mwts = [
+            (token.text, [w.text for w in token.words])
+            for sentence in doc.sentences
+            for token in sentence.tokens
+            if len(token.words) > 1
+        ]
+        assert actual_mwts == resolved_mwts

--- a/stanza/tests/tokenization/test_tokenize_data_augmentation.py
+++ b/stanza/tests/tokenization/test_tokenize_data_augmentation.py
@@ -1,0 +1,370 @@
+"""
+Tests for the augmentation and pre-counting functions in tokenization/data.py
+
+Stochastic augmentation methods are tested by running many independent trials
+and asserting that the expected outcome occurs at least once (or always, when
+the property must hold for every non-None result).  With 200 trials the
+probability of any one of the four spacing styles being missed is below
+1 in 10^24, which is acceptable.
+
+The other augmentation probs all default to 0.0 in FAKE_PROPERTIES, so only
+the augmentation under test is active in each test.
+
+Label encoding reminder (see data.py module docstring):
+  0  continuation      – character is inside a token
+  1  word end          – last character of a token
+  2  sentence end      – last character of the final token in a sentence
+  3  MWT end           – last character of a multi-word token
+  4  MWT + sentence end
+"""
+
+import pytest
+import random
+import os
+import tempfile
+
+from stanza.tests import TEST_WORKING_DIR
+from stanza.models.tokenization.data import (
+    DataLoader,
+    MID_SENT_AUGMENT_PAIRS,
+    build_move_punct_set,
+    build_known_mwt,
+)
+from stanza.models.tokenization.vocab import Vocab
+
+pytestmark = [pytest.mark.travis, pytest.mark.pipeline]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+FAKE_PROPERTIES = {
+    "lang": "en",
+    'feat_funcs': ("space_before", "capitalized"),
+    'max_seqlen': 300,
+    'use_dictionary': False,
+    # All augmentation probs default to 0.0; individual tests set the one
+    # they are exercising to 1.0 via extra_args so that only that augmentation
+    # is active, preventing interference between augmentations.
+}
+
+# "Hello, world."
+#  H e l l o ,   w o r l d  .
+#  0 0 0 0 1 1 0 0 0 0 0 1  2
+HELLO_TEXT   = "Hello, world."
+HELLO_LABELS = "0000110000012"
+
+# "Hello , world."  (space before comma — eligible for move_punct_back)
+#  H e l l o   ,   w o r l d  .
+#  0 0 0 0 1 0 1 0 0 0 0 0 1  2
+SPACED_COMMA_TEXT   = "Hello , world."
+SPACED_COMMA_LABELS = "00001010000012"
+
+
+def write_and_load(raw_text, labels, extra_args=None):
+    """Write text+labels to temp files and return a DataLoader."""
+    args = dict(FAKE_PROPERTIES)
+    if extra_args:
+        args.update(extra_args)
+    with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+        txt_path = os.path.join(test_dir, "text.txt")
+        lbl_path = os.path.join(test_dir, "labels.txt")
+        with open(txt_path, "w", encoding="utf-8") as f:
+            f.write(raw_text)
+        with open(lbl_path, "w", encoding="utf-8") as f:
+            f.write(labels)
+        data = DataLoader(args=args, input_files={'txt': txt_path, 'label': lbl_path})
+    return data
+
+
+def run_trials(fn, n=200):
+    """
+    Call fn() n times, collecting all non-None results.
+    Returns the list of results.
+    """
+    return [r for _ in range(n) if (r := fn()) is not None]
+
+
+# ---------------------------------------------------------------------------
+# augment_vocab
+# ---------------------------------------------------------------------------
+
+class TestAugmentVocab:
+
+    def _make(self, sentences):
+        vocab = Vocab(sentences, "en")
+        return vocab, sentences
+
+    def test_final_existing_absent_replacement(self):
+        """source present at sentence end, target absent -> returns True and adds to vocab."""
+        data = [[('H', 0), ('i', 1), ('?', 2)]]
+        vocab, data = self._make(data)
+        assert '?' in vocab
+        assert '！' not in vocab
+        assert DataLoader.augment_vocab(vocab, data, '?', '！', final=True) is True
+        assert '！' in vocab
+
+    def test_final_missing_source(self):
+        """source absent from vocab -> returns False."""
+        data = [[('H', 0), ('i', 1), ('?', 2)]]
+        vocab, data = self._make(data)
+        assert DataLoader.augment_vocab(vocab, data, '！', '?', final=True) is False
+
+    def test_final_replacement_already_present(self):
+        """target already in data -> returns False."""
+        data = [[('H', 0), ('i', 1), ('?', 2)],
+                [('B', 0), ('y', 1), ('！', 2)]]
+        vocab, data = self._make(data)
+        assert DataLoader.augment_vocab(vocab, data, '?', '！', final=True) is False
+
+    def test_final_source_not_at_end(self):
+        """source present mid-sentence only, never finally -> returns False."""
+        data = [[('H',0),('i',0),(',',1),(' ',0),('y',0),('o',0),('u',1),('.',2)]]
+        vocab, data = self._make(data)
+        assert DataLoader.augment_vocab(vocab, data, ',', '\u2013', final=True) is False
+
+    def test_not_final_finds_mid_sentence(self):
+        """final=False counts mid-sentence occurrences."""
+        data = [[('H',0),('i',0),(',',1),(' ',0),('y',0),('o',0),('u',1),('.',2)]]
+        vocab, data = self._make(data)
+        assert DataLoader.augment_vocab(vocab, data, ',', '\u2013', final=False) is True
+        assert '\u2013' in vocab
+
+    def test_not_final_includes_all_positions(self):
+        """final=False counts all positions including the final character."""
+        # '.' appears only as the final character; final=False still finds it
+        data = [[('H', 0), ('i', 1), ('.', 2)]]
+        vocab, data = self._make(data)
+        assert DataLoader.augment_vocab(vocab, data, '.', '\u2014', final=False) is True
+
+
+# ---------------------------------------------------------------------------
+# build_move_punct_set
+# ---------------------------------------------------------------------------
+
+class TestBuildMovePunctSet:
+    def test_comma_eligible_when_space_separated(self):
+        """A space-separated comma following a non-digit word should be eligible."""
+        chunk = [('H',0),('e',0),('l',0),('l',0),('o',1),(' ',0),(',',1),(' ',0),
+                 ('w',0),('o',0),('r',0),('l',0),('d',1),(' ',0),('.',2)]
+        result = build_move_punct_set([chunk], move_back_prob=0.02)
+        assert ',' in result
+
+    def test_comma_ineligible_when_already_attached(self):
+        """A comma already attached to the preceding word should be removed from the set."""
+        chunk = [('H',0),('e',0),('l',0),('l',0),('o',0),(',',1),(' ',0),
+                 ('w',0),('o',0),('r',0),('l',0),('d',1),('.',2)]
+        result = build_move_punct_set([chunk], move_back_prob=0.02)
+        assert ',' not in result
+
+# ---------------------------------------------------------------------------
+# build_known_mwt
+# ---------------------------------------------------------------------------
+
+class TestBuildKnownMwt:
+
+    def test_finds_known_mwt(self):
+        """An MWT present in mwt_expansions labelled 3 should be found."""
+        chunk = [('a',0),('l',3),(' ',0),('B',0),('a',0),('n',0),('c',0),('o',2)]
+        result = build_known_mwt([chunk], {"al": ["a", "el"]})
+        assert "al" in result
+
+    def test_ignores_mwt_not_in_expansions(self):
+        """An MWT label with no expansion entry should be ignored."""
+        chunk = [('d',0),('e',0),('l',3),(' ',0),('B',0),('a',0),('n',0),('c',0),('o',2)]
+        result = build_known_mwt([chunk], {})
+        assert "del" not in result
+
+    def test_ignores_three_way_mwt(self):
+        """MWTs expanding to more than 2 words are not supported and should be ignored."""
+        chunk = [('x',0),('y',0),('z',3),(' ',0),('f',0),('o',0),('o',2)]
+        result = build_known_mwt([chunk], {"xyz": ["x", "y", "z"]})
+        assert "xyz" not in result
+
+
+# ---------------------------------------------------------------------------
+# build_mid_sent_augmentations
+# ---------------------------------------------------------------------------
+
+class TestBuildMidSentAugmentations:
+
+    def test_comma_to_dash_activated(self):
+        """Comma present mid-sentence, en dash absent -> substitution activated."""
+        data = [[('H',0),('e',0),('l',0),('l',0),('o',0),(',',1),(' ',0),
+                 ('w',0),('o',0),('r',0),('l',0),('d',1),('.',2)]]
+        vocab = Vocab(data, "en")
+        result = DataLoader.build_mid_sent_augmentations(vocab, data, MID_SENT_AUGMENT_PAIRS)
+        assert ',' in result
+        assert '\u2013' in result[','] or '\u2014' in result[',']
+
+    def test_dash_present_blocks_activation(self):
+        """En dash already in data -> comma->en dash substitution should not activate,
+        even when commas are also present."""
+        data = [[('H',0),('e',0),('l',0),('l',0),('o',0),(',',1),(' ',0),
+                 ('w',0),('o',0),('r',0),('l',0),('d',1),(' ',0),('\u2013',1),
+                 ('f',0),('o',0),('o',1),('.',2)]]
+        vocab = Vocab(data, "en")
+        result = DataLoader.build_mid_sent_augmentations(vocab, data, [(',', '\u2013')])
+        assert '\u2013' not in result.get(',', [])
+
+    def test_empty_when_no_comma(self):
+        """No comma in data -> nothing to augment."""
+        data = [[('H',0),('i',1),('.',2)]]
+        vocab = Vocab(data, "en")
+        result = DataLoader.build_mid_sent_augmentations(vocab, data, MID_SENT_AUGMENT_PAIRS)
+        assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# augment_final_punct
+# ---------------------------------------------------------------------------
+
+class TestAugmentFinalPunct:
+
+    def _loader(self):
+        # "Hi?" -> H i ?  labels 0 1 2
+        # augment_final_punct_prob=1.0 activates the vocab check in __init__;
+        # all other augmentation probs remain at 0.0
+        return write_and_load("Hi?", "012", extra_args={'augment_final_punct_prob': 1.0})
+
+    def test_replaces_final_punct(self):
+        """augment_final_punct should always swap '?' for a fullwidth variant."""
+        loader = self._loader()
+        sentence = loader.sentences[0][0]
+        results = run_trials(lambda: loader.augment_final_punct(sentence))
+        assert len(results) > 0, "augment_final_punct never returned a result"
+        fullwidth = {'？', '︖', '﹖', '⁇'}
+        for result in results:
+            assert result[0][3][-1] in fullwidth, (
+                f"unexpected final character: {result[0][3][-1]!r}"
+            )
+
+    def test_no_eligible_punct_returns_none(self):
+        """augment_final_punct returns None when the augmentations dict is empty."""
+        loader = write_and_load("Hi.", "012", extra_args={'augment_final_punct_prob': 1.0})
+        loader.augmentations = {}
+        sentence = loader.sentences[0][0]
+        results = run_trials(lambda: loader.augment_final_punct(sentence))
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# augment_mid_sent_punct
+# ---------------------------------------------------------------------------
+
+class TestAugmentMidSentPunct:
+
+    def _loader(self):
+        # augment_mid_punct_prob=1.0 activates vocab check; other probs at 0.0
+        loader = write_and_load(HELLO_TEXT, HELLO_LABELS,
+                                extra_args={'augment_mid_punct_prob': 1.0})
+        loader.mid_sent_augmentations = DataLoader.build_mid_sent_augmentations(
+            loader.vocab, loader.data, MID_SENT_AUGMENT_PAIRS)
+        return loader
+
+    def test_comma_replaced_by_dash(self):
+        """The comma should always be replaced by a dash (never left as a comma)."""
+        loader = self._loader()
+        sentence = loader.sentences[0][0]
+        results = run_trials(lambda: loader.augment_mid_sent_punct(sentence))
+        assert len(results) > 0, "augment_mid_sent_punct never returned a result"
+        for result in results:
+            chars = result[0][3]
+            assert ',' not in chars
+            assert '\u2013' in chars or '\u2014' in chars
+
+    def test_dash_is_own_token(self):
+        """The replacement dash should always have a non-zero label (own token)."""
+        loader = self._loader()
+        sentence = loader.sentences[0][0]
+        results = run_trials(lambda: loader.augment_mid_sent_punct(sentence))
+        assert len(results) > 0
+        for result in results:
+            new_sentence = result[0]
+            for char, label in zip(new_sentence[3], new_sentence[1]):
+                if char in ('\u2013', '\u2014'):
+                    assert label != 0, "dash should not have continuation label"
+
+    def test_comma_in_number_not_replaced(self):
+        """A comma with label 0 (inside a number token) should never be replaced."""
+        # "1,000." -> 1 , 0 0 0 .  labels  0 0 0 0 1 2
+        loader = write_and_load("1,000.", "000012",
+                                extra_args={'augment_mid_punct_prob': 1.0})
+        loader.mid_sent_augmentations = DataLoader.build_mid_sent_augmentations(
+            loader.vocab, loader.data, MID_SENT_AUGMENT_PAIRS)
+        sentence = loader.sentences[0][0]
+        results = run_trials(lambda: loader.augment_mid_sent_punct(sentence))
+        assert len(results) == 0, "should not augment a comma inside a number"
+
+    def test_no_mid_sent_augmentations_returns_none(self):
+        """If mid_sent_augmentations is empty, the method always returns None."""
+        loader = write_and_load(HELLO_TEXT, HELLO_LABELS)
+        loader.mid_sent_augmentations = {}
+        sentence = loader.sentences[0][0]
+        results = run_trials(lambda: loader.augment_mid_sent_punct(sentence))
+        assert len(results) == 0
+
+    def test_all_spacing_styles_reachable(self):
+        """All four spacing styles (spaced both, left, right, neither) must be reachable."""
+        loader = self._loader()
+        sentence = loader.sentences[0][0]
+        seen_styles = set()
+        for _ in range(200):
+            result = loader.augment_mid_sent_punct(sentence)
+            if result is None:
+                continue
+            chars = result[0][3]
+            try:
+                dash_idx = next(i for i, c in enumerate(chars) if c in ('\u2013', '\u2014'))
+            except StopIteration:
+                continue
+            space_before = dash_idx > 0 and chars[dash_idx - 1] == ' '
+            space_after  = dash_idx < len(chars) - 1 and chars[dash_idx + 1] == ' '
+            seen_styles.add((space_before, space_after))
+        assert len(seen_styles) == 4, f"Only saw spacing styles: {seen_styles}"
+
+
+# ---------------------------------------------------------------------------
+# move_punct_back
+# ---------------------------------------------------------------------------
+
+class TestMovePunctBack:
+
+    def test_moves_space_separated_comma(self):
+        """A space-separated comma should always be moved to attach to the preceding word."""
+        loader = write_and_load(SPACED_COMMA_TEXT, SPACED_COMMA_LABELS,
+                                extra_args={'punct_move_back_prob': 1.0})
+        loader.move_punct = build_move_punct_set(loader.data, move_back_prob=0.02)
+        sentence = loader.sentences[0][0]
+        results = run_trials(lambda: loader.move_punct_back(sentence), n=1)
+        assert len(results) > 0
+        for result in results:
+            chars = result[0][3]
+            comma_idx = chars.index(',')
+            assert chars[comma_idx - 1] != ' ', "comma should be attached to preceding word"
+
+    def test_does_not_move_attached_comma(self):
+        """A comma already attached to its word should never trigger move_punct_back."""
+        loader = write_and_load(HELLO_TEXT, HELLO_LABELS,
+                                extra_args={'punct_move_back_prob': 1.0})
+        loader.move_punct = build_move_punct_set(loader.data, move_back_prob=0.02)
+        sentence = loader.sentences[0][0]
+        results = run_trials(lambda: loader.move_punct_back(sentence))
+        assert len(results) == 0
+
+    def test_does_not_move_comma_after_digit(self):
+        """
+        '1 ,' should not be moved — the digit guard in move_punct_back prevents it.
+
+        "1 , 000."  — comma is space-separated so build_move_punct_set includes it,
+        but move_punct_back should skip it because idx-2 is a digit
+        """
+        text   = "1 , 000."
+        labels = "01010012"
+        loader = write_and_load(text, labels, extra_args={'punct_move_back_prob': 1.0})
+        loader.move_punct = build_move_punct_set(loader.data, move_back_prob=0.02)
+        sentence = loader.sentences[0][0]
+        results = run_trials(lambda: loader.move_punct_back(sentence))
+        assert len(results) == 0
+


### PR DESCRIPTION
Test the error sentences reported in https://github.com/stanfordnlp/stanza/issues/1257

they should be fixed now and we do not want them to drift as time goes by

Furthermore, update the whitespace splitting RE to take into account control characters as well, eliminating a bug where certain control characters would be treated as content characters

developed in collaboration with Claude (Anthropic)