### PR TITLE
Add (from Claude) a script which lists the models currently installed

### DIFF
--- a/stanza/resources/list_installed.py
+++ b/stanza/resources/list_installed.py
@@ -1,0 +1,361 @@
+"""
+Utilities for inspecting locally installed Stanza models.
+
+Can also be run directly::
+
+    python -m stanza.resources.installed
+    python -m stanza.resources.installed --include-test-models
+"""
+
+import os
+import logging
+from itertools import groupby
+
+from platformdirs import user_cache_dir
+
+from stanza.resources.common import DEFAULT_MODEL_DIR, load_resources_json, ResourcesFileNotFoundError
+from stanza._version import __resources_version__
+
+logger = logging.getLogger('stanza')
+
+_SKIP_ENTRIES = {'resources.json'}
+
+# The unversioned platform cache root, e.g. ~/.cache/stanza on Linux.
+# Each subdirectory of this is expected to be a resources version, e.g. 1.10.0.
+_STANZA_CACHE_ROOT = user_cache_dir('stanza', 'StanfordNLP')
+
+# Cache root for test fixtures.  Mirrors the logic in stanza/tests/__init__.py:
+#   TEST_DIR_BASE_NAME = 'stanza_test'
+#   TEST_WORKING_DIR = os.getenv('STANZA_TEST_HOME') or
+#                      user_cache_dir('stanza_test', 'StanfordNLP', __resources_version__)
+# We use the unversioned root so we can show all versions, same as for models.
+# Keep this in sync with stanza/tests/__init__.py if those constants change.
+_STANZA_TEST_CACHE_ROOT = user_cache_dir('stanza_test', 'StanfordNLP')
+
+
+def _dir_size_bytes(path):
+    """Return the total byte-size of all regular files under *path*."""
+    total = 0
+    for dirpath, _dirnames, filenames in os.walk(path):
+        for fname in filenames:
+            fpath = os.path.join(dirpath, fname)
+            try:
+                total += os.path.getsize(fpath)
+            except OSError:
+                pass
+    return total
+
+
+def _human_size(nbytes):
+    """Format *nbytes* as a human-readable string (e.g. '1.23 GB')."""
+    for unit in ('B', 'KB', 'MB', 'GB', 'TB'):
+        if nbytes < 1024 or unit == 'TB':
+            return f'{nbytes:.1f} {unit}'
+        nbytes /= 1024
+
+
+def _scan_model_dir(model_dir, version=None):
+    """
+    Scan a single *model_dir* and return a list of row dicts.
+
+    Each dict has the keys: lang, lang_name, processor, package, path,
+    size_bytes, and version (which may be None if unknown).
+    """
+    if not os.path.isdir(model_dir):
+        return []
+
+    try:
+        resources = load_resources_json(model_dir)
+    except (ResourcesFileNotFoundError, FileNotFoundError):
+        resources = {}
+
+    rows = []
+
+    for lang in sorted(os.listdir(model_dir)):
+        if lang in _SKIP_ENTRIES:
+            continue
+        lang_dir = os.path.join(model_dir, lang)
+        if not os.path.isdir(lang_dir):
+            continue
+
+        # Follow alias chains in resources.json for the display name.
+        lang_name = lang
+        lang_entry = resources.get(lang, {})
+        visited = set()
+        while isinstance(lang_entry, dict) and 'alias' in lang_entry:
+            alias = lang_entry['alias']
+            if alias in visited:
+                break
+            visited.add(alias)
+            lang_entry = resources.get(alias, {})
+        if isinstance(lang_entry, dict):
+            lang_name = lang_entry.get('lang_name', lang)
+
+        for processor in sorted(os.listdir(lang_dir)):
+            proc_dir = os.path.join(lang_dir, processor)
+            if not os.path.isdir(proc_dir):
+                continue
+
+            pt_files = [f for f in os.listdir(proc_dir) if f.endswith('.pt')]
+
+            if pt_files:
+                for fname in sorted(pt_files):
+                    fpath = os.path.join(proc_dir, fname)
+                    try:
+                        fsize = os.path.getsize(fpath)
+                    except OSError:
+                        fsize = 0
+                    rows.append({
+                        'version': version,
+                        'lang': lang,
+                        'lang_name': lang_name,
+                        'processor': processor,
+                        'package': fname[:-3],  # strip .pt
+                        'path': fpath,
+                        'size_bytes': fsize,
+                    })
+            else:
+                # No .pt files directly; report the directory itself.
+                rows.append({
+                    'version': version,
+                    'lang': lang,
+                    'lang_name': lang_name,
+                    'processor': processor,
+                    'package': None,
+                    'path': proc_dir,
+                    'size_bytes': _dir_size_bytes(proc_dir),
+                })
+
+    return rows
+
+
+def _scan_cache_root(cache_root, subdir='resources'):
+    """
+    Walk a versioned cache root and return all rows across all version subdirs.
+
+    Expects the layout::
+
+        <cache_root>/<version>/<subdir>/<lang>/<processor>/<package>.pt
+
+    *subdir* is ``'resources'`` for the regular model cache and ``'models'``
+    for the test fixture cache (``stanza_test``).
+    """
+    rows = []
+    if os.path.isdir(cache_root):
+        for entry in sorted(os.listdir(cache_root)):
+            versioned_dir = os.path.join(cache_root, entry, subdir)
+            if os.path.isdir(versioned_dir):
+                rows.extend(_scan_model_dir(versioned_dir, version=entry))
+    return rows
+
+
+def list_installed(model_dir=DEFAULT_MODEL_DIR, print_table=True,
+                   include_test_models=False):
+    """
+    Scan *model_dir* and report which Stanza models are installed locally.
+
+    If *model_dir* is the default (i.e. ``STANZA_RESOURCES_DIR`` is not set),
+    all versioned subdirectories found under the platform cache root are
+    scanned, not just the current version.  This lets the user see models
+    from older Stanza installs that may still be taking up disk space.
+
+    When ``STANZA_RESOURCES_DIR`` is set the user has opted into a custom
+    layout, so only that single directory is scanned.
+
+    The directory layout expected under each versioned resources dir is::
+
+        <version>/resources/
+            resources.json          # optional; used for display names
+            <lang>/                 # e.g. 'en', 'zh-hans'
+                <processor>/        # e.g. 'pos', 'depparse', 'tokenize'
+                    <package>.pt    # e.g. 'ewt.pt', 'gsd.pt'
+
+    Parameters
+    ----------
+    model_dir : str
+        Root directory that was passed as *model_dir* to ``stanza.download``
+        (defaults to ``DEFAULT_MODEL_DIR``).
+    print_table : bool
+        When True (default) the results are printed as a formatted table in
+        addition to being returned.
+    include_test_models : bool
+        When True, also scan the stanza_test cache (used by the Stanza test
+        suite) and print those as a separate block.  Defaults to False since
+        most users have no test fixtures installed.  The test rows are
+        appended to the returned list after the regular model rows.
+
+    Returns
+    -------
+    list of dict
+        Each dict has the keys:
+
+        ``version``
+            Resources version string (e.g. ``'1.10.0'``), or ``None`` when
+            scanning a custom ``STANZA_RESOURCES_DIR``.
+        ``lang``
+            Language code directory name (e.g. ``'en'``).
+        ``lang_name``
+            Human-readable language name from resources.json, or the lang
+            code if resources.json is absent or the language is not listed.
+        ``processor``
+            Processor subdirectory name (e.g. ``'pos'``).
+        ``package``
+            Model filename without the ``.pt`` extension (e.g. ``'ewt'``),
+            or ``None`` when the processor directory contains no ``.pt``
+            files.
+        ``path``
+            Absolute path to the ``.pt`` file, or to the processor
+            directory when *package* is ``None``.
+        ``size_bytes``
+            Size in bytes of the file (or total bytes under the directory
+            when *package* is ``None``).
+    """
+    custom_dir = os.getenv('STANZA_RESOURCES_DIR')
+
+    if custom_dir:
+        # User has a custom layout; scan only that directory, version unknown.
+        rows = _scan_model_dir(model_dir, version=None)
+        if print_table:
+            _print_installed_table(rows, model_dir, multi_version=False)
+        return rows
+
+    # Default layout: <cache_root>/<version>/resources/
+    # Scan all version subdirectories we can find.
+    all_rows = _scan_cache_root(_STANZA_CACHE_ROOT)
+
+    if not all_rows:
+        # Fallback: maybe the caller passed an explicit non-default model_dir
+        all_rows = _scan_model_dir(model_dir, version=None)
+
+    if include_test_models:
+        test_rows = _scan_cache_root(_STANZA_TEST_CACHE_ROOT, subdir='models')
+    else:
+        test_rows = []
+
+    if print_table:
+        _print_installed_table(all_rows, _STANZA_CACHE_ROOT, multi_version=True)
+        if include_test_models:
+            if test_rows:
+                _print_installed_table(test_rows, _STANZA_TEST_CACHE_ROOT,
+                                       multi_version=True)
+            else:
+                print(f'\nNo test models found under {_STANZA_TEST_CACHE_ROOT}')
+        combined = all_rows + test_rows
+        total = sum(r['size_bytes'] for r in combined)
+        label = 'All models + test fixtures' if test_rows else 'All versions'
+        print(f'\n{label}: {len(combined)} model(s), {_human_size(total)} total')
+
+    return all_rows + test_rows
+
+
+def _format_rows(rows):
+    """
+    Return (headers, col_data, widths) for a flat list of model rows,
+    without any version column (version is shown in the section header).
+    """
+    headers = ['Language', 'Code', 'Processor', 'Package', 'Size']
+    col_data = [
+        (
+            r['lang_name'],
+            r['lang'],
+            r['processor'],
+            r['package'] if r['package'] is not None else '(directory)',
+            _human_size(r['size_bytes']),
+        )
+        for r in rows
+    ]
+    widths = [len(h) for h in headers]
+    for row_vals in col_data:
+        for i, val in enumerate(row_vals):
+            widths[i] = max(widths[i], len(val))
+    return headers, col_data, widths
+
+
+def _print_section(rows, header_path, widths, sep='  '):
+    """Print one version section: path header, table body, subtotal footer."""
+    headers, col_data, _ = _format_rows(rows)
+
+    # Recompute a rule sized to *widths* (may be wider than this section alone
+    # when called from a multi-version print that pre-computed shared widths).
+    rule = sep.join('-' * w for w in widths)
+    header_line = sep.join(h.ljust(widths[i]) for i, h in enumerate(headers))
+
+    print(f'\n{header_path}')
+    print(header_line)
+    print(rule)
+
+    prev_lang = None
+    for row_vals in col_data:
+        if prev_lang is not None and row_vals[1] != prev_lang:
+            print()
+        prev_lang = row_vals[1]
+        print(sep.join(v.ljust(widths[i]) for i, v in enumerate(row_vals)))
+
+    subtotal = sum(r['size_bytes'] for r in rows)
+    print(f'  ({len(rows)} model(s), {_human_size(subtotal)})')
+
+
+def _print_installed_table(rows, root_dir, multi_version=False):
+    """Pretty-print the installed models as an aligned table."""
+    if not rows:
+        print(f'No models found under {root_dir}')
+        return
+
+    current = __resources_version__
+    sep = '  '
+
+    if multi_version:
+        # Group rows by version and compute column widths across all sections
+        # so that the tables line up visually.
+        _, _, widths = _format_rows(rows)
+
+        print(f'\nInstalled Stanza models under: {root_dir}')
+
+        versions_seen = []
+        for version, version_rows in groupby(rows, key=lambda r: r['version']):
+            version_rows = list(version_rows)
+            versions_seen.append(version)
+            label = ' (current)' if version == current else ''
+            path = os.path.join(root_dir, version or '', 'resources')
+            _print_section(version_rows, f'{path}{label}', widths, sep)
+
+    else:
+        _, _, widths = _format_rows(rows)
+        _print_section(rows, root_dir, widths, sep)
+        print()  # trailing newline for single-dir output
+
+
+if __name__ == '__main__':
+    import argparse
+    import sys
+
+    # Set up a basic logger so any warnings from _scan_model_dir are visible.
+    logging.basicConfig(stream=sys.stderr, level=logging.WARNING,
+                        format='%(levelname)s: %(message)s')
+
+    parser = argparse.ArgumentParser(
+        description='List locally installed Stanza models.'
+    )
+    parser.add_argument(
+        '--model-dir', default=None,
+        help=(
+            'Root model directory to scan (default: auto-detected from '
+            'STANZA_RESOURCES_DIR or the platform cache).'
+        )
+    )
+    parser.add_argument(
+        '--include-test-models', action='store_true',
+        help=(
+            'Also scan the stanza_test cache used by the Stanza test suite '
+            'and display those models in a separate block.'
+        )
+    )
+    args = parser.parse_args()
+
+    kwargs = {}
+    if args.model_dir is not None:
+        kwargs['model_dir'] = args.model_dir
+    if args.include_test_models:
+        kwargs['include_test_models'] = True
+
+    list_installed(**kwargs)

--- a/stanza/tests/resources/test_list_installed.py
+++ b/stanza/tests/resources/test_list_installed.py
@@ -1,0 +1,435 @@
+"""
+Tests for stanza.resources.list_installed.
+
+All tests build temporary directories with fake .pt files so they never
+touch the real Stanza cache or require downloaded models.
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from stanza import __resources_version__
+
+from stanza.resources.list_installed import (
+    _dir_size_bytes,
+    _format_rows,
+    _human_size,
+    _scan_cache_root,
+    _scan_model_dir,
+    _STANZA_CACHE_ROOT,
+    _STANZA_TEST_CACHE_ROOT,
+    list_installed,
+)
+
+# A version string distinct from __resources_version__, used in tests that
+# need to simulate an older install alongside the current one.
+_OLDER_VERSION = '1.10.0'
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _touch(path, content=b''):
+    """Create a file (and any parent dirs) with the given byte content."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'wb') as f:
+        f.write(content)
+
+
+def _make_model_dir(base, lang, processor, package, size=1024,
+                    resources_json=None):
+    """
+    Create a minimal model directory structure under *base*::
+
+        base/
+            resources.json          (optional)
+            <lang>/<processor>/<package>.pt
+
+    Returns *base* for convenience.
+    """
+    _touch(os.path.join(base, lang, processor, f'{package}.pt'), b'x' * size)
+    if resources_json is not None:
+        with open(os.path.join(base, 'resources.json'), 'w',
+                  encoding='utf-8') as f:
+            json.dump(resources_json, f)
+    return base
+
+
+def _make_versioned_cache(cache_root, version, lang, processor, package,
+                          size=1024, resources_json=None, subdir='resources'):
+    """
+    Create a versioned directory tree under *cache_root*::
+
+        cache_root/<version>/<subdir>/<lang>/<processor>/<package>.pt
+
+    Use ``subdir='models'`` for test fixture caches.
+    """
+    model_dir = os.path.join(cache_root, version, subdir)
+    return _make_model_dir(model_dir, lang, processor, package,
+                           size=size, resources_json=resources_json)
+
+
+def _no_custom_dir(monkeypatch):
+    """Remove STANZA_RESOURCES_DIR from the environment."""
+    monkeypatch.delenv('STANZA_RESOURCES_DIR', raising=False)
+
+
+# ---------------------------------------------------------------------------
+# _human_size
+# ---------------------------------------------------------------------------
+
+def test_human_size_bytes():
+    assert _human_size(512) == '512.0 B'
+
+def test_human_size_kilobytes():
+    assert _human_size(2048) == '2.0 KB'
+
+def test_human_size_megabytes():
+    assert _human_size(3 * 1024 ** 2) == '3.0 MB'
+
+def test_human_size_gigabytes():
+    assert _human_size(1024 ** 3) == '1.0 GB'
+
+def test_human_size_zero():
+    assert _human_size(0) == '0.0 B'
+
+
+# ---------------------------------------------------------------------------
+# _dir_size_bytes
+# ---------------------------------------------------------------------------
+
+def test_dir_size_bytes_single_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        _touch(os.path.join(tmp, 'a.pt'), b'x' * 100)
+        assert _dir_size_bytes(tmp) == 100
+
+def test_dir_size_bytes_nested_files():
+    with tempfile.TemporaryDirectory() as tmp:
+        _touch(os.path.join(tmp, 'sub', 'a.pt'), b'x' * 200)
+        _touch(os.path.join(tmp, 'b.pt'), b'x' * 50)
+        assert _dir_size_bytes(tmp) == 250
+
+def test_dir_size_bytes_empty_dir():
+    with tempfile.TemporaryDirectory() as tmp:
+        assert _dir_size_bytes(tmp) == 0
+
+
+# ---------------------------------------------------------------------------
+# _scan_model_dir
+# ---------------------------------------------------------------------------
+
+def test_scan_model_dir_nonexistent():
+    assert _scan_model_dir('/this/does/not/exist') == []
+
+def test_scan_model_dir_basic():
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'en', 'pos', 'ewt', size=100)
+        rows = _scan_model_dir(tmp)
+    assert len(rows) == 1
+    assert rows[0]['lang'] == 'en'
+    assert rows[0]['processor'] == 'pos'
+    assert rows[0]['package'] == 'ewt'
+    assert rows[0]['size_bytes'] == 100
+    assert rows[0]['version'] is None
+
+def test_scan_model_dir_version_propagated():
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'en', 'pos', 'ewt')
+        rows = _scan_model_dir(tmp, version=_OLDER_VERSION)
+    assert rows[0]['version'] == _OLDER_VERSION
+
+def test_scan_model_dir_multiple_packages():
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'en', 'pos', 'ewt')
+        _touch(os.path.join(tmp, 'en', 'pos', 'craft.pt'), b'y' * 50)
+        rows = _scan_model_dir(tmp)
+    assert {r['package'] for r in rows} == {'ewt', 'craft'}
+
+def test_scan_model_dir_multiple_languages():
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'en', 'pos', 'ewt')
+        _make_model_dir(tmp, 'de', 'pos', 'gsd')
+        rows = _scan_model_dir(tmp)
+    assert {r['lang'] for r in rows} == {'en', 'de'}
+
+def test_scan_model_dir_resources_json_not_treated_as_lang():
+    """resources.json at the top level must not appear as a language."""
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'en', 'pos', 'ewt',
+                        resources_json={'url': 'http://example.com'})
+        rows = _scan_model_dir(tmp)
+    assert 'resources.json' not in {r['lang'] for r in rows}
+
+def test_scan_model_dir_lang_name_from_resources_json():
+    rj = {
+        'url': 'http://example.com',
+        'en': {'lang_name': 'English', 'pos': {'ewt': {'md5': 'abc'}}},
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'en', 'pos', 'ewt', resources_json=rj)
+        rows = _scan_model_dir(tmp)
+    assert rows[0]['lang_name'] == 'English'
+
+def test_scan_model_dir_lang_name_falls_back_to_code():
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'sd', 'pos', 'isra')
+        rows = _scan_model_dir(tmp)
+    assert rows[0]['lang_name'] == 'sd'
+
+def test_scan_model_dir_alias_resolved():
+    """An aliased lang code should resolve to the target's lang_name."""
+    rj = {
+        'url': 'http://example.com',
+        'german': {'alias': 'de'},
+        'de': {'lang_name': 'German', 'pos': {'gsd': {'md5': 'abc'}}},
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'german', 'pos', 'gsd', resources_json=rj)
+        rows = _scan_model_dir(tmp)
+    assert rows[0]['lang_name'] == 'German'
+
+def test_scan_model_dir_alias_cycle_terminates():
+    """A malformed alias cycle must not hang."""
+    rj = {
+        'url': 'http://example.com',
+        'a': {'alias': 'b'},
+        'b': {'alias': 'a'},
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'a', 'pos', 'pkg', resources_json=rj)
+        rows = _scan_model_dir(tmp)
+    assert len(rows) == 1
+
+def test_scan_model_dir_no_pt_files_reports_directory():
+    """A processor dir with no .pt files should appear as a directory row."""
+    with tempfile.TemporaryDirectory() as tmp:
+        subdir = os.path.join(tmp, 'en', 'pretrain', 'gsd')
+        os.makedirs(subdir)
+        _touch(os.path.join(subdir, 'model.bin'), b'z' * 200)
+        rows = _scan_model_dir(tmp)
+    assert len(rows) == 1
+    assert rows[0]['package'] is None
+    assert rows[0]['size_bytes'] == 200
+
+def test_scan_model_dir_stray_files_in_lang_dir_ignored():
+    """Non-directory entries inside a lang dir (e.g. default.zip) are skipped."""
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'en', 'pos', 'ewt')
+        _touch(os.path.join(tmp, 'en', 'default.zip'), b'z' * 100)
+        rows = _scan_model_dir(tmp)
+    assert len(rows) == 1
+    assert rows[0]['processor'] == 'pos'
+
+
+# ---------------------------------------------------------------------------
+# _scan_cache_root
+# ---------------------------------------------------------------------------
+
+def test_scan_cache_root_empty():
+    with tempfile.TemporaryDirectory() as tmp:
+        assert _scan_cache_root(tmp) == []
+
+def test_scan_cache_root_nonexistent():
+    assert _scan_cache_root('/does/not/exist') == []
+
+def test_scan_cache_root_multiple_versions():
+    with tempfile.TemporaryDirectory() as cache_root:
+        _make_versioned_cache(cache_root, _OLDER_VERSION, 'en', 'pos', 'ewt', size=10)
+        _make_versioned_cache(cache_root, __resources_version__, 'de', 'pos', 'gsd', size=20)
+        rows = _scan_cache_root(cache_root)
+    assert {r['version'] for r in rows} == {_OLDER_VERSION, __resources_version__}
+    assert len(rows) == 2
+
+def test_scan_cache_root_ignores_dirs_without_resources_subdir():
+    """A version dir that has no 'resources' subdirectory should be skipped."""
+    with tempfile.TemporaryDirectory() as cache_root:
+        os.makedirs(os.path.join(cache_root, 'junk', 'something'))
+        _make_versioned_cache(cache_root, __resources_version__, 'en', 'pos', 'ewt')
+        rows = _scan_cache_root(cache_root)
+    assert len(rows) == 1
+    assert rows[0]['version'] == __resources_version__
+
+
+# ---------------------------------------------------------------------------
+# _format_rows
+# ---------------------------------------------------------------------------
+
+def _make_row(lang='en', lang_name='English', processor='pos',
+              package='ewt', size=1024, version='1.0.0'):
+    return {
+        'version': version,
+        'lang': lang,
+        'lang_name': lang_name,
+        'processor': processor,
+        'package': package,
+        'path': f'/fake/{lang}/{processor}/{package}.pt',
+        'size_bytes': size,
+    }
+
+def test_format_rows_headers():
+    headers, _, _ = _format_rows([_make_row()])
+    assert headers == ['Language', 'Code', 'Processor', 'Package', 'Size']
+
+def test_format_rows_none_package_shown_as_directory():
+    row = _make_row()
+    row['package'] = None
+    _, col_data, _ = _format_rows([row])
+    assert '(directory)' in col_data[0]
+
+def test_format_rows_widths_at_least_header_length():
+    headers, _, widths = _format_rows([_make_row()])
+    for h, w in zip(headers, widths):
+        assert w >= len(h)
+
+def test_format_rows_widths_reflect_data():
+    row = _make_row(lang_name='A' * 50)
+    _, _, widths = _format_rows([row])
+    assert widths[0] == 50
+
+
+# ---------------------------------------------------------------------------
+# list_installed
+# ---------------------------------------------------------------------------
+
+def test_list_installed_custom_dir(monkeypatch):
+    """When STANZA_RESOURCES_DIR is set, only that dir is scanned."""
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'en', 'pos', 'ewt')
+        monkeypatch.setenv('STANZA_RESOURCES_DIR', tmp)
+        rows = list_installed(model_dir=tmp, print_table=False)
+    assert len(rows) == 1
+    assert rows[0]['version'] is None
+
+def test_list_installed_scans_all_versions(monkeypatch):
+    """Without STANZA_RESOURCES_DIR, all versioned subdirs are scanned."""
+    with tempfile.TemporaryDirectory() as cache_root:
+        _make_versioned_cache(cache_root, _OLDER_VERSION, 'en', 'pos', 'ewt', size=10)
+        _make_versioned_cache(cache_root, __resources_version__, 'en', 'pos', 'ewt', size=20)
+        _no_custom_dir(monkeypatch)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_CACHE_ROOT',
+                            cache_root)
+        rows = list_installed(print_table=False)
+    assert {r['version'] for r in rows} == {_OLDER_VERSION, __resources_version__}
+    assert len(rows) == 2
+
+def test_list_installed_empty_cache(monkeypatch):
+    with tempfile.TemporaryDirectory() as cache_root:
+        _no_custom_dir(monkeypatch)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_CACHE_ROOT',
+                            cache_root)
+        rows = list_installed(model_dir=cache_root, print_table=False)
+    assert rows == []
+
+def test_list_installed_nonexistent_custom_dir(monkeypatch):
+    monkeypatch.setenv('STANZA_RESOURCES_DIR', '/does/not/exist')
+    rows = list_installed(model_dir='/does/not/exist', print_table=False)
+    assert rows == []
+
+def test_list_installed_version_order(monkeypatch):
+    """Versions should appear in sorted (ascending) order."""
+    with tempfile.TemporaryDirectory() as cache_root:
+        _make_versioned_cache(cache_root, __resources_version__, 'en', 'pos', 'ewt')
+        _make_versioned_cache(cache_root, _OLDER_VERSION, 'en', 'pos', 'ewt')
+        _no_custom_dir(monkeypatch)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_CACHE_ROOT',
+                            cache_root)
+        rows = list_installed(print_table=False)
+    assert rows[0]['version'] == _OLDER_VERSION
+    assert rows[1]['version'] == __resources_version__
+
+def test_list_installed_print_table_smoke(monkeypatch):
+    """print_table=True should run without errors."""
+    with tempfile.TemporaryDirectory() as tmp:
+        _make_model_dir(tmp, 'en', 'pos', 'ewt')
+        monkeypatch.setenv('STANZA_RESOURCES_DIR', tmp)
+        list_installed(model_dir=tmp, print_table=True)
+
+def test_list_installed_multi_version_print_smoke(monkeypatch):
+    with tempfile.TemporaryDirectory() as cache_root:
+        _make_versioned_cache(cache_root, _OLDER_VERSION, 'en', 'pos', 'ewt')
+        _make_versioned_cache(cache_root, __resources_version__, 'de', 'pos', 'gsd')
+        _no_custom_dir(monkeypatch)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_CACHE_ROOT',
+                            cache_root)
+        list_installed(print_table=True)
+
+
+# ---------------------------------------------------------------------------
+# list_installed: include_test_models
+# ---------------------------------------------------------------------------
+
+def test_include_test_models_excluded_by_default(monkeypatch):
+    with tempfile.TemporaryDirectory() as model_cache, \
+         tempfile.TemporaryDirectory() as test_cache:
+        _make_versioned_cache(model_cache, __resources_version__, 'en', 'pos', 'ewt')
+        _make_versioned_cache(test_cache, __resources_version__, 'en', 'pos', 'ewt',
+                              subdir='models')
+        _no_custom_dir(monkeypatch)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_CACHE_ROOT',
+                            model_cache)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_TEST_CACHE_ROOT',
+                            test_cache)
+        rows = list_installed(print_table=False)
+    assert len(rows) == 1
+
+def test_include_test_models_appended(monkeypatch):
+    with tempfile.TemporaryDirectory() as model_cache, \
+         tempfile.TemporaryDirectory() as test_cache:
+        _make_versioned_cache(model_cache, __resources_version__, 'en', 'pos', 'ewt', size=10)
+        _make_versioned_cache(test_cache, __resources_version__, 'de', 'pos', 'gsd', size=20,
+                              subdir='models')
+        _no_custom_dir(monkeypatch)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_CACHE_ROOT',
+                            model_cache)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_TEST_CACHE_ROOT',
+                            test_cache)
+        rows = list_installed(print_table=False, include_test_models=True)
+    assert len(rows) == 2
+    assert {r['lang'] for r in rows} == {'en', 'de'}
+
+def test_include_test_models_empty_test_cache(monkeypatch):
+    """include_test_models=True with no test fixtures should not raise."""
+    with tempfile.TemporaryDirectory() as model_cache, \
+         tempfile.TemporaryDirectory() as test_cache:
+        _make_versioned_cache(model_cache, __resources_version__, 'en', 'pos', 'ewt')
+        _no_custom_dir(monkeypatch)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_CACHE_ROOT',
+                            model_cache)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_TEST_CACHE_ROOT',
+                            test_cache)
+        rows = list_installed(print_table=False, include_test_models=True)
+    assert len(rows) == 1
+    assert rows[0]['lang'] == 'en'
+
+def test_include_test_models_print_smoke(monkeypatch):
+    with tempfile.TemporaryDirectory() as model_cache, \
+         tempfile.TemporaryDirectory() as test_cache:
+        _make_versioned_cache(model_cache, __resources_version__, 'en', 'pos', 'ewt')
+        _make_versioned_cache(test_cache, __resources_version__, 'de', 'pos', 'gsd',
+                              subdir='models')
+        _no_custom_dir(monkeypatch)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_CACHE_ROOT',
+                            model_cache)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_TEST_CACHE_ROOT',
+                            test_cache)
+        list_installed(print_table=True, include_test_models=True)
+
+def test_include_test_models_order(monkeypatch):
+    """Test rows must come after model rows in the returned list."""
+    with tempfile.TemporaryDirectory() as model_cache, \
+         tempfile.TemporaryDirectory() as test_cache:
+        _make_versioned_cache(model_cache, __resources_version__, 'en', 'pos', 'ewt')
+        _make_versioned_cache(test_cache, __resources_version__, 'de', 'pos', 'gsd',
+                              subdir='models')
+        _no_custom_dir(monkeypatch)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_CACHE_ROOT',
+                            model_cache)
+        monkeypatch.setattr('stanza.resources.list_installed._STANZA_TEST_CACHE_ROOT',
+                            test_cache)
+        rows = list_installed(print_table=False, include_test_models=True)
+    assert rows[0]['lang'] == 'en'
+    assert rows[1]['lang'] == 'de'


### PR DESCRIPTION
Instead of including tools to delete resources directories (which would be a disaster if they go wrong), instead we simply include a tool that lists what is available.  The user can delete or not delete extra resources as they wish.

Assist from Claude

https://github.com/stanfordnlp/stanza/issues/1542
