### PR TITLE
fix(doc): write coref chains under coref_chains MISC key, not ner

### DIFF
--- a/stanza/models/common/doc.py
+++ b/stanza/models/common/doc.py
@@ -1144,7 +1144,7 @@ def dict_to_conll_text(token_dict, id_connector="-"):
                     coref_position = "middle-"
                 is_representative = "repr-" if chain.is_representative else ""
                 misc_chains.append("%s%sid%d" % (coref_position, is_representative, chain.chain.index))
-            misc.append("{}={}".format(key, ",".join(misc_chains)))
+            misc.append("{}={}".format(COREF_CHAINS, ",".join(misc_chains)))
 
     if MORPHEMES in token_dict and token_dict[MORPHEMES]:
         misc.append("Morphemes={}".format(",".join(token_dict[MORPHEMES])))

--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -616,3 +616,23 @@ def test_speaker():
     doc.sentences[0].speaker = "Siri"
     assert doc.sentences[0].speaker == 'Siri'
     assert "# speaker = Siri" in doc.sentences[0].comments
+
+def test_coref_chains_misc_key():
+    """The coref chains should be serialized under the coref_chains MISC key, not ner.
+
+    Regression test: dict_to_conll_text used to reuse a stale `key` loop variable
+    (left as NER), writing coref annotations as `ner=...` and colliding with a
+    real NER value when both were present.
+    """
+    from stanza.models.common.doc import dict_to_conll_text, ID, TEXT, NER, COREF_CHAINS
+    from stanza.models.coref.coref_chain import CorefChain, CorefAttachment
+
+    chain = CorefChain(index=3, mentions=[], representative_text="Joe", representative_index=0)
+    attachment = CorefAttachment(chain, is_start=True, is_end=True, is_representative=True)
+
+    misc = dict_to_conll_text({ID: (1,), TEXT: "Joe", COREF_CHAINS: [attachment]}).split("\t")[-1]
+    assert misc == "coref_chains=unit-repr-id3"
+
+    # NER and coref must remain distinct keys when both are present
+    misc = dict_to_conll_text({ID: (1,), TEXT: "Joe", NER: "S-PERSON", COREF_CHAINS: [attachment]}).split("\t")[-1]
+    assert misc == "ner=S-PERSON|coref_chains=unit-repr-id3"


### PR DESCRIPTION
## What's broken
When serializing a Document to CoNLL-U, `dict_to_conll_text()` emits coreference-chain annotations under the MISC key `ner=` instead of `coref_chains=`. When a token also has a real NER label, the output contains two colliding `ner=` entries.

```
WITH NER : 'ner=S-PERSON|ner=unit-repr-id3'   (expected '...|coref_chains=unit-repr-id3')
```

## Why it happens
Commit de2b0b8f moved coref handling out of the `for key in token_dict.keys()` loop (where `key == COREF_CHAINS`) into a standalone block placed after a `for key in [START_CHAR, END_CHAR, NER]` loop. The dict access was updated to `COREF_CHAINS`, but the `"{}={}".format(key, ...)` was left using the now-stale `key`, which is `NER`.

## Fix
Use the `COREF_CHAINS` constant explicitly in the format string, restoring the pre-refactor key.

## Test
Added `test_coref_chains_misc_key` checking both the coref-only case and the NER+coref case (keys stay distinct). Fails before, passes after; full `test_data_conversion.py` green.
