### PR TITLE
Lemma classifier upgrades

### DIFF
--- a/stanza/models/lemma/attach_lemma_classifier.py
+++ b/stanza/models/lemma/attach_lemma_classifier.py
@@ -1,15 +1,24 @@
 import argparse
+import logging
 
 from stanza.models.lemma.trainer import Trainer
 from stanza.models.lemma_classifier.base_model import LemmaClassifier
 
-def attach_classifier(input_filename, output_filename, classifiers):
+logger = logging.getLogger('stanza')
+
+def attach_classifier(input_filename, output_filename, classifiers, remove_existing):
+    logger.info("Attaching lemmatizers to %s", input_filename)
     trainer = Trainer(model_file=input_filename)
 
+    if remove_existing:
+        trainer.contextual_lemmatizers = []
+
     for classifier in classifiers:
+        logger.info("Loading %s", classifier)
         classifier = LemmaClassifier.load(classifier)
         trainer.contextual_lemmatizers.append(classifier)
 
+    logger.info("Total contextual_lemmatizers: %d", len(trainer.contextual_lemmatizers))
     trainer.save(output_filename)
 
 def main(args=None):
@@ -17,9 +26,10 @@ def main(args=None):
     parser.add_argument('--input', type=str, required=True, help='Which lemmatizer to start from')
     parser.add_argument('--output', type=str, required=True, help='Where to save the lemmatizer')
     parser.add_argument('--classifier', type=str, required=True, nargs='+', help='Lemma classifier to attach')
+    parser.add_argument('--remove_existing', default=False, action='store_true', help='Remove any existing lemma classifiers')
     args = parser.parse_args(args)
 
-    attach_classifier(args.input, args.output, args.classifier)
+    attach_classifier(args.input, args.output, args.classifier, args.remove_existing)
 
 if __name__ == '__main__':
     main()

--- a/stanza/models/lemma_classifier/base_model.py
+++ b/stanza/models/lemma_classifier/base_model.py
@@ -124,7 +124,7 @@ class LemmaClassifier(ABC, nn.Module):
     @staticmethod
     def load(filename, args=None):
         try:
-            checkpoint = torch.load(filename, lambda storage, loc: storage)
+            checkpoint = torch.load(filename, lambda storage, loc: storage, weights_only=True)
         except BaseException:
             logger.exception("Cannot load model from %s", filename)
             raise

--- a/stanza/utils/datasets/prepare_lemma_classifier.py
+++ b/stanza/utils/datasets/prepare_lemma_classifier.py
@@ -9,8 +9,11 @@ from stanza.utils.conll import CoNLL
 
 SECTIONS = ("train", "dev", "test")
 
-def process_treebank(paths, short_name, word, upos, allowed_lemmas, sections=SECTIONS):
-    treebank = short_name_to_treebank(short_name)
+def process_treebank(paths, short_name, word, upos, allowed_lemmas, sections=SECTIONS, dataset_to_use=None):
+    if dataset_to_use is None:
+        treebank = short_name_to_treebank(short_name)
+    else:
+        treebank = short_name_to_treebank(dataset_to_use)
     udbase_dir = paths["UDBASE"]
 
     output_dir = paths["LEMMA_CLASSIFIER_DATA_DIR"]
@@ -79,7 +82,8 @@ def process_ja_gsd(paths, short_name):
     upos = "AUX"
     allowed_lemmas = None
 
-    process_treebank(paths, short_name, word, upos, allowed_lemmas)
+    # both the base GSD and 'ja_combined' with extra training sentences will use the ja_gsd dataset
+    process_treebank(paths, short_name, word, upos, allowed_lemmas, dataset_to_use='ja_gsd')
 
 def process_fa_perdt(paths, short_name):
     word = "شد"
@@ -125,20 +129,21 @@ DATASET_MAPPING = {
     "en_combined":       process_en_combined,
     "fa_perdt":          process_fa_perdt,
     "hi_hdtb":           process_hi_hdtb,
+    "ja_combined":       process_ja_gsd,
     "ja_gsd":            process_ja_gsd,
 }
 
 
 def main(dataset_name):
     paths = get_default_paths()
-    print("Processing %s" % dataset_name)
+    print("Processing lemma_classifier %s" % dataset_name)
 
     # obviously will want to multiplex to multiple languages / datasets
     if dataset_name in DATASET_MAPPING:
         DATASET_MAPPING[dataset_name](paths, dataset_name)
     else:
         raise UnknownDatasetError(dataset_name, f"dataset {dataset_name} currently not handled by prepare_lemma_classifier.py")
-    print("Done processing %s" % dataset_name)
+    print("Done processing lemma_classifier %s" % dataset_name)
 
 if __name__ == '__main__':
     main(sys.argv[1])

--- a/stanza/utils/datasets/prepare_lemma_classifier.py
+++ b/stanza/utils/datasets/prepare_lemma_classifier.py
@@ -35,6 +35,18 @@ def process_treebank(paths, short_name, word, upos, allowed_lemmas, sections=SEC
 
     return output_filenames
 
+def convert_en_combined_docs(docs, target_word, target_upos):
+    sentences = [ [], [], [] ]
+
+    for section_docs, section_sentences in zip(docs, sentences):
+        for filename, doc in section_docs:
+            processor = prepare_dataset.DataProcessor(target_word=target_word, target_upos=target_upos, allowed_lemmas=".*")
+            new_sentences = processor.process_document(doc, save_name=None)
+            print("Read %d sentences from %s" % (len(new_sentences), filename))
+            section_sentences.extend(new_sentences)
+
+    return sentences
+
 def process_en_combined(paths, short_name):
     udbase_dir = paths["UDBASE"]
     output_dir = paths["LEMMA_CLASSIFIER_DATA_DIR"]
@@ -43,26 +55,24 @@ def process_en_combined(paths, short_name):
     train_treebanks = ["UD_English-EWT", "UD_English-GUM", "UD_English-GUMReddit", "UD_English-LinES"]
     test_treebanks = ["UD_English-PUD", "UD_English-Pronouns"]
 
-    target_word = "'s"
-    target_upos = ["AUX"]
-
-    sentences = [ [], [], [] ]
+    docs = [ [], [], [] ]
     for treebank in train_treebanks:
         for section_idx, section in enumerate(SECTIONS):
             filename = find_treebank_dataset_file(treebank, udbase_dir, section, "conllu", fail=True)
             doc = CoNLL.conll2doc(filename)
-            processor = prepare_dataset.DataProcessor(target_word=target_word, target_upos=target_upos, allowed_lemmas=".*")
-            new_sentences = processor.process_document(doc, save_name=None)
-            print("Read %d sentences from %s" % (len(new_sentences), filename))
-            sentences[section_idx].extend(new_sentences)
+            docs[section_idx].append((filename, doc))
+            print("Loaded %s" % filename)
     for treebank in test_treebanks:
         section = "test"
         filename = find_treebank_dataset_file(treebank, udbase_dir, section, "conllu", fail=True)
         doc = CoNLL.conll2doc(filename)
-        processor = prepare_dataset.DataProcessor(target_word=target_word, target_upos=target_upos, allowed_lemmas=".*")
-        new_sentences = processor.process_document(doc, save_name=None)
-        print("Read %d sentences from %s" % (len(new_sentences), filename))
-        sentences[2].extend(new_sentences)
+        # only test set for these documents
+        docs[2].append((filename, doc))
+        print("Loaded %s" % filename)
+
+    target_word = "'s"
+    target_upos = ["AUX"]
+    sentences = convert_en_combined_docs(docs, target_word, target_upos)
 
     for section, section_sentences in zip(SECTIONS, sentences):
         output_filename = os.path.join(output_dir, "%s.%s.lemma" % (short_name, section))

--- a/stanza/utils/datasets/prepare_lemma_classifier.py
+++ b/stanza/utils/datasets/prepare_lemma_classifier.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import os
 import sys
 
@@ -8,6 +9,8 @@ from stanza.models.common.short_name_to_treebank import short_name_to_treebank
 from stanza.utils.conll import CoNLL
 
 SECTIONS = ("train", "dev", "test")
+
+Target = namedtuple("Target", "word upos filename")
 
 def process_treebank(paths, short_name, word, upos, allowed_lemmas, sections=SECTIONS, dataset_to_use=None):
     if dataset_to_use is None:
@@ -42,7 +45,7 @@ def convert_en_combined_docs(docs, target_word, target_upos):
         for filename, doc in section_docs:
             processor = prepare_dataset.DataProcessor(target_word=target_word, target_upos=target_upos, allowed_lemmas=".*")
             new_sentences = processor.process_document(doc, save_name=None)
-            print("Read %d sentences from %s" % (len(new_sentences), filename))
+            print("Extracted %d sentences from %s" % (len(new_sentences), filename))
             section_sentences.extend(new_sentences)
 
     return sentences
@@ -70,14 +73,14 @@ def process_en_combined(paths, short_name):
         docs[2].append((filename, doc))
         print("Loaded %s" % filename)
 
-    target_word = "'s"
-    target_upos = ["AUX"]
-    sentences = convert_en_combined_docs(docs, target_word, target_upos)
+    for target_word, target_upos, target_filename in DATASET_TARGETS["en_combined"]:
+        print("Processing %s_%s" % (target_word, target_upos))
+        sentences = convert_en_combined_docs(docs, target_word, target_upos)
 
-    for section, section_sentences in zip(SECTIONS, sentences):
-        output_filename = os.path.join(output_dir, "%s.%s.lemma" % (short_name, section))
-        prepare_dataset.DataProcessor.write_output_file(output_filename, target_upos, section_sentences)
-        print("Wrote %s sentences to %s" % (len(section_sentences), output_filename))
+        for section, section_sentences in zip(SECTIONS, sentences):
+            output_filename = os.path.join(output_dir, "%s.%s.%s.lemma" % (short_name, target_filename, section))
+            prepare_dataset.DataProcessor.write_output_file(output_filename, target_upos, section_sentences)
+            print("Wrote %s sentences to %s" % (len(section_sentences), output_filename))
 
 def process_ja_gsd(paths, short_name):
     # this one looked promising, but only has 10 total dev & test cases
@@ -143,6 +146,12 @@ DATASET_MAPPING = {
     "ja_gsd":            process_ja_gsd,
 }
 
+DATASET_TARGETS = {
+    "en_combined":       [
+        Target("'s",  "AUX",  "s"),   # since we don't want filenames with 's
+        Target("her", "PRON", "her"),
+    ]
+}
 
 def main(dataset_name):
     paths = get_default_paths()

--- a/stanza/utils/training/run_lemma.py
+++ b/stanza/utils/training/run_lemma.py
@@ -156,17 +156,23 @@ def run_treebank(mode, paths, treebank, short_name, command_args, extra_args):
             from stanza.models.lemma import attach_lemma_classifier
             from stanza.utils.training import run_lemma_classifier
 
-            lc_charlm_args = ['--no_charlm'] if command_args.charlm is None else ['--charlm', command_args.charlm]
-            lemma_classifier_args = [treebank] + lc_charlm_args
-            if command_args.force:
-                lemma_classifier_args.append('--force')
-            run_lemma_classifier.main(lemma_classifier_args)
+            if short_name in prepare_lemma_classifier.DATASET_TARGETS:
+                lc_treebanks = ["%s.%s" % (short_name, lc.filename) for lc in prepare_lemma_classifier.DATASET_TARGETS[short_name]]
+            else:
+                lc_treebanks = [short_name]
+            for lc_treebank in lc_treebanks:
+                lc_charlm_args = ['--no_charlm'] if command_args.charlm is None else ['--charlm', command_args.charlm]
+                lemma_classifier_args = [lc_treebank] + lc_charlm_args
+                if command_args.force:
+                    lemma_classifier_args.append('--force')
+                run_lemma_classifier.main(lemma_classifier_args)
 
             save_name = build_model_filename(paths, short_name, command_args, extra_args)
-            # TODO: use a temp path for the lemma_classifier or keep it somewhere
+            # TODO: use a temp path for the lemma_classifier or keep it somewhere?
+            lc_filenames = ['saved_models/lemma_classifier/%s_lemma_classifier.pt' % lc_treebank for lc_treebank in lc_treebanks]
             attach_args = ['--input', save_name,
                            '--output', save_name,
-                           '--classifier', 'saved_models/lemma_classifier/%s_lemma_classifier.pt' % short_name]
+                           '--classifier', *lc_filenames]
             attach_lemma_classifier.main(attach_args)
 
             # now we rerun the dev set - the HI in particular demonstrates some good improvement


### PR DESCRIPTION
Upgrade the lemma classifier in a couple important ways:

- enforce `weights_only=True` when loading the lemma classifier.  This in an important first step to cleaning up the leftover `weights_only` security issues, as reported in https://github.com/stanfordnlp/stanza/security/advisories/GHSA-v5jw-96jm-7h2c#event-715139
- we have a lemma classifier for ja_gsd.  that should also be attached to ja_combined
- train & attach two lemma classifiers to en_combined - both `'s` and `her` can be classified reliably from the available data