### PR TITLE
Use huggingface-hub to download models on HF instead of using requests

### DIFF
--- a/.github/workflows/stanza-tests.yaml
+++ b/.github/workflows/stanza-tests.yaml
@@ -19,7 +19,6 @@ jobs:
           #. $CONDA_PREFIX/etc/profile.d/conda.sh
           . /home/stanzabuild/miniconda3/etc/profile.d/conda.sh
           conda activate stanza
-          export HF_HUB_DISABLE_XET=1   # newer downloads are intermittently failing...
           export STANZA_TEST_HOME=/scr/stanza_test
           export CORENLP_HOME=$STANZA_TEST_HOME/corenlp_dir
           export CLASSPATH=$CORENLP_HOME/*:

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         'torch>=1.13.0',
         'tqdm',
         'udtools>=0.2.4',
+        'huggingface-hub',
     ],
 
     # List required Python versions

--- a/stanza/resources/common.py
+++ b/stanza/resources/common.py
@@ -10,11 +10,14 @@ import json
 import logging
 import os
 from pathlib import Path
+import re
 import requests
 import shutil
 import tempfile
 import zipfile
 
+import huggingface_hub
+from packaging import version
 from platformdirs import user_cache_dir
 from tqdm.auto import tqdm
 
@@ -113,10 +116,45 @@ def assert_file_exists(path, md5=None, alternate_md5=None):
             else:
                 raise ValueError("md5 for %s is %s, expected %s" % (path, file_md5, md5))
 
+_HF_URL_RE = re.compile(
+    r'^https://huggingface\.co/(?P<repo_id>[^/]+/[^/]+)/resolve/(?P<revision>[^/]+)/(?P<filename>.+)$'
+)
+
+def _parse_hf_url(url):
+    m = _HF_URL_RE.match(url)
+    if m is None:
+        return None
+    return m.group('repo_id'), m.group('revision'), m.group('filename')
+
 def download_file(url, path, proxies, raise_for_status=False):
     """
     Download a URL into a file as specified by `path`.
+
+    For HuggingFace Hub URLs (when no proxy is configured), routes through
+    huggingface_hub so that Xet, retries, and auth are handled correctly.
+    Falls back to raw requests for non-HF URLs or when proxies are in use.
     """
+    hf_parts = _parse_hf_url(url)
+    if hf_parts is not None and not proxies:
+        repo_id, revision, filename = hf_parts
+        # TODO: here we could use local_dir, but the local layout
+        #   en/constituency/ptb3-revised_electra-large.pt
+        # unfortunately does not match the HF layout
+        #   https://huggingface.co/stanfordnlp/stanza-en/resolve/v1.13.0/models/constituency/ptb3-revised_electra-large.pt
+        kwargs = dict(
+            repo_id=repo_id,
+            filename=filename,
+            revision=revision,
+        )
+        # local_dir_use_symlinks was removed in v1.0; only pass it on older versions
+        # the problem here is that older versions might unexpectedly produce
+        # symlinks here
+        if version.parse(huggingface_hub.__version__) < version.parse("1.0.0"):
+            kwargs["local_dir_use_symlinks"] = False
+        cached = huggingface_hub.hf_hub_download(**kwargs)
+        shutil.copy2(cached, path)
+        return 200
+
     verbose = logger.level in [0, 10, 20]
     r = requests.get(url, stream=True, proxies=proxies)
     if raise_for_status:

--- a/stanza/tests/resources/test_common.py
+++ b/stanza/tests/resources/test_common.py
@@ -2,10 +2,12 @@
 Test various resource downloading functions from resources/common.py
 """
 
+import hashlib
 import json
 import logging
 import os
 import pytest
+import requests
 import tempfile
 from unittest.mock import patch
 
@@ -35,6 +37,96 @@ def test_assert_file_exists():
             common.assert_file_exists(filename, md5="12345", alternate_md5="12345")
 
         common.assert_file_exists(filename, md5="12345", alternate_md5=EXPECTED_MD5)
+
+
+FILE_CONTENT = b"Unban mox opal!"
+# MD5 of FILE_CONTENT, verified independently
+FILE_CONTENT_MD5 = hashlib.md5(FILE_CONTENT).hexdigest()
+
+NON_HF_URL = "http://nlp.stanford.edu/software/stanza/fake_model.pt"
+HF_URL = "https://huggingface.co/stanfordnlp/stanza-en/resolve/v1.13.0/models/ner/fake_model.pt"
+
+
+class FakeResponse:
+    """
+    Minimal mock of a requests.Response sufficient for download_file.
+    """
+    def __init__(self, content=FILE_CONTENT, status_code=200):
+        self.status_code = status_code
+        self._content = content
+        self.headers = {"content-length": str(len(content))}
+
+    def iter_content(self, chunk_size=131072):
+        yield self._content
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(
+                f"{self.status_code} Client Error", response=self
+            )
+
+
+def test_parse_hf_url():
+    """
+    Test that _parse_hf_url correctly identifies HF URLs and extracts components,
+    and returns None for non-HF URLs.
+    """
+    result = common._parse_hf_url(HF_URL)
+    assert result == ("stanfordnlp/stanza-en", "v1.13.0", "models/ner/fake_model.pt")
+
+    assert common._parse_hf_url(NON_HF_URL) is None
+    assert common._parse_hf_url("https://github.com/stanfordnlp/stanza") is None
+    assert common._parse_hf_url("") is None
+
+
+def test_download_file_non_hf():
+    """
+    Test the raw requests path in download_file using a non-HF URL.
+
+    requests.get is mocked so no network traffic is generated.
+    Verifies that chunked content is written correctly to the destination.
+    """
+    with patch("stanza.resources.common.requests.get", return_value=FakeResponse()):
+        with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+            dest = os.path.join(test_dir, "fake_model.pt")
+            status = common.download_file(NON_HF_URL, dest, proxies=None)
+            assert status == 200
+            assert os.path.exists(dest)
+            assert common.get_md5(dest) == FILE_CONTENT_MD5
+
+
+def test_download_file_non_hf_404():
+    """
+    Test that download_file raises on a 404 when raise_for_status=True,
+    and does not raise when raise_for_status=False (default).
+    """
+    with patch("stanza.resources.common.requests.get", return_value=FakeResponse(content=b"", status_code=404)):
+        with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+            dest = os.path.join(test_dir, "fake_model.pt")
+
+            # default: no exception, but status code reflects the failure
+            status = common.download_file(NON_HF_URL, dest, proxies=None)
+            assert status == 404
+
+            with pytest.raises(requests.exceptions.HTTPError):
+                common.download_file(NON_HF_URL, dest, proxies=None, raise_for_status=True)
+
+
+def test_download_file_hf_url_with_proxies():
+    """
+    Test that a HF URL with proxies set falls back to the raw requests path
+    rather than going through hf_hub_download.
+    """
+    with patch("stanza.resources.common.requests.get", return_value=FakeResponse()) as mock_get:
+        with patch("stanza.resources.common.huggingface_hub.hf_hub_download") as mock_hf:
+            with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+                dest = os.path.join(test_dir, "fake_model.pt")
+                proxies = {"https": "http://proxy.example.com:8080"}
+                status = common.download_file(HF_URL, dest, proxies=proxies)
+                assert status == 200
+                mock_get.assert_called_once()
+                mock_hf.assert_not_called()
+                assert common.get_md5(dest) == FILE_CONTENT_MD5
 
 
 def test_download_tokenize_mwt():


### PR DESCRIPTION
This should be more reliable, use XET when possible, and presumably save on downloads for the CI if the corenlp packages are already downloaded to the HF cache, for example