### PR TITLE
Fix output layer bug - the last two layers did not have a nonlinearit…

### DIFF
--- a/stanza/models/constituency/lstm_model.py
+++ b/stanza/models/constituency/lstm_model.py
@@ -1162,9 +1162,7 @@ class LSTMModel(BaseModel, nn.Module):
         hx = torch.cat((word_hx, transition_hx, constituent_hx), axis=1)
         for idx, output_layer in enumerate(self.output_layers):
             hx = self.predict_dropout(hx)
-            # TODO: why self.output_layers - 1?
-            if not self.maxout_k and idx < len(self.output_layers) - 1:
-                hx = self.nonlinearity(hx)
+            hx = self.nonlinearity(hx)
             hx = output_layer(hx)
         return hx
 


### PR DESCRIPTION
Fix output layer bug - the last two layers did not have a nonlinearity between them, no obvious explanation why this happened.  It turns out that we can merge the layers and get back the same exact results
