### PR TITLE
Odia dataset mixed with other Indic languages

### DIFF
--- a/stanza/resources/default_packages.py
+++ b/stanza/resources/default_packages.py
@@ -76,6 +76,7 @@ default_treebanks = {
     "nl":      "alpino",
     "nn":      "nynorsk",
     "olo":     "kkpp",
+    "or":      "odtb",
     "orv":     "torot",
     "ota":     "boun",
     "pcm":     "nsc",

--- a/stanza/resources/default_packages.py
+++ b/stanza/resources/default_packages.py
@@ -386,6 +386,7 @@ default_ners = {
     "nb": "norne",
     "nl": "conll02",
     "nn": "norne",
+    "or": "ilner_nocharlm",
     "pl": "nkjp",
     "ru": "wikiner",
     "sd": "siner",

--- a/stanza/resources/prepare_resources.py
+++ b/stanza/resources/prepare_resources.py
@@ -44,8 +44,6 @@ def parse_args():
 allowed_empty_languages = [
     # only tokenize and NER for Myanmar right now (soon...)
     "my",
-    # currently only an NER, not even a tokenizer, for Oriya
-    "or",
 ]
 
 # map processor name to file ending
@@ -338,20 +336,38 @@ def process_dirs(args):
     print("Processed initial model directories.  Writing preliminary resources.json")
     json.dump(resources, open(os.path.join(args.output_dir, 'resources.json'), 'w'), indent=2)
 
-def get_default_pos_package(lang, ud_package):
+def get_default_pos_package(lang, ud_package, known_resources):
     charlm_package = get_pos_charlm_package(lang, ud_package)
     if charlm_package is not None:
         return ud_package + "_charlm"
     if lang in no_pretrain_languages:
         return ud_package + "_nopretrain"
+    transformer = TRANSFORMER_NICKNAMES.get(TRANSFORMERS.get(lang, None), None)
+    transformer_package = "%s_%s" % (ud_package, transformer)
+    nocharlm_package = "%s_nocharlm" % ud_package
+    # TODO: use a defaultdict here instead
+    if nocharlm_package in known_resources.get("pos", {}):
+        return nocharlm_package
+    if transformer_package in known_resources.get("pos", {}):
+        return transformer_package
+    # this will probably cause a problem when there is no model of this name
     return ud_package + "_nocharlm"
 
-def get_default_depparse_package(lang, ud_package):
+def get_default_depparse_package(lang, ud_package, known_resources):
     charlm_package = get_depparse_charlm_package(lang, ud_package)
     if charlm_package is not None:
         return ud_package + "_charlm"
     if lang in no_pretrain_languages:
         return ud_package + "_nopretrain"
+    transformer = TRANSFORMER_NICKNAMES.get(TRANSFORMERS.get(lang, None), None)
+    transformer_package = "%s_%s" % (ud_package, transformer)
+    nocharlm_package = "%s_nocharlm" % ud_package
+    # TODO: use a defaultdict here instead
+    if nocharlm_package in known_resources.get("pos", {}):
+        return nocharlm_package
+    if transformer_package in known_resources.get("pos", {}):
+        return transformer_package
+    # this will probably cause a problem when there is no model of this name
     return ud_package + "_nocharlm"
 
 def process_default_zips(args):
@@ -451,14 +467,14 @@ def get_default_processors(resources, lang):
         default_processors['lemma'] = 'identity'
 
     if 'pos' in resources[lang]:
-        default_processors['pos'] = get_default_pos_package(lang, default_package)
+        default_processors['pos'] = get_default_pos_package(lang, default_package, resources[lang])
         if default_processors['pos'] not in resources[lang]['pos']:
             raise AssertionError("Expected POS model not in resources: %s" % default_processors['pos'])
     elif lang not in allowed_empty_languages:
         raise AssertionError("Expected to find POS models for language %s" % lang)
 
     if 'depparse' in resources[lang]:
-        default_processors['depparse'] = get_default_depparse_package(lang, default_package)
+        default_processors['depparse'] = get_default_depparse_package(lang, default_package, resources[lang])
         if default_processors['depparse'] not in resources[lang]['depparse']:
             raise AssertionError("Expected depparse model not in resources: %s" % default_processors['depparse'])
     elif lang not in allowed_empty_languages:

--- a/stanza/utils/datasets/common.py
+++ b/stanza/utils/datasets/common.py
@@ -334,4 +334,5 @@ def main(process_treebank, model_type, add_specific_args=None):
             treebanks.append(treebank)
 
     for treebank in treebanks:
-        process_treebank(treebank, model_type, paths, args)
+        if not process_treebank(treebank, model_type, paths, args):
+            logger.error("Processing %s failed!", treebank)

--- a/stanza/utils/datasets/common.py
+++ b/stanza/utils/datasets/common.py
@@ -309,6 +309,8 @@ def build_argparse():
     parser.add_argument('treebanks', type=str, nargs='+', help='Which treebanks to run on.  Use all_ud or ud_all for all UD treebanks')
 
     parser.add_argument('--no_spanish_future', action='store_false', default=True, dest='use_spanish_future', help="Don't use the file of future tense Spanish data")
+    parser.add_argument('--small_dataset_threshold', type=int, default=10_000, help="How many words we need in a test set before declaring it too small")
+    parser.add_argument('--split_ratio', type=float, default=0.2, help="How large to split the dev/test chunks when splitting a single file into train/dev/test")
 
     return parser
 

--- a/stanza/utils/datasets/indic/mixed_odia_dataset.py
+++ b/stanza/utils/datasets/indic/mixed_odia_dataset.py
@@ -1,0 +1,293 @@
+"""
+Build a combined POS training dataset for an Odia Stanza tagger.
+
+The Odia treebank (UD_Odia-ODTB) currently has only a test split, so this
+script first splits it deterministically into train/dev/test using a hash of
+each sentence's sent_id.  That way sentences keep their split assignment even
+if the file is later reordered.
+
+Additional languages supported in MuRIL that can be mixed in:
+  Hindi   (UD_Hindi-HDTB)
+  Urdu    (UD_Urdu-UDTB)
+  Sindhi  (UD_Sindhi-Isra)
+  Marathi (UD_Marathi-UFAL)
+  Tamil   (UD_Tamil-TTB)
+
+For all extra languages, xpos and morphological features are stripped so the
+model learns only UPOS from them.  Odia keeps its full annotation.
+
+The purpose of mixing in additional datasets is that while the Odia
+dataset is quite small, there is the Muril transformer from Google
+which supports Odia along with several related languages.  Thus we can
+mix in those datasets and use only the Muril embedding (no fasttext or
+charlm) in order to get crosslingual training.  This worked quite well
+for Sindhi when building that dataset, should help here as well.
+
+https://aclanthology.org/2025.udw-1.11/
+
+Usage example:
+  python build_odia_stanza_training_set.py \\
+      --use_hindi --use_urdu --use_sindhi --use_marathi \\
+      --hindi_size 1000 --urdu_size 1000 --sindhi_size 1000
+
+Adapted from the Sindhi build script in UD_Sindhi-Isra by the original authors.
+
+If needed, we can refactor / repurpose this to operate on larger
+combinations of datasets.
+"""
+
+import argparse
+import hashlib
+import io
+import os
+import random
+import zipfile
+
+from stanza.models.common.doc import Document
+from stanza.utils.conll import CoNLL
+from stanza.utils.default_paths import get_default_paths
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def remove_xpos_and_features(doc):
+    """Strip xpos and morphological features from every word in *doc*."""
+    for sent in doc.sentences:
+        for word in sent.words:
+            word.feats = None
+            word.xpos = None
+
+
+def read_conllu(path, strip_xpos=True):
+    """Read a single .conllu file and return a Stanza Document."""
+    if not os.path.exists(path):
+        raise FileNotFoundError("File not found: %s" % path)
+    doc = CoNLL.conll2doc(path)
+    if strip_xpos:
+        remove_xpos_and_features(doc)
+    return doc
+
+
+def random_select(doc, size, seed=1234):
+    """Return *size* sentences chosen at random from *doc*."""
+    sentences = list(doc.sentences)
+    rng = random.Random(seed)
+    rng.shuffle(sentences)
+    chosen = sentences[:size]
+    return Document(
+        [s.to_dict() for s in chosen],
+        comments=[s.comments for s in chosen],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic split keyed on sent_id
+# ---------------------------------------------------------------------------
+
+def _sent_bucket(sent, weights=(0.8, 0.1, 0.1)):
+    """
+    Assign a sentence to train/dev/test deterministically using a hash of its
+    sent_id comment.  Falls back to a hash of the sentence text if no sent_id
+    comment is present.
+
+    Returns 0 (train), 1 (dev), or 2 (test).
+    """
+    sent_id = None
+    for comment in sent.comments:
+        if comment.startswith("# sent_id"):
+            sent_id = comment
+            break
+    key = sent_id if sent_id is not None else sent.text
+    h = int(hashlib.md5(key.encode("utf-8")).hexdigest(), 16)
+    # Map the hash uniformly onto [0, 1) then bucket by cumulative weights
+    frac = (h % 10000) / 10000.0
+    cumulative = 0.0
+    for bucket, w in enumerate(weights):
+        cumulative += w
+        if frac < cumulative:
+            return bucket
+    return len(weights) - 1  # safety
+
+
+def split_by_sent_id(doc, weights=(0.8, 0.1, 0.1)):
+    """
+    Split *doc* into (train, dev, test) Documents deterministically using
+    sent_id hashing so that split membership is stable across file reorderings.
+    """
+    buckets = [[], []], [[], []]  # placeholder; rebuilt below
+    train_sents, train_comments = [], []
+    dev_sents, dev_comments = [], []
+    test_sents, test_comments = [], []
+
+    for sent in doc.sentences:
+        bucket = _sent_bucket(sent, weights)
+        if bucket == 0:
+            train_sents.append(sent.to_dict())
+            train_comments.append(sent.comments)
+        elif bucket == 1:
+            dev_sents.append(sent.to_dict())
+            dev_comments.append(sent.comments)
+        else:
+            test_sents.append(sent.to_dict())
+            test_comments.append(sent.comments)
+
+    train = Document(train_sents, comments=train_comments)
+    dev   = Document(dev_sents,   comments=dev_comments)
+    test  = Document(test_sents,  comments=test_comments)
+
+    print("Odia split: %d train / %d dev / %d test" % (
+        len(train.sentences), len(dev.sentences), len(test.sentences)))
+    return train, dev, test
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    paths = get_default_paths()
+    udbase = paths["UDBASE"]
+
+    parser = argparse.ArgumentParser(
+        description="Build a combined POS training set for an Odia Stanza tagger"
+    )
+
+    # --- Odia source ---
+    parser.add_argument(
+        "--odia_file",
+        default=os.path.join(udbase, "UD_Odia-ODTB/or_odtb-ud-test.conllu"),
+        help="Path to the Odia conllu file (currently the test split only)",
+    )
+    parser.add_argument(
+        "--train_weight", type=float, default=0.8,
+        help="Fraction of Odia sentences for train (default 0.8)",
+    )
+    parser.add_argument(
+        "--dev_weight", type=float, default=0.1,
+        help="Fraction of Odia sentences for dev (default 0.1)",
+    )
+    # test gets the remainder
+
+    # --- Extra languages ---
+    parser.add_argument("--use_all_languages", default=False, action="store_true",
+                        help="Include all five extra languages (Hindi, Urdu, Sindhi, Marathi, Tamil). "
+                             "Individual --use_* flags are still respected and override this.")
+    parser.add_argument("--use_hindi",   default=False, action="store_true",
+                        help="Include Hindi trees")
+    parser.add_argument("--use_urdu",    default=False, action="store_true",
+                        help="Include Urdu trees")
+    parser.add_argument("--use_sindhi",  default=False, action="store_true",
+                        help="Include Sindhi trees")
+    parser.add_argument("--use_marathi", default=False, action="store_true",
+                        help="Include Marathi trees")
+    parser.add_argument("--use_tamil",   default=False, action="store_true",
+                        help="Include Tamil trees")
+
+    # --- Per-language size caps ---
+    parser.add_argument("--hindi_size",   type=int, default=1000,
+                        help="Max Hindi sentences to include (default 1000)")
+    parser.add_argument("--urdu_size",    type=int, default=1000,
+                        help="Max Urdu sentences to include (default 1000)")
+    parser.add_argument("--sindhi_size",  type=int, default=1000,
+                        help="Max Sindhi sentences to include (default 1000)")
+    parser.add_argument("--marathi_size", type=int, default=None,
+                        help="Max Marathi sentences (default: all)")
+    parser.add_argument("--tamil_size",   type=int, default=None,
+                        help="Max Tamil sentences (default: all)")
+
+    # --- Output ---
+    parser.add_argument(
+        "--output_dir", default="data/pos",
+        help="Directory to write output files (default: data/pos)",
+    )
+    parser.add_argument(
+        "--dataset_name", default="or_odtb",
+        help="Short name used in output filenames (default: or_odtb)",
+    )
+
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # 1. Load and split the Odia data (keep full annotation)
+    # ------------------------------------------------------------------
+    print("Reading Odia data from: %s" % args.odia_file)
+    odia_doc = read_conllu(args.odia_file, strip_xpos=False)
+    print("Total Odia sentences: %d" % len(odia_doc.sentences))
+
+    weights = (args.train_weight, args.dev_weight,
+               1.0 - args.train_weight - args.dev_weight)
+    train, dev, test = split_by_sent_id(odia_doc, weights=weights)
+
+    # ------------------------------------------------------------------
+    # 2. Load extra-language training data (xpos/feats stripped)
+    # ------------------------------------------------------------------
+    extra_datasets = {}  # name -> Document
+
+    if args.use_all_languages:
+        args.use_hindi = args.use_urdu = args.use_sindhi = \
+            args.use_marathi = args.use_tamil = True
+
+    lang_configs = [
+        ("hindi",   args.use_hindi,   args.hindi_size,
+         os.path.join(udbase, "UD_Hindi-HDTB/hi_hdtb-ud-train.conllu")),
+        ("urdu",    args.use_urdu,    args.urdu_size,
+         os.path.join(udbase, "UD_Urdu-UDTB/ur_udtb-ud-train.conllu")),
+        ("sindhi",  args.use_sindhi,  args.sindhi_size,
+         os.path.join(udbase, "UD_Sindhi-Isra/sd_isra-ud-train.conllu")),
+        ("marathi", args.use_marathi, args.marathi_size,
+         os.path.join(udbase, "UD_Marathi-UFAL/mr_ufal-ud-train.conllu")),
+        ("tamil",   args.use_tamil,   args.tamil_size,
+         os.path.join(udbase, "UD_Tamil-TTB/ta_ttb-ud-train.conllu")),
+    ]
+
+    for lang_name, use_lang, size_cap, lang_path in lang_configs:
+        if not use_lang:
+            continue
+        print("Reading %s from: %s" % (lang_name, lang_path))
+        lang_doc = read_conllu(lang_path, strip_xpos=True)
+        print("  %d sentences read" % len(lang_doc.sentences))
+        if size_cap is not None and len(lang_doc.sentences) > size_cap:
+            lang_doc = random_select(lang_doc, size_cap)
+            print("  down-sampled to %d sentences" % len(lang_doc.sentences))
+        extra_datasets[lang_name] = lang_doc
+
+    # ------------------------------------------------------------------
+    # 3. Write output
+    # ------------------------------------------------------------------
+    shortname = args.dataset_name
+    out = args.output_dir
+
+    # dev and test are written as plain conllu
+    dev_path  = os.path.join(out, "%s.dev.in.conllu"  % shortname)
+    test_path = os.path.join(out, "%s.test.in.conllu" % shortname)
+    CoNLL.write_doc2conll(dev,  dev_path)
+    CoNLL.write_doc2conll(test, test_path)
+    print("Wrote dev  -> %s (%d sentences)" % (dev_path,  len(dev.sentences)))
+    print("Wrote test -> %s (%d sentences)" % (test_path, len(test.sentences)))
+
+    # train is written as a zip containing one conllu per source
+    train_zip_path = os.path.join(out, "%s.train.in.zip" % shortname)
+    train_datasets = {"%s_train.in.conllu" % shortname: train}
+    for lang_name, lang_doc in extra_datasets.items():
+        train_datasets["%s.conllu" % lang_name] = lang_doc
+
+    print("Writing training zip -> %s" % train_zip_path)
+    with zipfile.ZipFile(train_zip_path, "w") as zout:
+        for name, doc in train_datasets.items():
+            if len(doc.sentences) == 0:
+                print("  Skipping %s (empty)" % name)
+                continue
+            with zout.open(name, mode="w") as fout:
+                with io.TextIOWrapper(fout, encoding="utf-8") as tout:
+                    CoNLL.write_doc2conll(doc, tout)
+            print("  Wrote %d sentences as %s" % (len(doc.sentences), name))
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/stanza/utils/datasets/indic/mixed_odia_dataset.py
+++ b/stanza/utils/datasets/indic/mixed_odia_dataset.py
@@ -25,10 +25,19 @@ for Sindhi when building that dataset, should help here as well.
 
 https://aclanthology.org/2025.udw-1.11/
 
-Usage example:
-  python build_odia_stanza_training_set.py \\
+Usage examples:
+
+  # POS tagging dataset (default)
+  python mixed_odia_dataset.py \\
       --use_hindi --use_urdu --use_sindhi --use_marathi \\
       --hindi_size 1000 --urdu_size 1000 --sindhi_size 1000
+
+  # Dependency parsing dataset
+  python mixed_odia_dataset.py --mode depparse --use_all_languages
+
+  # All languages, both modes
+  python mixed_odia_dataset.py --mode pos      --use_all_languages
+  python mixed_odia_dataset.py --mode depparse --use_all_languages
 
 Adapted from the Sindhi build script in UD_Sindhi-Isra by the original authors.
 
@@ -151,7 +160,13 @@ def main():
     udbase = paths["UDBASE"]
 
     parser = argparse.ArgumentParser(
-        description="Build a combined POS training set for an Odia Stanza tagger"
+        description="Build a combined POS or dependency parsing training set for an Odia Stanza tagger"
+    )
+
+    # --- Mode ---
+    parser.add_argument(
+        "--mode", default="pos", choices=["pos", "depparse"],
+        help="Build a POS tagging dataset or a dependency parsing dataset (default: pos)",
     )
 
     # --- Odia source ---
@@ -199,8 +214,9 @@ def main():
 
     # --- Output ---
     parser.add_argument(
-        "--output_dir", default="data/pos",
-        help="Directory to write output files (default: data/pos)",
+        "--output_dir", default=None,
+        help="Directory to write output files. "
+             "Defaults to data/pos or data/depparse depending on --mode.",
     )
     parser.add_argument(
         "--dataset_name", default="or_odtb",
@@ -209,10 +225,15 @@ def main():
 
     args = parser.parse_args()
 
+    if args.output_dir is None:
+        args.output_dir = "data/pos" if args.mode == "pos" else "data/depparse"
+
     os.makedirs(args.output_dir, exist_ok=True)
 
     # ------------------------------------------------------------------
-    # 1. Load and split the Odia data (keep full annotation)
+    # 1. Load and split the Odia data.
+    #    Always keep full annotation (xpos, feats, head, deprel) so the
+    #    same split is usable for both pos and depparse modes.
     # ------------------------------------------------------------------
     print("Reading Odia data from: %s" % args.odia_file)
     odia_doc = read_conllu(args.odia_file, strip_xpos=False)
@@ -223,7 +244,12 @@ def main():
     train, dev, test = split_by_sent_id(odia_doc, weights=weights)
 
     # ------------------------------------------------------------------
-    # 2. Load extra-language training data (xpos/feats stripped)
+    # 2. Load extra-language training data.
+    #
+    #    Always strip xpos/feats from extra languages regardless of mode.
+    #    For depparse, we want the parser to generalize on UPOS and tree
+    #    structure rather than language-specific xpos tagsets.
+    #    Odia always retains full annotation since it is the target language.
     # ------------------------------------------------------------------
     extra_datasets = {}  # name -> Document
 
@@ -261,7 +287,9 @@ def main():
     shortname = args.dataset_name
     out = args.output_dir
 
-    # dev and test are written as plain conllu
+    print("Mode: %s  ->  writing to %s" % (args.mode, out))
+
+    # dev and test are always plain conllu
     dev_path  = os.path.join(out, "%s.dev.in.conllu"  % shortname)
     test_path = os.path.join(out, "%s.test.in.conllu" % shortname)
     CoNLL.write_doc2conll(dev,  dev_path)
@@ -269,7 +297,7 @@ def main():
     print("Wrote dev  -> %s (%d sentences)" % (dev_path,  len(dev.sentences)))
     print("Wrote test -> %s (%d sentences)" % (test_path, len(test.sentences)))
 
-    # train is written as a zip containing one conllu per source
+    # train is a zip containing one conllu per source
     train_zip_path = os.path.join(out, "%s.train.in.zip" % shortname)
     train_datasets = {"%s_train.in.conllu" % shortname: train}
     for lang_name, lang_doc in extra_datasets.items():

--- a/stanza/utils/datasets/prepare_depparse_treebank.py
+++ b/stanza/utils/datasets/prepare_depparse_treebank.py
@@ -28,7 +28,7 @@ def process_treebank(treebank, model_type, paths, args) -> None:
         prepare_tokenizer_treebank.copy_conllu_treebank(treebank, model_type, paths, paths["DEPPARSE_DATA_DIR"], args=args, postprocess=retag_dataset)
     else:
         raise ValueError("Unknown tags method: {}".format(args.tag_method))
-
+    return True
 
 def main() -> None:
     """Call Process Treebank."""

--- a/stanza/utils/datasets/prepare_lemma_treebank.py
+++ b/stanza/utils/datasets/prepare_lemma_treebank.py
@@ -73,6 +73,7 @@ def process_treebank(treebank, model_type, paths, args):
     short_name = treebank_to_short_name(treebank)
     if args.lemma_classifier and short_name in prepare_lemma_classifier.DATASET_MAPPING:
         prepare_lemma_classifier.main(short_name)
+    return True
 
 def main():
     common.main(process_treebank, common.ModelType.LEMMA, add_specific_args)

--- a/stanza/utils/datasets/prepare_mwt_treebank.py
+++ b/stanza/utils/datasets/prepare_mwt_treebank.py
@@ -79,6 +79,7 @@ def process_treebank(treebank, model_type, paths, args):
                      f"{mwt_dir}/{short_name}.dev.in.conllu")
         contract_mwt(f"{mwt_dir}/{short_name}.test.gold.conllu",
                      f"{mwt_dir}/{short_name}.test.in.conllu")
+    return True
 
 def main():
     common.main(process_treebank, common.ModelType.MWT)

--- a/stanza/utils/datasets/prepare_pos_treebank.py
+++ b/stanza/utils/datasets/prepare_pos_treebank.py
@@ -28,6 +28,7 @@ def copy_conllu_file_or_zip(tokenizer_dir, tokenizer_file, dest_dir, dest_file, 
 
 def process_treebank(treebank, model_type, paths, args):
     prepare_tokenizer_treebank.copy_conllu_treebank(treebank, model_type, paths, paths["POS_DATA_DIR"], args, postprocess=copy_conllu_file_or_zip)
+    return True
 
 def main():
     common.main(process_treebank, common.ModelType.POS)

--- a/stanza/utils/datasets/prepare_tokenizer_treebank.py
+++ b/stanza/utils/datasets/prepare_tokenizer_treebank.py
@@ -85,7 +85,7 @@ def copy_conllu_treebank(treebank, model_type, paths, dest_dir, args, postproces
         postprocess(tokenizer_dir, "dev.gold", dest_dir, "dev.in", short_name)
         postprocess(tokenizer_dir, "test.gold", dest_dir, "test.in", short_name)
 
-def split_conllu_file(treebank, input_conllu, train_output_conllu, dev_output_conllu, test_output_conllu):
+def split_conllu_file(treebank, input_conllu, train_output_conllu, dev_output_conllu, test_output_conllu, xv_ratio):
     # set the seed for each data file so that the results are the same
     # regardless of how many treebanks are processed at once
     random.seed(1234)
@@ -93,9 +93,9 @@ def split_conllu_file(treebank, input_conllu, train_output_conllu, dev_output_co
     # read and shuffle conllu data
     sents = read_sentences_from_conllu(input_conllu)
     random.shuffle(sents)
-    n_dev = int(len(sents) * XV_RATIO)
+    n_dev = int(len(sents) * xv_ratio)
     assert n_dev >= 1, "Dev sentence number less than one."
-    n_test = int(len(sents) * XV_RATIO)
+    n_test = int(len(sents) * xv_ratio)
     assert n_test >= 1, "Test sentence number less than one."
     n_train = len(sents) - n_dev - n_test
 
@@ -113,7 +113,7 @@ def split_conllu_file(treebank, input_conllu, train_output_conllu, dev_output_co
 
     return True
 
-def split_train_file(treebank, train_input_conllu, train_output_conllu, dev_output_conllu):
+def split_train_file(treebank, train_input_conllu, train_output_conllu, dev_output_conllu, xv_ratio):
     # set the seed for each data file so that the results are the same
     # regardless of how many treebanks are processed at once
     random.seed(1234)
@@ -121,7 +121,7 @@ def split_train_file(treebank, train_input_conllu, train_output_conllu, dev_outp
     # read and shuffle conllu data
     sents = read_sentences_from_conllu(train_input_conllu)
     random.shuffle(sents)
-    n_dev = int(len(sents) * XV_RATIO)
+    n_dev = int(len(sents) * xv_ratio)
     assert n_dev >= 1, "Dev sentence number less than one."
     n_train = len(sents) - n_dev
 
@@ -1453,9 +1453,8 @@ def process_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name, short_l
     return True
 
 
-XV_RATIO = 0.2
 
-def process_test_only_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name, short_language):
+def process_test_only_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name, short_language, args):
     """
     Process a large UD treebank with only a test
 
@@ -1472,22 +1471,22 @@ def process_test_only_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_nam
     test_output_conllu = common.tokenizer_conllu_name(tokenizer_dir, short_name, "test")
 
     num_words = common.num_words_in_file(test_input_conllu)
-    threshold = 10000
-    if num_words < threshold:
-        print("Only had %d words, threshold was %d" % (num_words, threshold))
+    if num_words < args.small_dataset_threshold:
+        print("Only had %d words, threshold was %d" % (num_words, args.small_dataset_threshold))
         return False
 
     if not split_conllu_file(treebank=treebank,
                              input_conllu=test_input_conllu,
                              train_output_conllu=train_output_conllu,
                              dev_output_conllu=dev_output_conllu,
-                             test_output_conllu=test_output_conllu):
+                             test_output_conllu=test_output_conllu,
+                             xv_ratio=args.split_ratio):
         return False
 
     return True
 
 
-def process_partial_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name, short_language):
+def process_partial_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name, short_language, args):
     """
     Process a UD treebank with only train/test splits
 
@@ -1522,7 +1521,8 @@ def process_partial_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name,
     if not split_train_file(treebank=treebank,
                             train_input_conllu=train_input_conllu,
                             train_output_conllu=train_output_conllu,
-                            dev_output_conllu=dev_output_conllu):
+                            dev_output_conllu=dev_output_conllu,
+                            split_ratio=args.split_ratio):
         return False
 
     # the test set is already fine
@@ -1588,12 +1588,12 @@ def process_treebank(treebank, model_type, paths, args):
             # maybe this dataset has a huge test set we can split?
             test_conllu_file = common.find_treebank_dataset_file(treebank, udbase_dir, "test", "conllu", fail=True)
             print("Checking data for %s: %s, %s to see if the test dataset is large enough" % (treebank, short_name, short_language))
-            success = process_test_only_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name, short_language)
+            success = process_test_only_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name, short_language, args)
         else:
             print("Preparing data for %s: %s, %s" % (treebank, short_name, short_language))
 
             if not common.find_treebank_dataset_file(treebank, udbase_dir, "dev", "conllu", fail=False):
-                success = process_partial_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name, short_language)
+                success = process_partial_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name, short_language, args)
             else:
                 success = process_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_name, short_language, args.augment)
 

--- a/stanza/utils/datasets/prepare_tokenizer_treebank.py
+++ b/stanza/utils/datasets/prepare_tokenizer_treebank.py
@@ -1471,7 +1471,10 @@ def process_test_only_ud_treebank(treebank, udbase_dir, tokenizer_dir, short_nam
     dev_output_conllu = common.tokenizer_conllu_name(tokenizer_dir, short_name, "dev")
     test_output_conllu = common.tokenizer_conllu_name(tokenizer_dir, short_name, "test")
 
-    if common.num_words_in_file(test_input_conllu) <= 10000:
+    num_words = common.num_words_in_file(test_input_conllu)
+    threshold = 10000
+    if num_words < threshold:
+        print("Only had %d words, threshold was %d" % (num_words, threshold))
         return False
 
     if not split_conllu_file(treebank=treebank,
@@ -1601,6 +1604,7 @@ def process_treebank(treebank, model_type, paths, args):
         if args.prepare_labels:
             common.prepare_tokenizer_treebank_labels(tokenizer_dir, short_name)
 
+    return success
 
 def main():
     common.main(process_treebank, common.ModelType.TOKENIZER, add_specific_args)


### PR DESCRIPTION
Build a mixed Odia dataset for pos & depparse - mixed from the current Odia test set and some other languages present in Muril-Large.  This starts from the Sindhi mixing dataset script from the Sindhi project, but now we can include Sindhi as one of the languages to use!  If we wind up doing this sort of exercise frequently, we can turn it into a more general script with more configurable flags.

Also included is using the ODTB package as the default for Odia when preparing Stanza packages.