### PR TITLE
Make rootroo the default word vectors for MYV (the models are also re…

### DIFF
--- a/stanza/resources/default_packages.py
+++ b/stanza/resources/default_packages.py
@@ -184,7 +184,7 @@ specific_default_pretrains = {
     "mr":      "fasttextwiki",
     "mt":      "fasttextwiki",
     "my":      "ucsy",
-    "myv":     "mokha",
+    "myv":     "rootroo",
     "nb":      "conll17",
     "nds":     "fasttext157",
     "nl":      "conll17",


### PR DESCRIPTION
Make rootroo the default word vectors for MYV (the models are also rebuilt with these word vectors)

These vectors work better on POS:

mokha
dev:
   UPOS    XPOS  UFeats AllTags
  90.21   89.32   81.41   77.95
test:
   UPOS    XPOS  UFeats AllTags
  85.35   84.37   77.09   70.85

rootroo
dev:
   UPOS    XPOS  UFeats AllTags
  90.81   89.82   82.50   79.04
test:
   UPOS    XPOS  UFeats AllTags
  86.33   85.23   77.40   71.24

but on depparse, it is a little less clear:

mokha
dev:
  UAS   LAS  CLAS  MLAS  BLEX
78.40 68.17 64.06 62.06 64.06
test:
  UAS   LAS  CLAS  MLAS  BLEX
69.84 56.33 50.61 47.61 50.61

rootroo
dev:
  UAS   LAS  CLAS  MLAS  BLEX
79.09 69.15 64.92 62.56 64.92
test:
  UAS   LAS  CLAS  MLAS  BLEX
69.95 56.25 50.16 47.49 50.16
