### PR TITLE
Lemmatizer model path options

### DIFF
--- a/stanza/models/common/utils.py
+++ b/stanza/models/common/utils.py
@@ -617,11 +617,12 @@ def embedding_name(args):
     such as electra, roberta, etc.  Maybe even phobert for VI, for example
     """
     embedding = "nocharlm"
-    if args['wordvec_pretrain_file'] is None and args['wordvec_file'] is None:
+    # lemmatizer can use charlm w/o using pretrain, for example
+    if 'wordvec_pretrain_file' in args and args['wordvec_pretrain_file'] is None and args['wordvec_file'] is None:
         embedding = "nopretrain"
-    if args.get('charlm', True) and (args['charlm_forward_file'] or args['charlm_backward_file']):
+    if args.get('charlm', True) and (args.get('charlm_forward_file') or args.get('charlm_backward_file')):
         embedding = "charlm"
-    if args['bert_model']:
+    if args.get('bert_model'):
         if args['bert_model'] in TRANSFORMER_NICKNAMES:
             embedding = TRANSFORMER_NICKNAMES[args['bert_model']]
         else:
@@ -636,6 +637,7 @@ def standard_model_file_name(args, model_type, **kwargs):
     The expectation is that the args will have something like
 
       parser.add_argument('--save_name', type=str, default="{shorthand}_{embedding}_parser.pt", help="File name to save the model")
+      parser.add_argument('--save_dir', type=str, default='saved_models/lemma', help='Root dir for saving models.')
 
     Then the model shorthand, embedding type, and other args will be
     turned into arguments in a format string

--- a/stanza/models/lemma_classifier/evaluate_many.py
+++ b/stanza/models/lemma_classifier/evaluate_many.py
@@ -58,10 +58,10 @@ def main():
     parser.add_argument("--eval_file", type=str, help="path to evaluation file")
 
     # Args specific to several model eval
-    parser.add_argument("--base_path", type=str, default=None, help="path to dir for eval")
+    parser.add_argument("--save_dir", type=str, default=None, help="path to dir for eval")
 
     args = parser.parse_args()
-    evaluate_n_models(args.base_path, args)
+    evaluate_n_models(args.save_dir, args)
 
 
 if __name__ == "__main__":

--- a/stanza/models/lemma_classifier/evaluate_models.py
+++ b/stanza/models/lemma_classifier/evaluate_models.py
@@ -195,21 +195,26 @@ def main(args=None, predefined_args=None):
     parser.add_argument('--charlm_shorthand', type=str, default=None, help="Shorthand for character-level language model training corpus.")
     parser.add_argument("--charlm_forward_file", type=str, default=os.path.join(os.path.dirname(__file__), "charlm_files", "1billion_forward.pt"), help="Path to forward charlm file")
     parser.add_argument("--charlm_backward_file", type=str, default=os.path.join(os.path.dirname(__file__), "charlm_files", "1billion_backwards.pt"), help="Path to backward charlm file")
-    parser.add_argument("--save_name", type=str, default=os.path.join(os.path.dirname(__file__), "saved_models", "lemma_classifier_model.pt"), help="Path to model save file")
+    parser.add_argument("--save_dir", type=str, default="saved_models/lemma_classifier", help="Which directory for saving lemma classifiers")
+    parser.add_argument("--save_name", type=str, default="lemma_classifier_model.pt", help="Path to model save file")
     parser.add_argument("--model_type", type=str, default="roberta", help="Which transformer to use ('bert' or 'roberta' or 'lstm')")
     parser.add_argument("--bert_model", type=str, default=None, help="Use a specific transformer instead of the default bert/roberta")
     parser.add_argument("--eval_file", type=str, help="path to evaluation file")
 
     args = parser.parse_args(args) if not predefined_args else predefined_args
 
-    logger.info("Running training script with the following args:")
+    save_name = args.save_name
+    if args.save_dir and not save_name.startswith(args.save_dir):
+        save_name = os.path.join(args.save_dir, save_name)
+
+    logger.info("Running evaluation script with the following args:")
     args = vars(args)
     for arg in args:
         logger.info(f"{arg}: {args[arg]}")
     logger.info("------------------------------------------------------------")
 
-    logger.info(f"Attempting evaluation of model from {args['save_name']} on file {args['eval_file']}")
-    model = LemmaClassifier.load(args['save_name'], args)
+    logger.info(f"Attempting evaluation of model from {save_name} on file {args['eval_file']}")
+    model = LemmaClassifier.load(save_name, args)
 
     mcc_results, confusion, acc, weighted_f1 = evaluate_model(model, args['eval_file'])
 

--- a/stanza/models/lemma_classifier/train_lstm_model.py
+++ b/stanza/models/lemma_classifier/train_lstm_model.py
@@ -87,7 +87,8 @@ def build_argparse():
     parser.add_argument("--upos_emb_dim", type=int, default=20, help="Dimension size for UPOS tag embeddings.")
     parser.add_argument("--use_attn", action='store_true', dest='attn', default=False, help='Whether to use multihead attention instead of LSTM.')
     parser.add_argument("--num_heads", type=int, default=0, help="Number of heads to use for multihead attention.")
-    parser.add_argument("--save_name", type=str, default=os.path.join(os.path.dirname(__file__), "saved_models", "lemma_classifier_model_weighted_loss_charlm_new.pt"), help="Path to model save file")
+    parser.add_argument("--save_dir", type=str, default="saved_models/lemma_classifier", help="Which directory for saving lemma classifiers")
+    parser.add_argument("--save_name", type=str, default="lemma_classifier_model_weighted_loss_charlm_new.pt", help="Path to model save file")
     parser.add_argument("--lr", type=float, default=0.001, help="learning rate")
     parser.add_argument("--num_epochs", type=float, default=10, help="Number of training epochs")
     parser.add_argument("--batch_size", type=int, default=DEFAULT_BATCH_SIZE, help="Number of examples to include in each batch")
@@ -109,6 +110,8 @@ def main(args=None, predefined_args=None):
     use_attention = args.attn
     num_heads = args.num_heads
     save_name = args.save_name
+    if args.save_dir and not save_name.startswith(args.save_dir):
+        save_name = os.path.join(args.save_dir, save_name)
     lr = args.lr
     num_epochs = args.num_epochs
     train_file = args.train_file

--- a/stanza/models/lemma_classifier/train_many.py
+++ b/stanza/models/lemma_classifier/train_many.py
@@ -134,7 +134,7 @@ def main():
     # Multi-model train args
     parser.add_argument("--multi_train_type", type=str, default="lstm", help="Whether you are attempting to multi-train an LSTM or transformer")
     parser.add_argument("--multi_train_count", type=int, default=5, help="Number of each model to build")
-    parser.add_argument("--base_path", type=str, default=None, help="Path to start generating model type for.")
+    parser.add_argument("--save_dir", type=str, default=None, help="Path to start generating model type for.")
     parser.add_argument("--change_param", type=str, default=None, help="Which hyperparameter to change when training")
 
 
@@ -142,11 +142,11 @@ def main():
 
     if args.multi_train_type == "lstm":
         train_n_models(num_models=args.multi_train_count,
-                       base_path=args.base_path,
+                       base_path=args.save_dir,
                        args=args)
     elif args.multi_train_type == "tfmr":
         train_n_tfmrs(num_models=args.multi_train_count,
-                      base_path=args.base_path,
+                      base_path=args.save_dir,
                       args=args)
     else:
         raise ValueError(f"Improper input {args.multi_train_type}")

--- a/stanza/models/lemma_classifier/train_transformer_model.py
+++ b/stanza/models/lemma_classifier/train_transformer_model.py
@@ -79,7 +79,8 @@ class TransformerBaselineTrainer(BaseLemmaClassifierTrainer):
 def main(args=None, predefined_args=None):
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("--save_name", type=str, default=os.path.join(os.path.dirname(os.path.dirname(__file__)), "saved_models", "big_model_roberta_weighted_loss.pt"), help="Path to model save file")
+    parser.add_argument("--save_dir", type=str, default="saved_models/lemma_classifier", help="Which directory for saving lemma classifiers")
+    parser.add_argument("--save_name", type=str, default="big_model_roberta_weighted_loss.pt", help="Path to model save file")
     parser.add_argument("--num_epochs", type=float, default=10, help="Number of training epochs")
     parser.add_argument("--train_file", type=str, default=os.path.join(os.path.dirname(os.path.dirname(__file__)), "test_sets", "combined_train.txt"), help="Full path to training file")
     parser.add_argument("--model_type", type=str, default="roberta", help="Which transformer to use ('bert' or 'roberta')")
@@ -93,6 +94,8 @@ def main(args=None, predefined_args=None):
     args = parser.parse_args(args) if predefined_args is None else predefined_args
 
     save_name = args.save_name
+    if args.save_dir and not save_name.startswith(args.save_dir):
+        save_name = os.path.join(args.save_dir, save_name)
     num_epochs = args.num_epochs
     train_file = args.train_file
     loss_fn = args.loss_fn

--- a/stanza/models/lemmatizer.py
+++ b/stanza/models/lemmatizer.py
@@ -119,16 +119,8 @@ def all_lowercase(doc):
                 return False
     return True
 
-def build_model_filename(args):
-    embedding = "nocharlm"
-    if args['charlm'] and args['charlm_forward_file']:
-        embedding = "charlm"
-    model_file = args['save_name'].format(shorthand=args['shorthand'],
-                                          embedding=embedding)
-    model_dir = os.path.split(model_file)[0]
-    if not model_dir.startswith(args['save_dir']):
-        model_file = os.path.join(args['save_dir'], model_file)
-    return model_file
+def model_file_name(args):
+    return utils.standard_model_file_name(args, "lemmatizer")
 
 def train(args):
     # load data
@@ -142,7 +134,7 @@ def train(args):
     dev_batch = DataLoader(dev_doc, args['batch_size'], args, vocab=vocab, evaluation=True)
 
     utils.ensure_dir(args['save_dir'])
-    model_file = build_model_filename(args)
+    model_file = model_file_name(args)
     logger.info("Using full savename: %s", model_file)
 
     # gold path
@@ -259,7 +251,7 @@ def train(args):
 def evaluate(args):
     # file paths
     system_pred_file = args['output_file']
-    model_file = build_model_filename(args)
+    model_file = model_file_name(args)
 
     # load model
     trainer = Trainer(model_file=model_file, device=args['device'], args=args)

--- a/stanza/utils/training/run_lemma.py
+++ b/stanza/utils/training/run_lemma.py
@@ -67,7 +67,7 @@ def build_model_filename(paths, short_name, command_args, extra_args):
                   "--mode", "train"]
     train_args = train_args + charlm_args + extra_args
     args = lemmatizer.parse_args(train_args)
-    save_name = lemmatizer.build_model_filename(args)
+    save_name = lemmatizer.model_file_name(args)
     return save_name
 
 def run_treebank(mode, paths, treebank, short_name, command_args, extra_args):

--- a/stanza/utils/training/run_lemma.py
+++ b/stanza/utils/training/run_lemma.py
@@ -37,6 +37,9 @@ def add_lemma_args(parser):
     parser.add_argument('--no_lemma_classifier', dest='lemma_classifier', action='store_false',
                         help="Don't use the lemma classifier datasets.  Default is to build lemma classifier as part of the original lemmatizer if the charlm is used")
 
+    parser.add_argument('--lemma_classifier_save_dir', default=None, type=str,
+                        help="Save the lemma classifiers in this directory instead of the default lemma classifier home")
+
 def build_model_filename(paths, short_name, command_args, extra_args):
     """
     Figure out what the model savename will be, taking into account the model settings.
@@ -156,6 +159,7 @@ def run_treebank(mode, paths, treebank, short_name, command_args, extra_args):
             from stanza.models.lemma import attach_lemma_classifier
             from stanza.utils.training import run_lemma_classifier
 
+            lc_save_dir = command_args.lemma_classifier_save_dir
             if short_name in prepare_lemma_classifier.DATASET_TARGETS:
                 lc_treebanks = ["%s.%s" % (short_name, lc.filename) for lc in prepare_lemma_classifier.DATASET_TARGETS[short_name]]
             else:
@@ -165,11 +169,14 @@ def run_treebank(mode, paths, treebank, short_name, command_args, extra_args):
                 lemma_classifier_args = [lc_treebank] + lc_charlm_args
                 if command_args.force:
                     lemma_classifier_args.append('--force')
+                if lc_save_dir:
+                    lemma_classifier_args.extend(['--save_dir', lc_save_dir])
                 run_lemma_classifier.main(lemma_classifier_args)
 
+            if lc_save_dir is None:
+                lc_save_dir = os.path.join('saved_models', 'lemma_classifier')
             save_name = build_model_filename(paths, short_name, command_args, extra_args)
-            # TODO: use a temp path for the lemma_classifier or keep it somewhere?
-            lc_filenames = ['saved_models/lemma_classifier/%s_lemma_classifier.pt' % lc_treebank for lc_treebank in lc_treebanks]
+            lc_filenames = [os.path.join(lc_save_dir, '%s_lemma_classifier.pt' % lc_treebank) for lc_treebank in lc_treebanks]
             attach_args = ['--input', save_name,
                            '--output', save_name,
                            '--classifier', *lc_filenames]

--- a/stanza/utils/training/run_lemma_classifier.py
+++ b/stanza/utils/training/run_lemma_classifier.py
@@ -16,7 +16,12 @@ def add_lemma_args(parser):
                         help='Model type to use.  {}'.format(", ".join(x.name for x in ModelType)))
 
 def build_model_filename(paths, short_name, command_args, extra_args):
-    return os.path.join("saved_models", "lemma_classifier", short_name + "_lemma_classifier.pt")
+    if not command_args.save_dir:
+        save_dir = os.path.join("saved_models", "lemma_classifier")
+    else:
+        save_dir = command_args.save_dir
+
+    return os.path.join(save_dir, short_name + "_lemma_classifier.pt")
 
 def run_treebank(mode, paths, treebank, short_name, command_args, extra_args):
     short_language, dataset = short_name.split("_", 1)


### PR DESCRIPTION
Simplify / refactor the lemmatizer filename and allow for the lemma classifiers to go to a directory other than `saved_models/lemma_classifier`.  The goal is to make it easier to change output directories for writing tests