### PR TITLE
Unify embeddings

### DIFF
--- a/stanza/models/classifiers/cnn_classifier.py
+++ b/stanza/models/classifiers/cnn_classifier.py
@@ -532,10 +532,6 @@ class CNNClassifier(BaseClassifier):
             params["bert_lora"] = get_peft_model_state_dict(self.bert_model, adapter_name=self.peft_name)
         return params
 
-    def preprocess_data(self, sentences):
-        sentences = [data.update_text(s, self.config.wordvec_type) for s in sentences]
-        return sentences
-
     def extract_sentences(self, doc):
         # TODO: tokens or words better here?
         return [[token.text for token in sentence.tokens] for sentence in doc.sentences]

--- a/stanza/models/classifiers/cnn_classifier.py
+++ b/stanza/models/classifiers/cnn_classifier.py
@@ -142,8 +142,7 @@ class CNNClassifier(BaseClassifier):
         # you want to spend a long time debugging this
         self.unk = nn.Parameter(torch.randn(self.embedding_dim) / np.sqrt(self.embedding_dim) / 10.0)
 
-        # replacing NBSP picks up a whole bunch of words for VI
-        self.vocab_map = { word.replace('\xa0', ' '): i for i, word in enumerate(pretrain.vocab) }
+        self.emb_vocab = pretrain.vocab
 
         if self.config.extra_wordvec_method is not ExtraVectors.NONE:
             if not extra_vocab:
@@ -337,16 +336,16 @@ class CNNClassifier(BaseClassifier):
         # assume all pieces are on the same device
         device = next(self.parameters()).device
 
-        vocab_map = self.vocab_map
+        emb_vocab = self.emb_vocab
         def map_word(word):
-            idx = vocab_map.get(word, None)
-            if idx is not None:
+            idx = emb_vocab.unit2id(word)
+            if idx != UNK_ID:
                 return idx
-            if word[-1] == "'":
-                idx = vocab_map.get(word[:-1], None)
-                if idx is not None:
+            if len(word) > 1 and word[-1] == "'":
+                idx = emb_vocab.unit2id(word[:-1])
+                if idx != UNK_ID:
                     return idx
-            return vocab_map.get(word.lower(), UNK_ID)
+            return emb_vocab.unit2id(word.lower())
 
         inputs = [x.text if isinstance(x, SentimentDatum) else x for x in inputs]
         # we will pad each phrase so either it matches the longest

--- a/stanza/models/constituency/lstm_model.py
+++ b/stanza/models/constituency/lstm_model.py
@@ -213,9 +213,9 @@ class ConstituencyComposition(Enum):
     UNTIED_KEY            = 10
 
 class LSTMModel(BaseModel, nn.Module):
-    def __init__(self, pretrain, forward_charlm, backward_charlm, bert_model, bert_tokenizer, force_bert_saved, peft_name, transitions, constituents, tags, words, rare_words, root_labels, constituent_opens, unary_limit, args):
+    def __init__(self, pt, forward_charlm, backward_charlm, bert_model, bert_tokenizer, force_bert_saved, peft_name, transitions, constituents, tags, words, rare_words, root_labels, constituent_opens, unary_limit, args):
         """
-        pretrain: a Pretrain object
+        pt: a Pretrain object
         transitions: a list of all possible transitions which will be
           used to build trees
         constituents: a list of all possible constituents in the treebank
@@ -241,14 +241,14 @@ class LSTMModel(BaseModel, nn.Module):
         self.args = args
         self.unsaved_modules = []
 
-        emb_matrix = pretrain.emb
+        emb_matrix = pt.emb
         self.add_unsaved_module('embedding', nn.Embedding.from_pretrained(emb_matrix, freeze=True))
 
         # replacing NBSP picks up a whole bunch of words for VI
-        self.vocab_map = { word.replace('\xa0', ' '): i for i, word in enumerate(pretrain.vocab) }
+        self.vocab_map = { word.replace('\xa0', ' '): i for i, word in enumerate(pt.vocab) }
         # precompute tensors for the word indices
         # the tensors should be put on the GPU if needed by calling to(device)
-        self.register_buffer('vocab_tensors', torch.tensor(range(len(pretrain.vocab)), requires_grad=False))
+        self.register_buffer('vocab_tensors', torch.tensor(range(len(pt.vocab)), requires_grad=False))
         self.vocab_size = emb_matrix.shape[0]
         self.embedding_dim = emb_matrix.shape[1]
 

--- a/stanza/models/constituency/lstm_model.py
+++ b/stanza/models/constituency/lstm_model.py
@@ -244,12 +244,7 @@ class LSTMModel(BaseModel, nn.Module):
         emb_matrix = pt.emb
         self.add_unsaved_module('embedding', nn.Embedding.from_pretrained(emb_matrix, freeze=True))
 
-        # replacing NBSP picks up a whole bunch of words for VI
-        self.vocab_map = { word.replace('\xa0', ' '): i for i, word in enumerate(pt.vocab) }
-        # precompute tensors for the word indices
-        # the tensors should be put on the GPU if needed by calling to(device)
-        self.register_buffer('vocab_tensors', torch.tensor(range(len(pt.vocab)), requires_grad=False))
-        self.vocab_size = emb_matrix.shape[0]
+        self.emb_vocab = pt.vocab
         self.embedding_dim = emb_matrix.shape[1]
 
         self.constituents = sorted(list(constituents))
@@ -670,7 +665,7 @@ class LSTMModel(BaseModel, nn.Module):
         return output_layers
 
     def num_words_known(self, words):
-        return sum(word in self.vocab_map or word.lower() in self.vocab_map for word in words)
+        return sum(word in self.emb_vocab or word.lower() in self.emb_vocab for word in words)
 
     @property
     def retag_method(self):
@@ -737,12 +732,12 @@ class LSTMModel(BaseModel, nn.Module):
         """
         device = next(self.parameters()).device
 
-        vocab_map = self.vocab_map
+        emb_vocab = self.emb_vocab
         def map_word(word):
-            idx = vocab_map.get(word, None)
-            if idx is not None:
+            idx = emb_vocab.unit2id(word)
+            if idx != UNK_ID:
                 return idx
-            return vocab_map.get(word.lower(), UNK_ID)
+            return emb_vocab.unit2id(word.lower())
 
         all_word_inputs = []
         all_word_labels = [[word.children[0].label for word in tagged_words]
@@ -750,7 +745,7 @@ class LSTMModel(BaseModel, nn.Module):
 
         for sentence_idx, tagged_words in enumerate(tagged_word_lists):
             word_labels = all_word_labels[sentence_idx]
-            word_idx = torch.stack([self.vocab_tensors[map_word(word.children[0].label)] for word in tagged_words])
+            word_idx = torch.tensor([map_word(word.children[0].label) for word in tagged_words], device=device)
             word_input = self.embedding(word_idx)
 
             # this occasionally learns UNK at train time

--- a/stanza/models/constituency/trainer.py
+++ b/stanza/models/constituency/trainer.py
@@ -178,7 +178,7 @@ class Trainer(BaseTrainer):
             if all(isinstance(x, str) for x in transitions):
                 transitions = [Transition.from_repr(x) for x in transitions]
 
-            model = LSTMModel(pretrain=pt,
+            model = LSTMModel(pt=pt,
                               forward_charlm=forward_charlm,
                               backward_charlm=backward_charlm,
                               bert_model=bert_model,

--- a/stanza/models/lemma_classifier/lstm_model.py
+++ b/stanza/models/lemma_classifier/lstm_model.py
@@ -25,7 +25,6 @@ class LemmaClassifierLSTM(LemmaClassifier):
                  use_charlm=False, charlm_forward_file=None, charlm_backward_file=None):
         """
         Args:
-            vocab_size (int): Size of the vocab being used (if custom vocab)
             output_dim (int): Size of output vector from MLP layer
             upos_to_id (Mapping[str, int]): A dictionary mapping UPOS tag strings to their respective IDs
             pt_embedding (Pretrain): pretrained embeddings
@@ -51,8 +50,7 @@ class LemmaClassifierLSTM(LemmaClassifier):
 
         emb_matrix = pt_embedding.emb
         self.add_unsaved_module("embeddings", nn.Embedding.from_pretrained(emb_matrix, freeze=True))
-        self.vocab_map = { word.replace('\xa0', ' '): i for i, word in enumerate(pt_embedding.vocab) }
-        self.vocab_size = emb_matrix.shape[0]
+        self.emb_vocab = pt_embedding.vocab
         self.embedding_dim = emb_matrix.shape[1]
 
         self.known_words = known_words
@@ -144,7 +142,7 @@ class LemmaClassifierLSTM(LemmaClassifier):
         token_ids = []
         delta_token_ids = []
         for words in sentences:
-            sentence_token_ids = [self.vocab_map.get(word.lower(), UNK_ID) for word in words]
+            sentence_token_ids = self.emb_vocab.map([word.lower() for word in words])
             sentence_token_ids = torch.tensor(sentence_token_ids, device=device)
             token_ids.append(sentence_token_ids)
 

--- a/stanza/tests/pipeline/test_pipeline_sentiment_processor.py
+++ b/stanza/tests/pipeline/test_pipeline_sentiment_processor.py
@@ -20,7 +20,7 @@ class TestSentimentPipeline:
     @pytest.fixture(scope="class")
     def pipeline(self):
         """
-        A reusable pipeline with the NER module
+        A reusable pipeline with the sentiment module
         """
         gc.collect()
         return stanza.Pipeline(dir=TEST_MODELS_DIR, processors="tokenize,sentiment")

--- a/stanza/tests/pipeline/test_pipeline_sentiment_processor.py
+++ b/stanza/tests/pipeline/test_pipeline_sentiment_processor.py
@@ -23,7 +23,7 @@ class TestSentimentPipeline:
         A reusable pipeline with the sentiment module
         """
         gc.collect()
-        return stanza.Pipeline(dir=TEST_MODELS_DIR, processors="tokenize,sentiment")
+        return stanza.Pipeline(dir=TEST_MODELS_DIR, processors="tokenize,sentiment", download_method=None)
 
     def test_simple(self, pipeline):
         results = []

--- a/stanza/tests/setup.py
+++ b/stanza/tests/setup.py
@@ -39,6 +39,7 @@ logger.info("DOWNLOADING MODELS")
 
 stanza.download(lang='en', model_dir=models_dir, logging_level='info')
 stanza.download(lang='en', model_dir=models_dir, package=None, processors={"ner":"ncbi_disease"})
+stanza.download(lang='en', model_dir=models_dir, logging_level='info', processors="tokenize,sentiment")
 stanza.download(lang='en', model_dir=models_dir, package='default_accurate', processors="lemma")
 stanza.download(lang='fr', model_dir=models_dir, logging_level='info')
 # Latin ITTB has no case information for the lemmatizer


### PR DESCRIPTION
Go through each of the models which don't use `PretrainedWordVocab` from the `Pretrain` and change them to use that vocab directly instead of storing the word vectors themselves.

Note that many models - POS and depparse included - have additional finetuned vectors which do not go through the normalization.  This may be an issue when handling word vector families that need certain kinds of normalization, specifically OTA and its different orthography