### PR TITLE
Download test patch

### DIFF
--- a/.github/workflows/stanza-tests.yaml
+++ b/.github/workflows/stanza-tests.yaml
@@ -19,6 +19,7 @@ jobs:
           #. $CONDA_PREFIX/etc/profile.d/conda.sh
           . /home/stanzabuild/miniconda3/etc/profile.d/conda.sh
           conda activate stanza
+          export HF_HUB_DISABLE_XET=1   # newer downloads are intermittently failing...
           export STANZA_TEST_HOME=/scr/stanza_test
           export CORENLP_HOME=$STANZA_TEST_HOME/corenlp_dir
           export CLASSPATH=$CORENLP_HOME/*:

--- a/stanza/tests/pipeline/test_core.py
+++ b/stanza/tests/pipeline/test_core.py
@@ -65,31 +65,100 @@ def test_pretagged():
 
 def test_download_missing_ner_model():
     """
-    Test that the pipeline will automatically download missing models
+    Test that the pipeline will automatically download missing models.
+
+    Tokenize is pre-seeded (already "downloaded"); ner, charlm, and pretrain
+    are absent and should be fetched automatically by Pipeline.  request_file
+    is mocked so no network traffic is generated.  All models that Pipeline
+    will load are restored from TEST_MODELS_DIR so torch can open them.
     """
     with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
-        stanza.download("en", model_dir=test_dir, processors="tokenize", package="combined", verbose=False)
-        pipe = stanza.Pipeline("en", model_dir=test_dir, processors="tokenize,ner", package={"ner": ("ontonotes_charlm")})
+        # Tokenize was already present; the rest are "downloaded" by Pipeline.
+        # All of them need real content because Pipeline loads every processor.
+        model_rel_paths = [
+            "tokenize/combined.pt",
+            "mwt/combined.pt",
+            "ner/ontonotes-ww-multi_charlm.pt",
+            "forward_charlm/1billion.pt",
+            "backward_charlm/1billion.pt",
+            "pretrain/conll17.pt",
+        ]
+        real_files = {
+            os.path.join(test_dir, "en", rel): os.path.join(TEST_MODELS_DIR, "en", rel)
+            for rel in model_rel_paths
+        }
 
-        assert sorted(os.listdir(test_dir)) == ['en', 'resources.json']
-        en_dir = os.path.join(test_dir, 'en')
-        en_dir_listing = sorted(os.listdir(en_dir))
-        assert en_dir_listing == ['backward_charlm', 'forward_charlm', 'mwt', 'ner', 'pretrain', 'tokenize']
-        assert os.listdir(os.path.join(en_dir, 'ner')) == ['ontonotes_charlm.pt']
+        def fake_request_file_with_restore(url, path, *args, **kwargs):
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            if path.endswith("resources.json"):
+                real_path = os.path.join(TEST_MODELS_DIR, "resources.json")
+                with open(real_path, encoding="utf-8") as fin:
+                    data = fin.read()
+                with open(path, "w", encoding="utf-8") as fout:
+                    fout.write(data)
+            elif path in real_files:
+                shutil.copy2(real_files[path], path)
+            else:
+                open(path, "wb").close()
+
+        _seed_from_models_dir(test_dir, "en", ["tokenize/combined.pt", "mwt/combined.pt"])
+
+        with patch("stanza.resources.common.request_file", side_effect=fake_request_file_with_restore):
+            with patch("stanza.pipeline.core.download_resources_json", side_effect=lambda *a, **kw: fake_request_file_with_restore(None, os.path.join(a[0], "resources.json"))):
+                pipe = stanza.Pipeline("en", model_dir=test_dir, processors="tokenize,ner", package={"ner": ("ontonotes-ww-multi_charlm")})
+
+                assert sorted(os.listdir(test_dir)) == ['en', 'resources.json']
+                en_dir = os.path.join(test_dir, 'en')
+                en_dir_listing = sorted(os.listdir(en_dir))
+                assert en_dir_listing == ['backward_charlm', 'forward_charlm', 'mwt', 'ner', 'pretrain', 'tokenize']
+                assert os.listdir(os.path.join(en_dir, 'ner')) == ['ontonotes-ww-multi_charlm.pt']
 
 
 def test_download_missing_resources():
     """
-    Test that the pipeline will automatically download missing models
+    Test that the pipeline will automatically download missing models.
+
+    No models are pre-seeded; everything including resources.json must be
+    fetched by Pipeline.  request_file is mocked so no network traffic is
+    generated.  All models that Pipeline will load are restored from
+    TEST_MODELS_DIR so torch can open them.
     """
     with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
-        pipe = stanza.Pipeline("en", model_dir=test_dir, processors="tokenize,ner", package={"tokenize": "combined", "ner": "ontonotes_charlm"})
+        model_rel_paths = [
+            "tokenize/combined.pt",
+            "mwt/combined.pt",
+            "ner/ontonotes-ww-multi_charlm.pt",
+            "forward_charlm/1billion.pt",
+            "backward_charlm/1billion.pt",
+            "pretrain/conll17.pt",
+        ]
+        real_files = {
+            os.path.join(test_dir, "en", rel): os.path.join(TEST_MODELS_DIR, "en", rel)
+            for rel in model_rel_paths
+        }
 
-        assert sorted(os.listdir(test_dir)) == ['en', 'resources.json']
-        en_dir = os.path.join(test_dir, 'en')
-        en_dir_listing = sorted(os.listdir(en_dir))
-        assert en_dir_listing == ['backward_charlm', 'forward_charlm', 'mwt', 'ner', 'pretrain', 'tokenize']
-        assert os.listdir(os.path.join(en_dir, 'ner')) == ['ontonotes_charlm.pt']
+        def fake_request_file_with_restore(url, path, *args, **kwargs):
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            if path.endswith("resources.json"):
+                real_path = os.path.join(TEST_MODELS_DIR, "resources.json")
+                with open(real_path, encoding="utf-8") as fin:
+                    data = fin.read()
+                with open(path, "w", encoding="utf-8") as fout:
+                    fout.write(data)
+            elif path in real_files:
+                shutil.copy2(real_files[path], path)
+            else:
+                open(path, "wb").close()
+
+        with patch("stanza.resources.common.request_file", side_effect=fake_request_file_with_restore):
+            with patch("stanza.pipeline.core.download_resources_json", side_effect=lambda *a, **kw: fake_request_file_with_restore(None, os.path.join(a[0], "resources.json"))):
+                pipe = stanza.Pipeline("en", model_dir=test_dir, processors="tokenize,ner", package={"tokenize": "combined", "ner": "ontonotes-ww-multi_charlm"})
+
+                assert sorted(os.listdir(test_dir)) == ['en', 'resources.json']
+                en_dir = os.path.join(test_dir, 'en')
+                en_dir_listing = sorted(os.listdir(en_dir))
+                assert en_dir_listing == ['backward_charlm', 'forward_charlm', 'mwt', 'ner', 'pretrain', 'tokenize']
+                assert os.listdir(os.path.join(en_dir, 'ner')) == ['ontonotes-ww-multi_charlm.pt']
 
 
 def test_download_resources_overwrites():

--- a/stanza/tests/pipeline/test_core.py
+++ b/stanza/tests/pipeline/test_core.py
@@ -1,6 +1,7 @@
 import pytest
 import shutil
 import tempfile
+from unittest.mock import patch
 
 import stanza
 
@@ -10,6 +11,45 @@ from stanza.pipeline import core
 from stanza.resources.common import get_md5, load_resources_json
 
 pytestmark = pytest.mark.pipeline
+
+def _fake_request_file(url, path, *args, **kwargs):
+    """
+    Stand-in for request_file: creates or touches the destination file without
+    hitting the network.  This satisfies both "file exists" checks and mtime
+    comparisons (the file is always re-written, so the mtime always advances).
+    """
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if path.endswith("resources.json"):
+        # Copy the real resources.json so load_resources_json can parse it,
+        # but open for write so the mtime is updated on every call.
+        real_path = os.path.join(TEST_MODELS_DIR, "resources.json")
+        with open(real_path, encoding="utf-8") as fin:
+            data = fin.read()
+        with open(path, "w", encoding="utf-8") as fout:
+            fout.write(data)
+    else:
+        open(path, "wb").close()
+
+
+def _seed_from_models_dir(test_dir, lang, model_rel_paths):
+    """
+    Populate test_dir with the real resources.json and copies of the real
+    model files listed in model_rel_paths (e.g. ['tokenize/combined.pt',
+    'mwt/combined.pt']).  This lets Pipeline load processors without any
+    network access.
+
+    We use shutil.copy2 rather than os.symlink because symlinks require
+    elevated privileges on Windows.
+    """
+    real_resources = os.path.join(TEST_MODELS_DIR, "resources.json")
+    shutil.copy(real_resources, os.path.join(test_dir, "resources.json"))
+    for rel_path in model_rel_paths:
+        src = os.path.join(TEST_MODELS_DIR, lang, rel_path)
+        dst = os.path.join(test_dir, lang, rel_path)
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        if not os.path.exists(dst):
+            shutil.copy2(src, dst)
+
 
 def test_pretagged():
     """
@@ -57,15 +97,38 @@ def test_download_resources_overwrites():
     Test that the DOWNLOAD_RESOURCES method overwrites an existing resources.json
     """
     with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
-        pipe = stanza.Pipeline("en", model_dir=test_dir, processors="tokenize", package={"tokenize": "combined"})
+        model_rel_paths = ["tokenize/combined.pt", "mwt/combined.pt"]
+        _seed_from_models_dir(test_dir, "en", model_rel_paths)
 
-        assert sorted(os.listdir(test_dir)) == ['en', 'resources.json']
-        resources_path = os.path.join(test_dir, 'resources.json')
-        mod_time = os.path.getmtime(resources_path)
+        real_files = {
+            os.path.join(test_dir, "en", rel): os.path.join(TEST_MODELS_DIR, "en", rel)
+            for rel in model_rel_paths
+        }
 
-        pipe = stanza.Pipeline("en", model_dir=test_dir, processors="tokenize", package={"tokenize": "combined"})
-        new_mod_time = os.path.getmtime(resources_path)
-        assert mod_time != new_mod_time
+        def fake_request_file_with_restore(url, path, *args, **kwargs):
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            if path.endswith("resources.json"):
+                real_path = os.path.join(TEST_MODELS_DIR, "resources.json")
+                with open(real_path, encoding="utf-8") as fin:
+                    data = fin.read()
+                with open(path, "w", encoding="utf-8") as fout:
+                    fout.write(data)
+            elif path in real_files:
+                shutil.copy2(real_files[path], path)
+            else:
+                open(path, "wb").close()
+
+        with patch("stanza.resources.common.request_file", side_effect=fake_request_file_with_restore):
+            with patch("stanza.pipeline.core.download_resources_json", side_effect=lambda *a, **kw: fake_request_file_with_restore(None, os.path.join(a[0], "resources.json"))):
+                pipe = stanza.Pipeline("en", model_dir=test_dir, processors="tokenize", package={"tokenize": "combined"})
+
+                assert sorted(os.listdir(test_dir)) == ['en', 'resources.json']
+                resources_path = os.path.join(test_dir, 'resources.json')
+                mod_time = os.path.getmtime(resources_path)
+
+                pipe = stanza.Pipeline("en", model_dir=test_dir, processors="tokenize", package={"tokenize": "combined"})
+                new_mod_time = os.path.getmtime(resources_path)
+                assert mod_time != new_mod_time
 
 def test_reuse_resources_overwrites():
     """
@@ -143,7 +206,8 @@ def check_download_method_updates(download_method):
     Run a single test of creating a pipeline with a given download_method, checking that the model is updated
     """
     with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
-        stanza.download("en", model_dir=test_dir, processors="tokenize", package="combined")
+        model_rel_paths = ["tokenize/combined.pt", "mwt/combined.pt"]
+        _seed_from_models_dir(test_dir, "en", model_rel_paths)
 
         assert sorted(os.listdir(test_dir)) == ['en', 'resources.json']
         en_dir = os.path.join(test_dir, 'en')
@@ -151,12 +215,36 @@ def check_download_method_updates(download_method):
         assert en_dir_listing == ['mwt', 'tokenize']
         tokenize_path = os.path.join(en_dir, "tokenize", "combined.pt")
 
+        # Build a mapping from each seeded destination path back to its real
+        # source so the mock can restore real content when "re-downloading".
+        real_files = {
+            os.path.join(test_dir, "en", rel): os.path.join(TEST_MODELS_DIR, "en", rel)
+            for rel in model_rel_paths
+        }
+
+        def fake_request_file_with_restore(url, path, *args, **kwargs):
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            if path.endswith("resources.json"):
+                real_path = os.path.join(TEST_MODELS_DIR, "resources.json")
+                with open(real_path, encoding="utf-8") as fin:
+                    data = fin.read()
+                with open(path, "w", encoding="utf-8") as fout:
+                    fout.write(data)
+            elif path in real_files:
+                # Restore the real model so Pipeline can load it after "re-download"
+                shutil.copy2(real_files[path], path)
+            else:
+                open(path, "wb").close()
+
+        # Corrupt the tokenizer so the md5 check will trigger a re-download
         with open(tokenize_path, "w") as fout:
             fout.write("Unban mox opal!")
         mod_time = os.path.getmtime(tokenize_path)
 
-        pipe = stanza.Pipeline("en", model_dir=test_dir, processors="tokenize", package={"tokenize": "combined"}, download_method=download_method)
-        assert os.path.getmtime(tokenize_path) != mod_time
+        with patch("stanza.resources.common.request_file", side_effect=fake_request_file_with_restore):
+            with patch("stanza.pipeline.core.download_resources_json", side_effect=lambda *a, **kw: fake_request_file_with_restore(None, os.path.join(a[0], "resources.json"))):
+                pipe = stanza.Pipeline("en", model_dir=test_dir, processors="tokenize", package={"tokenize": "combined"}, download_method=download_method)
+                assert os.path.getmtime(tokenize_path) != mod_time
 
 def test_download_fixed():
     """

--- a/stanza/tests/resources/test_common.py
+++ b/stanza/tests/resources/test_common.py
@@ -109,15 +109,22 @@ def test_download_two_models():
     will fail.  Best way to update it will be two different models
     which download two different charlms
     """
-    with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
-        stanza.download("en", model_dir=test_dir, processors="ner", package={"ner": ["ontonotes_charlm", "anatem"]}, verbose=False)
-        assert sorted(os.listdir(test_dir)) == ['en', 'resources.json']
-        en_dir = os.path.join(test_dir, 'en')
-        en_dir_listing = sorted(os.listdir(en_dir))
-        assert en_dir_listing == ['backward_charlm', 'forward_charlm', 'ner', 'pretrain']
-        assert sorted(os.listdir(os.path.join(en_dir, 'ner'))) == ['anatem.pt', 'ontonotes_charlm.pt']
-        for i in en_dir_listing:
-            assert len(os.listdir(os.path.join(en_dir, i))) == 2
+    resources = common.load_resources_json(TEST_MODELS_DIR)
+
+    with patch("stanza.resources.common.request_file", side_effect=_fake_request_file):
+        with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+            resources_path = os.path.join(test_dir, "resources.json")
+            with open(resources_path, "w", encoding="utf-8") as fh:
+                json.dump(resources, fh)
+
+            stanza.download("en", model_dir=test_dir, processors="ner", package={"ner": ["ontonotes_charlm", "anatem"]}, verbose=False, download_json=False)
+            assert sorted(os.listdir(test_dir)) == ['en', 'resources.json']
+            en_dir = os.path.join(test_dir, 'en')
+            en_dir_listing = sorted(os.listdir(en_dir))
+            assert en_dir_listing == ['backward_charlm', 'forward_charlm', 'ner', 'pretrain']
+            assert sorted(os.listdir(os.path.join(en_dir, 'ner'))) == ['anatem.pt', 'ontonotes_charlm.pt']
+            for i in en_dir_listing:
+                assert len(os.listdir(os.path.join(en_dir, i))) == 2
 
 
 def test_process_pipeline_parameters():

--- a/stanza/tests/resources/test_common.py
+++ b/stanza/tests/resources/test_common.py
@@ -2,10 +2,12 @@
 Test various resource downloading functions from resources/common.py
 """
 
+import json
 import logging
 import os
 import pytest
 import tempfile
+from unittest.mock import patch
 
 import stanza
 from stanza.resources import common
@@ -43,22 +45,55 @@ def test_download_tokenize_mwt():
         # mwt should be added to the list
         assert len(pipeline.loaded_processors) == 2
 
+
+def _fake_request_file(url, path, *args, **kwargs):
+    """
+    Stand-in for request_file: creates the destination file without hitting
+    the network.  resources.json is handled by writing the real resources dict
+    (already loaded from TEST_MODELS_DIR) into the temp dir before download()
+    is called, so this mock only needs to stub out model .pt file downloads.
+    """
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    open(path, "wb").close()
+
 def test_download_non_default():
     """
-    Test the download path for a single file rather than the default zip
-
-    The expectation is that an NER model will also download two charlm models.
-    If that layout changes on purpose, this test will fail and will need to be updated
+    Test the download path for a single file rather than the default zip.
+ 
+    The expectation is that an NER model will also download two charlm models
+    and a pretrain.  If that layout changes on purpose, this test will fail
+    and will need to be updated.
+ 
+    The real resources.json is loaded from TEST_MODELS_DIR so the dependency
+    resolution reflects the actual package structure.  request_file is mocked
+    so no network traffic is generated.
     """
-    with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
-        stanza.download("en", model_dir=test_dir, processors="ner", package="ontonotes_charlm", verbose=False)
-        assert sorted(os.listdir(test_dir)) == ['en', 'resources.json']
-        en_dir = os.path.join(test_dir, 'en')
-        en_dir_listing = sorted(os.listdir(en_dir))
-        assert en_dir_listing == ['backward_charlm', 'forward_charlm', 'ner', 'pretrain']
-        assert os.listdir(os.path.join(en_dir, 'ner')) == ['ontonotes_charlm.pt']
-        for i in en_dir_listing:
-            assert len(os.listdir(os.path.join(en_dir, i))) == 1
+    resources = common.load_resources_json(TEST_MODELS_DIR)
+ 
+    with patch("stanza.resources.common.request_file", side_effect=_fake_request_file):
+        with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+            # Write the real resources.json into the temp dir so download()
+            # can load it without fetching from the network.
+            resources_path = os.path.join(test_dir, "resources.json")
+            with open(resources_path, "w", encoding="utf-8") as fh:
+                json.dump(resources, fh)
+
+            stanza.download(
+                "en",
+                model_dir=test_dir,
+                processors="ner",
+                package="ontonotes_charlm",
+                verbose=False,
+                download_json=False,
+            )
+
+            assert sorted(os.listdir(test_dir)) == ["en", "resources.json"]
+            en_dir = os.path.join(test_dir, "en")
+            en_dir_listing = sorted(os.listdir(en_dir))
+            assert en_dir_listing == ["backward_charlm", "forward_charlm", "ner", "pretrain"]
+            assert os.listdir(os.path.join(en_dir, "ner")) == ["ontonotes_charlm.pt"]
+            for i in en_dir_listing:
+                assert len(os.listdir(os.path.join(en_dir, i))) == 1
 
 
 def test_download_two_models():


### PR DESCRIPTION
A download test was failing on the CI, but this modification should make it so it doesn't need to actually download things and instead mocks up the file creation.  Assist from Claude