### PR TITLE
Add a fixed-expression dictionary input to the POS tagger, helping it learn ExtPos. Fixes #1575

### DIFF
--- a/stanza/models/pos/data.py
+++ b/stanza/models/pos/data.py
@@ -12,14 +12,14 @@ from stanza.models.common.bert_embedding import filter_data, needs_length_filter
 from stanza.models.common.data import map_to_ids, get_long_tensor, get_float_tensor, sort_all
 from stanza.models.common.utils import DEFAULT_WORD_CUTOFF, simplify_punct
 from stanza.models.common.vocab import PAD_ID, VOCAB_PREFIX, CharVocab
-from stanza.models.pos.vocab import WordVocab, XPOSVocab, FeatureVocab, MultiVocab
+from stanza.models.pos.vocab import WordVocab, XPOSVocab, FeatureVocab, FixedExpressionVocab, MultiVocab, FIXED_NO_ID
 from stanza.models.pos.xpos_vocab_factory import xpos_vocab_factory
 from stanza.models.common.doc import *
 
 logger = logging.getLogger('stanza')
 
-DataSample = namedtuple("DataSample", "word char upos xpos feats pretrain text")
-DataBatch = namedtuple("DataBatch", "words words_mask wordchars wordchars_mask upos xpos ufeats pretrained orig_idx word_orig_idx lens word_lens text idx")
+DataSample = namedtuple("DataSample", "word char upos xpos feats pretrain text fixed")
+DataBatch = namedtuple("DataBatch", "words words_mask wordchars wordchars_mask upos xpos ufeats pretrained fixed_flags orig_idx word_orig_idx lens word_lens text idx")
 
 class Dataset:
     def __init__(self, doc, args, pretrain, vocab=None, evaluation=False, sort_during_eval=False, bert_tokenizer=None, **kwargs):
@@ -79,13 +79,24 @@ class Dataset:
                             'upos': uposvocab,
                             'xpos': xposvocab,
                             'feats': featsvocab})
+        if args.get('use_fixed_expressions', False):
+            fixedvocab = Dataset.build_fixed_expressions(
+                docs,
+                min_count=args.get('fixed_expression_min_count', 1),
+                extra_file=args.get('fixed_expression_file', None),
+            )
+            logger.info("Built fixed expression vocab with %d unique expressions (max_len=%d)",
+                        len(fixedvocab), fixedvocab.max_len)
+            vocab['fixed'] = fixedvocab
         return vocab
 
     def preprocess(self, data, vocab, pretrain_vocab, args):
+        has_fixed = 'fixed' in vocab
         processed = []
         for sent in data:
+            words = [w[0] for w in sent]
             processed_sent = DataSample(
-                word = [vocab['word'].map([w[0] for w in sent])],
+                word = [vocab['word'].map(words)],
                 char = [[vocab['char'].map([x for x in w[0]]) for w in sent]],
                 upos = [vocab['upos'].map([w[1] for w in sent])],
                 xpos = [vocab['xpos'].map([w[2] for w in sent])],
@@ -93,7 +104,8 @@ class Dataset:
                 pretrain = ([pretrain_vocab.map([w[0].lower() for w in sent])]
                             if pretrain_vocab is not None
                            else [[PAD_ID] * len(sent)]),
-                text = [w[0] for w in sent]
+                text = words,
+                fixed = [vocab['fixed'].map(words)] if has_fixed else None,
             )
             processed.append(processed_sent)
 
@@ -176,6 +188,7 @@ class Dataset:
         xpos = torch.tensor(sample.xpos[0]) if self.has_xpos else None
         ufeats = torch.tensor(sample.feats[0]) if self.has_feats else None
         pretrained = torch.tensor(sample.pretrain[0])
+        fixed_flags = torch.tensor(sample.fixed[0]) if sample.fixed is not None else None
 
         # and deal with char & raw_text
         char = sample.char[0]
@@ -205,13 +218,15 @@ class Dataset:
                 if ufeats is not None:
                     ufeats[mask, ...] = PAD_ID
                 pretrained[mask] = PAD_ID
+                if fixed_flags is not None:
+                    fixed_flags[mask] = PAD_ID
                 char = char[:mask] + char[mask+1:]
                 raw_text = raw_text[:mask] + raw_text[mask+1:]
 
         # get each character from the input sentnece
         # chars = [w for sent in char for w in sent]
 
-        return DataSample(words, char, upos, xpos, ufeats, pretrained, raw_text), key
+        return DataSample(words, char, upos, xpos, ufeats, pretrained, raw_text, fixed_flags), key
 
     def __iter__(self):
         for i in range(self.__len__()):
@@ -234,7 +249,7 @@ class Dataset:
     def __collate_fn(data):
         """Function used by DataLoader to pack data"""
         (data, idx) = zip(*data)
-        (words, wordchars, upos, xpos, ufeats, pretrained, text) = zip(*data)
+        (words, wordchars, upos, xpos, ufeats, pretrained, text, fixed_flags) = zip(*data)
 
         # collate_fn is given a list of length batch size
         batch_size = len(data)
@@ -242,8 +257,8 @@ class Dataset:
         # sort sentences by lens for easy RNN operations
         lens = [torch.sum(x != PAD_ID) for x in words]
         (words, wordchars, upos, xpos,
-         ufeats, pretrained, text), orig_idx = sort_all((words, wordchars, upos, xpos,
-                                                         ufeats, pretrained, text), lens)
+         ufeats, pretrained, text, fixed_flags), orig_idx = sort_all((words, wordchars, upos, xpos,
+                                                                       ufeats, pretrained, text, fixed_flags), lens)
         lens = [torch.sum(x != PAD_ID) for x in words] # we need to reinterpret lengths for the RNN
 
         # combine all words into one large list, and sort for easy charRNN ops
@@ -267,6 +282,10 @@ class Dataset:
         else:
             ufeats = None
         pretrained = pad_sequence(pretrained, True, PAD_ID)
+        if None not in fixed_flags:
+            fixed_flags = pad_sequence(fixed_flags, True, PAD_ID)
+        else:
+            fixed_flags = None
         wordchars = get_long_tensor(wordchars, len(word_lens))
 
         # and finally create masks for the padding indices
@@ -274,7 +293,7 @@ class Dataset:
         wordchars_mask = torch.eq(wordchars, PAD_ID)
 
         return DataBatch(words, words_mask, wordchars, wordchars_mask, upos, xpos, ufeats,
-                         pretrained, orig_idx, word_orig_idx, lens, word_lens, text, idx)
+                         pretrained, fixed_flags, orig_idx, word_orig_idx, lens, word_lens, text, idx)
 
     @staticmethod
     def load_doc(doc):
@@ -282,6 +301,90 @@ class Dataset:
         data = Dataset.resolve_none(data)
         data = simplify_punct(data)
         return data
+
+    @staticmethod
+    def load_doc_with_deprel(doc):
+        """Like :meth:`load_doc`, but also returns each word's ID, head, and deprel.
+
+        Used to extract the fixed-expression dictionary; does not affect the
+        regular forward / training data path which still goes through
+        :meth:`load_doc`.
+        """
+        data = doc.get([TEXT, UPOS, XPOS, FEATS, ID, HEAD, DEPREL], as_sentences=True)
+        return data
+
+    @staticmethod
+    def build_fixed_expressions(docs, lowercase=True, min_count=1, extra_file=None):
+        """Scan training documents for fixed multi-word expressions.
+
+        For each token with ``deprel='fixed'``, collect the n-gram formed by
+        its head plus all fixed children (in surface order). The result is
+        deduplicated, filtered by ``min_count``, and optionally unioned with
+        an external newline-separated file of whitespace-tokenized expressions.
+        """
+        from collections import Counter
+
+        counter = Counter()
+        for doc in docs:
+            sentences = Dataset.load_doc_with_deprel(doc)
+            for sent in sentences:
+                # Build an id -> (text, position) index, skipping MWT range rows
+                # (whose ID is a tuple) and empty nodes (whose ID is a tuple).
+                id_to_pos = {}
+                texts = []
+                for pos, w in enumerate(sent):
+                    wid = w[4]
+                    if not isinstance(wid, int):
+                        continue
+                    id_to_pos[wid] = pos
+                    texts.append((pos, w[0]))
+                # Group fixed children by head id.
+                groups = {}
+                for w in sent:
+                    text, _, _, _, wid, head, deprel = w
+                    if not isinstance(wid, int):
+                        continue
+                    if deprel != 'fixed':
+                        continue
+                    if not isinstance(head, int) or head <= 0:
+                        continue
+                    groups.setdefault(head, []).append(wid)
+                for head_id, child_ids in groups.items():
+                    if head_id not in id_to_pos:
+                        continue
+                    ordered_ids = [head_id] + sorted(child_ids)
+                    try:
+                        words = [sent[id_to_pos[i]][0] for i in ordered_ids]
+                    except KeyError:
+                        continue
+                    if any(w is None for w in words):
+                        continue
+                    if lowercase:
+                        ngram = tuple(w.lower() for w in words)
+                    else:
+                        ngram = tuple(words)
+                    counter[ngram] += 1
+
+        expressions = [ng for ng, c in counter.items() if c >= min_count]
+        fixedvocab = FixedExpressionVocab(expressions, lowercase=lowercase)
+
+        if extra_file:
+            extra_added = 0
+            with open(extra_file, 'r', encoding='utf-8') as fin:
+                for line in fin:
+                    line = line.strip()
+                    if not line or line.startswith('#'):
+                        continue
+                    tokens = line.split()
+                    if len(tokens) < 2:
+                        continue
+                    before = len(fixedvocab)
+                    fixedvocab.add(tokens)
+                    if len(fixedvocab) > before:
+                        extra_added += 1
+            logger.info("Added %d new fixed expressions from %s", extra_added, extra_file)
+
+        return fixedvocab
 
     @staticmethod
     def resolve_none(data):

--- a/stanza/models/pos/model.py
+++ b/stanza/models/pos/model.py
@@ -13,9 +13,10 @@ from stanza.models.common.foundation_cache import load_bert, load_charlm
 from stanza.models.common.hlstm import HighwayLSTM
 from stanza.models.common.dropout import WordDropout
 from stanza.models.common.utils import attach_bert_model
-from stanza.models.common.vocab import CompositeVocab
+from stanza.models.common.vocab import CompositeVocab, PAD_ID
 from stanza.models.common.char_model import CharacterModel
 from stanza.models.common import utils
+from stanza.models.pos.vocab import FIXED_NUM_IDS
 
 logger = logging.getLogger('stanza')
 
@@ -86,7 +87,15 @@ class Tagger(nn.Module):
             self.add_unsaved_module('pretrained_emb', nn.Embedding.from_pretrained(emb_matrix, freeze=True))
             self.trans_pretrained = nn.Linear(emb_matrix.shape[1], self.args['transformed_dim'], bias=False)
             input_size += self.args['transformed_dim']
-        
+
+        # Optional embedding for the "begins a known fixed multi-word expression"
+        # binary input feature.  Only attached when both the trained-with vocab
+        # carries a 'fixed' entry and the configured embedding dim is positive.
+        self.fixed_emb = None
+        if 'fixed' in vocab and self.args.get('fixed_expression_emb_dim', 0) > 0:
+            self.fixed_emb = nn.Embedding(FIXED_NUM_IDS, self.args['fixed_expression_emb_dim'], padding_idx=PAD_ID)
+            input_size += self.args['fixed_expression_emb_dim']
+
         # recurrent layers
         self.taggerlstm = HighwayLSTM(input_size, self.args['hidden_dim'], self.args['num_layers'], batch_first=True, bidirectional=True, dropout=self.args['dropout'], rec_dropout=self.args['rec_dropout'], highway_func=torch.tanh)
         self.drop_replacement = nn.Parameter(torch.randn(input_size) / np.sqrt(input_size))
@@ -138,8 +147,8 @@ class Tagger(nn.Module):
     def log_norms(self):
         utils.log_norms(self)
 
-    def forward(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, word_orig_idx, sentlens, wordlens, text):
-        
+    def forward(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, word_orig_idx, sentlens, wordlens, text, fixed_flags=None):
+
         def pack(x):
             return pack_padded_sequence(x, sentlens, batch_first=True)
 
@@ -154,6 +163,11 @@ class Tagger(nn.Module):
             pretrained_emb = self.trans_pretrained(pretrained_emb)
             pretrained_emb = pack(pretrained_emb)
             inputs += [pretrained_emb]
+
+        if self.fixed_emb is not None and fixed_flags is not None:
+            fixed_emb = self.fixed_emb(fixed_flags)
+            fixed_emb = pack(fixed_emb)
+            inputs += [fixed_emb]
 
         def pad(x):
             return pad_packed_sequence(PackedSequence(x, inputs[0].batch_sizes), batch_first=True)[0]

--- a/stanza/models/pos/trainer.py
+++ b/stanza/models/pos/trainer.py
@@ -18,12 +18,12 @@ logger = logging.getLogger('stanza')
 
 def unpack_batch(batch, device):
     """ Unpack a batch from the data loader. """
-    inputs = [b.to(device) if b is not None else None for b in batch[:8]]
-    orig_idx = batch[8]
-    word_orig_idx = batch[9]
-    sentlens = batch[10]
-    wordlens = batch[11]
-    text = batch[12]
+    inputs = [b.to(device) if b is not None else None for b in batch[:9]]
+    orig_idx = batch[9]
+    word_orig_idx = batch[10]
+    sentlens = batch[11]
+    wordlens = batch[12]
+    text = batch[13]
     return inputs, orig_idx, word_orig_idx, sentlens, wordlens, text
 
 class Trainer(BaseTrainer):
@@ -63,7 +63,7 @@ class Trainer(BaseTrainer):
     def update(self, batch, eval=False):
         device = next(self.model.parameters()).device
         inputs, orig_idx, word_orig_idx, sentlens, wordlens, text = unpack_batch(batch, device)
-        word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained = inputs
+        word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, fixed_flags = inputs
 
         if eval:
             self.model.eval()
@@ -71,7 +71,7 @@ class Trainer(BaseTrainer):
             self.model.train()
             for optimizer in self.optimizers.values():
                 optimizer.zero_grad()
-        loss, _ = self.model(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, word_orig_idx, sentlens, wordlens, text)
+        loss, _ = self.model(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, word_orig_idx, sentlens, wordlens, text, fixed_flags=fixed_flags)
         if loss == 0.0:
             return loss
 
@@ -91,11 +91,11 @@ class Trainer(BaseTrainer):
     def predict(self, batch, unsort=True):
         device = next(self.model.parameters()).device
         inputs, orig_idx, word_orig_idx, sentlens, wordlens, text = unpack_batch(batch, device)
-        word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained = inputs
+        word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, fixed_flags = inputs
 
         self.model.eval()
         batch_size = word.size(0)
-        _, preds = self.model(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, word_orig_idx, sentlens, wordlens, text)
+        _, preds = self.model(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, word_orig_idx, sentlens, wordlens, text, fixed_flags=fixed_flags)
         upos_seqs = [self.vocab['upos'].unmap(sent) for sent in preds[0].tolist()]
         xpos_seqs = [self.vocab['xpos'].unmap(sent) for sent in preds[1].tolist()]
         feats_seqs = [self.vocab['feats'].unmap(sent) for sent in preds[2].tolist()]

--- a/stanza/models/pos/vocab.py
+++ b/stanza/models/pos/vocab.py
@@ -1,7 +1,7 @@
 from collections import Counter, OrderedDict
 
 from stanza.models.common.vocab import BaseVocab, BaseMultiVocab, CharVocab
-from stanza.models.common.vocab import CompositeVocab, VOCAB_PREFIX, EMPTY, EMPTY_ID
+from stanza.models.common.vocab import CompositeVocab, VOCAB_PREFIX, EMPTY, EMPTY_ID, PAD_ID
 
 class WordVocab(BaseVocab):
     def __init__(self, data=None, lang="", idx=0, cutoff=0, lower=False, ignore=None):
@@ -51,6 +51,83 @@ class FeatureVocab(CompositeVocab):
     def __init__(self, data=None, lang="", idx=0, sep="|", keyed=True):
         super().__init__(data, lang, idx=idx, sep=sep, keyed=keyed)
 
+# Reserved ids for the binary "starts a known fixed multi-word expression" flag.
+# PAD_ID (0) is reserved for padding so that the embedding's padding_idx behaves like the rest of the model.
+FIXED_NO_ID = 1
+FIXED_YES_ID = 2
+FIXED_NUM_IDS = 3
+
+class FixedExpressionVocab:
+    """A lexicon of multi-word fixed expressions.
+
+    Each entry is a tuple of lowercased word forms (e.g., ``('de', 'hecho')``).
+    Used by the POS tagger as a per-token binary input feature signalling
+    whether a token is the start of a known fixed multi-word expression.
+    Useful for predicting the ExtPos UFeat when the data is highly imbalanced.
+    """
+
+    def __init__(self, expressions=None, lowercase=True):
+        self.lowercase = lowercase
+        if expressions is None:
+            self.expressions = set()
+        else:
+            self.expressions = set(tuple(e) for e in expressions)
+        self.max_len = max((len(e) for e in self.expressions), default=0)
+
+    def __len__(self):
+        return len(self.expressions)
+
+    def __contains__(self, ngram):
+        return tuple(ngram) in self.expressions
+
+    def add(self, ngram):
+        ngram = tuple(w.lower() if self.lowercase else w for w in ngram)
+        if len(ngram) < 2:
+            return
+        self.expressions.add(ngram)
+        if len(ngram) > self.max_len:
+            self.max_len = len(ngram)
+
+    def update(self, ngrams):
+        for ng in ngrams:
+            self.add(ng)
+
+    def _norm(self, word):
+        return word.lower() if self.lowercase else word
+
+    def map(self, words):
+        """Return a list of ids (one per token): PAD_ID for empty inputs is not
+        produced here; instead each position gets FIXED_NO_ID (1) or FIXED_YES_ID (2)
+        depending on whether it begins any known fixed expression."""
+        n = len(words)
+        if n == 0 or not self.expressions or self.max_len < 2:
+            return [FIXED_NO_ID] * n
+        norm = [self._norm(w) for w in words]
+        out = [FIXED_NO_ID] * n
+        for i in range(n):
+            limit = min(self.max_len, n - i)
+            for j in range(2, limit + 1):
+                if tuple(norm[i:i + j]) in self.expressions:
+                    out[i] = FIXED_YES_ID
+                    break
+        return out
+
+    def state_dict(self):
+        # Serialise the expressions as a sorted list of tuples for stable IO.
+        return OrderedDict([
+            ('lowercase', self.lowercase),
+            ('expressions', sorted(self.expressions)),
+            ('max_len', self.max_len),
+        ])
+
+    @classmethod
+    def load_state_dict(cls, state_dict):
+        new = cls(expressions=state_dict.get('expressions', []),
+                  lowercase=state_dict.get('lowercase', True))
+        # max_len is derived but trust the saved one if present (e.g. for empty vocabs)
+        new.max_len = state_dict.get('max_len', new.max_len)
+        return new
+
 class MultiVocab(BaseMultiVocab):
     def state_dict(self):
         """ Also save a vocab name to class name mapping in state dict. """
@@ -67,7 +144,8 @@ class MultiVocab(BaseMultiVocab):
         class_dict = {'CharVocab': CharVocab,
                       'WordVocab': WordVocab,
                       'XPOSVocab': XPOSVocab,
-                      'FeatureVocab': FeatureVocab}
+                      'FeatureVocab': FeatureVocab,
+                      'FixedExpressionVocab': FixedExpressionVocab}
         new = cls()
         assert '_key2class' in state_dict, "Cannot find class name mapping in state dict!"
         key2class = state_dict['_key2class']

--- a/stanza/models/tagger.py
+++ b/stanza/models/tagger.py
@@ -84,6 +84,16 @@ def build_argparse():
     parser.add_argument('--share_hid', action='store_true', help="Share hidden representations for UPOS, XPOS and UFeats.")
     parser.set_defaults(share_hid=False)
 
+    parser.add_argument('--use_fixed_expressions', action='store_true', default=False,
+                        help='Use a binary "starts a known fixed multi-word expression" feature in the tagger input. '
+                             'Helps the morphological predictor learn ExtPos when training data is highly imbalanced (issue #1575).')
+    parser.add_argument('--fixed_expression_emb_dim', type=int, default=5,
+                        help='Embedding dimension for the fixed-expression binary input feature. Ignored if --use_fixed_expressions is not set.')
+    parser.add_argument('--fixed_expression_min_count', type=int, default=1,
+                        help='Minimum number of training occurrences for a fixed expression to be added to the dictionary.')
+    parser.add_argument('--fixed_expression_file', type=str, default=None,
+                        help='Optional path to a newline-separated file of whitespace-tokenized fixed expressions to extend the training-derived dictionary.')
+
     parser.add_argument('--sample_train', type=float, default=1.0, help='Subsample training data.')
     parser.add_argument('--optim', type=str, default='adam', help='sgd, adagrad, adam, adamw, adamax, or adadelta.  madgrad as an optional dependency')
     parser.add_argument('--second_optim', type=str, default='amsgrad', help='Optimizer for the second half of training.  Default is Adam with AMSGrad')

--- a/stanza/tests/pos/test_fixed_expressions.py
+++ b/stanza/tests/pos/test_fixed_expressions.py
@@ -1,0 +1,230 @@
+"""
+Unit tests for the fixed-expression input feature introduced for issue #1575.
+
+Covers:
+  * The standalone :class:`FixedExpressionVocab` lookup and serialisation.
+  * The :meth:`Dataset.build_fixed_expressions` extractor.
+  * Wiring through :meth:`Dataset.init_vocab` /
+    :meth:`Dataset.preprocess` / collation when ``--use_fixed_expressions``
+    is enabled, and the no-op default behaviour when it is not.
+"""
+
+from stanza.models import tagger
+from stanza.models.pos.data import Dataset
+from stanza.models.pos.vocab import (
+    FixedExpressionVocab,
+    MultiVocab,
+    FIXED_NO_ID,
+    FIXED_YES_ID,
+)
+from stanza.utils.conll import CoNLL
+
+
+# A pair of UD sentences with ExtPos-bearing fixed expressions:
+#   - Spanish "de hecho" (in fact)         -> ADV
+#   - English "in case of" (in case of)    -> ADP
+SPANISH_FIXED = """
+# sent_id = es-fixed-1
+# text = De hecho, llegó tarde.
+1	De	de	ADP	IN	ExtPos=ADV	4	advmod	_	_
+2	hecho	hecho	NOUN	NN	_	1	fixed	_	_
+3	,	,	PUNCT	,	_	1	punct	_	_
+4	llegó	llegar	VERB	VBD	Mood=Ind|Tense=Past	0	root	_	_
+5	tarde	tarde	ADV	RB	_	4	advmod	_	SpaceAfter=No
+6	.	.	PUNCT	.	_	4	punct	_	_
+
+""".lstrip()
+
+ENGLISH_FIXED = """
+# sent_id = en-fixed-1
+# text = In case of fire, run.
+1	In	in	ADP	IN	ExtPos=ADP	6	case	_	_
+2	case	case	NOUN	NN	_	1	fixed	_	_
+3	of	of	ADP	IN	_	1	fixed	_	_
+4	fire	fire	NOUN	NN	Number=Sing	6	obl	_	SpaceAfter=No
+5	,	,	PUNCT	,	_	6	punct	_	_
+6	run	run	VERB	VB	VerbForm=Inf	0	root	_	SpaceAfter=No
+7	.	.	PUNCT	.	_	6	punct	_	_
+
+""".lstrip()
+
+# A control sentence with no fixed relations; should contribute nothing.
+PLAIN_SENT = """
+# sent_id = plain-1
+# text = She left quickly.
+1	She	she	PRON	PRP	_	2	nsubj	_	_
+2	left	leave	VERB	VBD	Mood=Ind|Tense=Past	0	root	_	_
+3	quickly	quickly	ADV	RB	_	2	advmod	_	SpaceAfter=No
+4	.	.	PUNCT	.	_	2	punct	_	_
+
+""".lstrip()
+
+
+# ---------------------------------------------------------------------------
+# FixedExpressionVocab unit tests
+# ---------------------------------------------------------------------------
+
+class TestFixedExpressionVocab:
+    def test_empty_lookup(self):
+        v = FixedExpressionVocab()
+        assert len(v) == 0
+        # Empty vocab tags every token as "no".
+        assert v.map(["a", "b", "c"]) == [FIXED_NO_ID] * 3
+        assert v.map([]) == []
+
+    def test_basic_lookup_lowercases(self):
+        v = FixedExpressionVocab([("de", "hecho"), ("in", "case", "of")])
+        # Match is case-insensitive by default.
+        flags = v.map(["De", "hecho", "y", "In", "case", "of", "fire", "de"])
+        assert flags == [
+            FIXED_YES_ID,  # De -> "de hecho"
+            FIXED_NO_ID,   # hecho (middle of expression, not a start)
+            FIXED_NO_ID,   # y
+            FIXED_YES_ID,  # In -> "in case of"
+            FIXED_NO_ID,   # case
+            FIXED_NO_ID,   # of
+            FIXED_NO_ID,   # fire
+            FIXED_NO_ID,   # de (no "hecho" follows)
+        ]
+
+    def test_longest_match_window_respected(self):
+        # max_len should clamp the lookup window even with a long sentence.
+        v = FixedExpressionVocab([("a", "b")])
+        assert v.max_len == 2
+        # Trailing single-token windows must not flag anything.
+        assert v.map(["a"]) == [FIXED_NO_ID]
+        assert v.map(["a", "b"]) == [FIXED_YES_ID, FIXED_NO_ID]
+        assert v.map(["a", "c", "a", "b"]) == [
+            FIXED_NO_ID,
+            FIXED_NO_ID,
+            FIXED_YES_ID,
+            FIXED_NO_ID,
+        ]
+
+    def test_case_sensitive_mode(self):
+        v = FixedExpressionVocab([("De", "Hecho")], lowercase=False)
+        assert v.map(["De", "Hecho", "de", "hecho"]) == [
+            FIXED_YES_ID,
+            FIXED_NO_ID,
+            FIXED_NO_ID,
+            FIXED_NO_ID,
+        ]
+
+    def test_add_skips_singletons(self):
+        v = FixedExpressionVocab()
+        v.add(("just_one",))  # singletons are not multi-word expressions
+        v.add(("two", "words"))
+        assert len(v) == 1
+        assert ("two", "words") in v
+
+    def test_state_dict_roundtrip(self):
+        v = FixedExpressionVocab([("de", "hecho"), ("in", "case", "of")])
+        sd = v.state_dict()
+        restored = FixedExpressionVocab.load_state_dict(sd)
+        assert restored.expressions == v.expressions
+        assert restored.max_len == v.max_len
+        # The serialised form is deterministic (sorted) for reproducible IO.
+        assert sd["expressions"] == sorted(v.expressions)
+
+
+# ---------------------------------------------------------------------------
+# Dataset.build_fixed_expressions tests
+# ---------------------------------------------------------------------------
+
+class TestBuildFixedExpressions:
+    def _docs(self, *blobs):
+        return [CoNLL.conll2doc(input_str=b) for b in blobs]
+
+    def test_extracts_de_hecho_and_in_case_of(self):
+        docs = self._docs(SPANISH_FIXED, ENGLISH_FIXED, PLAIN_SENT)
+        v = Dataset.build_fixed_expressions(docs)
+        assert ("de", "hecho") in v
+        assert ("in", "case", "of") in v
+        # The plain sentence shouldn't contribute any spurious entries.
+        assert len(v) == 2
+        assert v.max_len == 3
+
+    def test_min_count_filters_singletons(self):
+        # "de hecho" appears once; with min_count=2 it should be dropped.
+        docs = self._docs(SPANISH_FIXED, ENGLISH_FIXED)
+        v = Dataset.build_fixed_expressions(docs, min_count=2)
+        assert len(v) == 0
+
+    def test_external_file_merges_in(self, tmp_path):
+        extra = tmp_path / "extra_fixed.txt"
+        # Whitespace-separated forms, blank/comment lines ignored.
+        extra.write_text("\n".join([
+            "# extras",
+            "à propos",
+            "ad hoc",
+            "",
+            "by the way",
+        ]))
+        docs = self._docs(SPANISH_FIXED)
+        v = Dataset.build_fixed_expressions(docs, extra_file=str(extra))
+        assert ("de", "hecho") in v
+        assert ("à", "propos") in v
+        assert ("ad", "hoc") in v
+        assert ("by", "the", "way") in v
+        assert v.max_len == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration with Dataset / DataLoader
+# ---------------------------------------------------------------------------
+
+class TestDatasetIntegration:
+    def _train_args(self, extra=None):
+        args = [
+            "--shorthand", "en_test",
+            "--augment_nopunct", "0.0",
+            "--batch_size", "4",
+        ]
+        if extra:
+            args = args + extra
+        return tagger.parse_args(args=args)
+
+    def test_default_off_keeps_legacy_behaviour(self):
+        args = self._train_args()
+        doc = CoNLL.conll2doc(input_str=ENGLISH_FIXED)
+        data = Dataset(doc, args, None)
+        # Without the flag, no 'fixed' vocab is built.
+        assert "fixed" not in data.vocab
+        loader = data.to_loader(batch_size=2)
+        batch = next(iter(loader))
+        assert batch.fixed_flags is None
+
+    def test_flag_enabled_threads_through_to_batch(self):
+        args = self._train_args(extra=["--use_fixed_expressions"])
+        doc = CoNLL.conll2doc(input_str=ENGLISH_FIXED)
+        # Both build the vocab from the same doc and run it through Dataset.
+        data = Dataset(doc, args, None)
+        assert "fixed" in data.vocab
+        fixedvocab = data.vocab["fixed"]
+        assert ("in", "case", "of") in fixedvocab
+
+        loader = data.to_loader(batch_size=2)
+        batch = next(iter(loader))
+        assert batch.fixed_flags is not None
+        flags = batch.fixed_flags
+        # Single sentence, so batch is [1, seq_len].
+        assert flags.shape[0] == 1
+        # The first token "In" should be flagged as the start of a known expression.
+        assert flags[0, 0].item() == FIXED_YES_ID
+        # Internal positions of the expression and the rest are "no".
+        for j in (1, 2):
+            assert flags[0, j].item() == FIXED_NO_ID
+
+
+# ---------------------------------------------------------------------------
+# MultiVocab serialisation roundtrip including FixedExpressionVocab
+# ---------------------------------------------------------------------------
+
+def test_multivocab_serialises_fixed_vocab():
+    fv = FixedExpressionVocab([("de", "hecho")])
+    mv = MultiVocab()
+    mv["fixed"] = fv
+    state = mv.state_dict()
+    restored = MultiVocab.load_state_dict(state)
+    assert "fixed" in restored
+    assert ("de", "hecho") in restored["fixed"]


### PR DESCRIPTION
**BEFORE YOU START**: please make sure your pull request is against the `dev` branch.
We cannot accept pull requests against the `main` branch.
See our [contributing guide](https://github.com/stanfordnlp/stanza/blob/main/CONTRIBUTING.md) for details.

## Description
Adds an optional binary "begins a known fixed multi-word expression" input feature to the POS / morphological tagger so the model can learn the `ExtPos` UFeat despite the extreme class imbalance discussed in #1575.

- A new `FixedExpressionVocab` (in `stanza/models/pos/vocab.py`) holds a lowercased set of n-gram tuples.
- `Dataset.build_fixed_expressions` (in `stanza/models/pos/data.py`) auto-builds the lexicon from training data by collecting every span rooted at a token whose children carry `deprel=fixed`, with an optional `--fixed_expression_min_count` filter and an optional `--fixed_expression_file` external whitespace-tokenized list to union in.
- Each token's flag (`0`=pad, `1`=no, `2`=yes) is mapped through a small `nn.Embedding(3, fixed_expression_emb_dim, padding_idx=PAD_ID)` and concatenated alongside the existing word / pretrain / char / BERT inputs in `Tagger.forward`, so the BiLSTM and every head (UPOS / XPOS / UFeats — including the `ExtPos` slot) get the cue. This matches @nschneid's suggestion on the issue: "appended to the embedding for the word and fed into the morphological feature predictor."
- New CLI flags (all off / no-op by default):
  - `--use_fixed_expressions` (store_true, default `False`)
  - `--fixed_expression_emb_dim` (int, default `5`)
  - `--fixed_expression_min_count` (int, default `1`)
  - `--fixed_expression_file` (optional path)

## Fixes Issues
- Closes #1575 (the input-feature variant proposed by @nschneid and endorsed by @AngledLuffa in the issue thread).

## Unit test coverage
Yes — new tests live in [`stanza/tests/pos/test_fixed_expressions.py`](stanza/tests/pos/test_fixed_expressions.py) covering:
- `FixedExpressionVocab`: empty lookup, case-insensitive lookup, max-window clamping, case-sensitive mode, singleton skipping, `state_dict` / `load_state_dict` roundtrip.
- `Dataset.build_fixed_expressions`: end-to-end extraction of `de hecho` (ES) and `in case of` (EN) from synthetic CoNLL-U; `min_count` filtering; merging with an external file.
- `Dataset` integration: default-off run produces `batch.fixed_flags is None` (i.e. legacy behaviour preserved); enabling `--use_fixed_expressions` threads the flags through `preprocess` / `__getitem__` / `__collate_fn` and yields the expected per-token labels.
- `MultiVocab` serialisation roundtrip including the new vocab.

Existing tagger / data tests (`stanza/tests/pos/test_tagger.py`, `stanza/tests/pos/test_data.py`) continue to pass unchanged — the new feature only activates when `--use_fixed_expressions` is set.

## Known breaking changes/behaviors
None expected. The feature is opt-in and fully backward compatible:
- Old checkpoints have no `'fixed'` vocab and no `fixed_expression_emb_dim` in `args` → the model ctor skips the new `fixed_emb` module, `Dataset.preprocess` skips the slot, `__collate_fn` yields `fixed_flags=None`, the trainer passes `None` through, and `Tagger.forward` skips the branch.
- `MultiVocab.load_state_dict` registers the new `FixedExpressionVocab` class so new checkpoints round-trip cleanly.
- `Tagger.forward`'s new `fixed_flags` argument is a keyword-only-defaulted parameter, so any external callers using the existing positional signature are unaffected.
- `POSProcessor` requires no code changes; it picks up the new vocab automatically from the loaded model.