### PR TITLE
Depparse constraints

### DIFF
--- a/stanza/models/depparse/head_constraints.py
+++ b/stanza/models/depparse/head_constraints.py
@@ -7,9 +7,9 @@ enforced by reweighting root arc costs -- see chuliu_edmonds_one_root), since
 they depend on which LABEL ends up chosen for each arc, not just the tree
 structure.
 
-See stanza.models.depparse.scorer for the exact SINGLETON_DEPREL_GROUPS
-definitions (including the nsubj:outer/csubj:outer exception) and for
-counting how often these violations occur across a corpus.
+SINGLETON_DEPREL_GROUPS/DEPREL_TO_GROUP below are the canonical definitions
+of which deprels are mutually exclusive on a single head; stanza.models.depparse.scorer
+imports them from here to count how often violations occur across a corpus.
 """
 
 from collections import defaultdict
@@ -18,13 +18,34 @@ import numpy as np
 
 from stanza.models.common.chuliu_edmonds import chuliu_edmonds_one_root
 from stanza.models.common.vocab import VOCAB_PREFIX_SIZE
-from stanza.models.depparse.scorer import DEPREL_TO_GROUP
+
+# groups of deprels which are mutually exclusive per head -- a single head
+# should never have more than one edge belonging to the same group.
+#
+# nsubj:pass / csubj:pass collapse into the ordinary subj group (a head
+# still shouldn't have two of nsubj/csubj/nsubj:pass/csubj:pass combined).
+#
+# nsubj:outer / csubj:outer are their own group instead, since a head can
+# legitimately have both a plain nsubj/csubj AND an nsubj:outer/csubj:outer
+# at once -- this is the "outer" clausal subject of a copula construction, eg:
+#   "The thing to keep in mind is that X, Y, and Z are more dangerous..."
+# where "thing" is nsubj:outer of "likely" and "nationalists" is a separate,
+# ordinary nsubj of the same head ("likely").
+SINGLETON_DEPREL_GROUPS = {
+    "subj": {"nsubj", "csubj", "nsubj:pass", "csubj:pass"},
+    "subj_outer": {"nsubj:outer", "csubj:outer"},
+    "obj": {"obj"},
+}
+
+# reverse lookup built from SINGLETON_DEPREL_GROUPS: exact deprel -> group name
+DEPREL_TO_GROUP = {deprel: group_name
+                    for group_name, deprels in SINGLETON_DEPREL_GROUPS.items()
+                    for deprel in deprels}
 
 def find_head_constraint_violations(tree, deprel_strs):
     """
     Finds heads with more than one dependent in the same SINGLETON_DEPREL_GROUPS
-    group (eg two nsubj, or an nsubj + csubj, or two obj) -- see
-    stanza.models.depparse.scorer for the exact group definitions.
+    group (eg two nsubj, or an nsubj + csubj, or two obj).
 
     Returns a list of (head_idx, group_name, [dependent_word_indices]) for
     each violating (head, group) combination.

--- a/stanza/models/depparse/head_constraints.py
+++ b/stanza/models/depparse/head_constraints.py
@@ -1,0 +1,187 @@
+"""
+Detects and repairs head-constraint violations in a decoded dependency tree:
+heads that end up with more than one nsubj/csubj (or nsubj:pass/csubj:pass),
+or more than one obj. These aren't enforced by the arc-factored graph parser
+or by Chu-Liu-Edmonds itself (unlike the single-root constraint, which is
+enforced by reweighting root arc costs -- see chuliu_edmonds_one_root), since
+they depend on which LABEL ends up chosen for each arc, not just the tree
+structure.
+
+See stanza.models.depparse.scorer for the exact SINGLETON_DEPREL_GROUPS
+definitions (including the nsubj:outer/csubj:outer exception) and for
+counting how often these violations occur across a corpus.
+"""
+
+from collections import defaultdict
+
+import numpy as np
+
+from stanza.models.common.chuliu_edmonds import chuliu_edmonds_one_root
+from stanza.models.common.vocab import VOCAB_PREFIX_SIZE
+from stanza.models.depparse.scorer import DEPREL_TO_GROUP
+
+def find_head_constraint_violations(tree, deprel_strs):
+    """
+    Finds heads with more than one dependent in the same SINGLETON_DEPREL_GROUPS
+    group (eg two nsubj, or an nsubj + csubj, or two obj) -- see
+    stanza.models.depparse.scorer for the exact group definitions.
+
+    Returns a list of (head_idx, group_name, [dependent_word_indices]) for
+    each violating (head, group) combination.
+    """
+    deps_per_head = defaultdict(lambda: defaultdict(list))
+    for j, deprel in enumerate(deprel_strs):
+        word_idx = j + 1
+        group_name = DEPREL_TO_GROUP.get(deprel)
+        if group_name is not None:
+            deps_per_head[tree[word_idx]][group_name].append(word_idx)
+    return [(head_idx, group_name, deps)
+            for head_idx, groups in deps_per_head.items()
+            for group_name, deps in groups.items()
+            if len(deps) > 1]
+
+def label_for_arc(label_log_probs, deprel_id_to_group, dep, head, exclude_groups=None):
+    """
+    Best raw label id (and its log-prob) for a specific (dependent, head) arc.
+    exclude_groups, if given, is a set of SINGLETON_DEPREL_GROUPS names whose
+    labels are not eligible here.
+    """
+    row = label_log_probs[dep, head]
+    if not exclude_groups:
+        best_id = int(np.argmax(row))
+        return best_id, row[best_id]
+    best_id, best_score = None, -np.inf
+    for label_id, score in enumerate(row):
+        if deprel_id_to_group[label_id] in exclude_groups:
+            continue
+        if score > best_score:
+            best_score, best_id = score, label_id
+    return best_id, best_score
+
+def resolve_head_constraint_violations(scores, label_log_probs, tree, vocab, max_iterations=5):
+    """
+    Repairs head-constraint violations (more than one nsubj/csubj, or more
+    than one obj, attached to the same head) with a single Chu-Liu-Edmonds
+    rerun per candidate, rather than separately trying "relabel in place" and
+    "reroute structurally" and comparing the two afterward.
+
+    For a violation with offending dependents `deps` at `head_idx`, and for
+    each choice of which one of them keeps its original (in-group) label
+    unchanged ("keep_idx"), every OTHER offending dependent gets its
+    unlabeled score row replaced with a COMBINED row: arc log-prob + best
+    available label log-prob, for every candidate head -- except at
+    head_idx itself, where the violating group's label is excluded from
+    that "best available" search (since this dependent is not the one
+    keeping the group label this round).
+
+    Rerunning CLE on this combined-row matrix lets CLE itself decide,
+    per dependent, whether the best option is to stay at head_idx with a
+    worse (but still legal) label, or to move to a genuinely better head
+    elsewhere -- both possibilities are visible in the same score, so one
+    CLE call captures what previously took two separate mechanisms (an
+    in-place label swap, and a separately-scored structural reroute) and a
+    max() over both. Eg for "I gave the cat a fish", if the parser scored
+    obj(gave, cat) slightly above iobj(gave, cat), "cat"'s combined row will
+    show that staying at "gave" with the iobj label beats any arc it has
+    elsewhere, so CLE naturally keeps the attachment and only the label
+    changes -- no separate label-swap-only code path is needed to find that.
+
+    This takes k CLE calls for a violation with k offending dependents (one
+    per choice of "keep_idx"), not 2k: there is only one repair mechanism,
+    not two compared against each other.
+
+    Loops up to max_iterations times to handle the rare case of more than
+    one independent violation in the same sentence. After each round,
+    excluded_groups records, for each dependent that was pushed away from
+    head_idx this round, that it may not use group_name AT head_idx again --
+    nothing broader than that. This is deliberately narrow: rather than
+    freezing a dependent's entire row (which would also forbid it from ever
+    moving again, or from reconsidering other labels elsewhere, even for
+    unrelated reasons in some later round), it only rules out recreating
+    the EXACT conflict just resolved. A dependent that was pushed away
+    remains free to be reconsidered structurally in a later round if that
+    round's own repair happens to affect it; it just can't silently drift
+    back to (head_idx, group_name) again, since every label lookup for that
+    pair consults excluded_groups first. Without this, a later round --
+    fixing a different, unrelated violation -- reruns CLE and recomputes
+    labels with no memory of what an earlier round decided, and can revert
+    it (relabeling a dependent back to its original, violating label; or,
+    for a dependent that was rerouted, if it were ever reconsidered again,
+    landing back on the same excluded combination).
+
+    Returns (tree, raw_label_ids), where raw_label_ids is a list of raw label
+    indices (0..num_relations-1, no VOCAB_PREFIX_SIZE offset), one per real
+    word (tree[1:]).
+    """
+    num_relations = label_log_probs.shape[-1]
+    # precompute, once, which SINGLETON_DEPREL_GROUPS group (if any) each raw
+    # label id belongs to -- static per vocab, cheap to build per sentence
+    deprel_id_to_group = [DEPREL_TO_GROUP.get(vocab.unmap([r + VOCAB_PREFIX_SIZE])[0])
+                          for r in range(num_relations)]
+
+    # persistent memory: (dependent_word_idx, head_idx) -> set of groups that
+    # dependent may no longer use AT THAT HEAD, because an earlier round
+    # already decided it must yield the group there to a different dependent
+    excluded_groups = defaultdict(set)
+
+    def label_for(dep, head, extra_exclude=None):
+        exclude = excluded_groups.get((dep, head), set())
+        if extra_exclude:
+            exclude = exclude | {extra_exclude}
+        return label_for_arc(label_log_probs, deprel_id_to_group, dep, head, exclude)
+
+    def labels_for_tree(t):
+        return [label_for(j, t[j])[0] for j in range(1, len(t))]
+
+    def combined_score(t, raw_ids):
+        return sum(scores[j, t[j]] + label_log_probs[j, t[j], raw_ids[j-1]]
+                  for j in range(1, len(t)))
+
+    raw_ids = labels_for_tree(tree)
+
+    for _ in range(max_iterations):
+        deprel_strs = vocab.unmap([r + VOCAB_PREFIX_SIZE for r in raw_ids])
+        violations = find_head_constraint_violations(tree, deprel_strs)
+        if not violations:
+            break
+        head_idx, group_name, deps = violations[0]
+
+        best_candidate = None
+        for keep_idx in range(len(deps)):
+            trial_scores = scores.copy()
+            for k, dep in enumerate(deps):
+                if k == keep_idx:
+                    continue
+                # combined row: best label available at each candidate head,
+                # respecting any exclusions persisted from earlier rounds,
+                # plus THIS round's exclusion of group_name at head_idx
+                best_label_per_head = np.empty(len(tree))
+                for h in range(len(tree)):
+                    extra = group_name if h == head_idx else None
+                    _, best_score = label_for(dep, h, extra_exclude=extra)
+                    best_label_per_head[h] = best_score
+                trial_scores[dep, :] = scores[dep, :] + best_label_per_head
+            trial_tree = chuliu_edmonds_one_root(trial_scores)
+            trial_ids = labels_for_tree(trial_tree)
+            # if a pushed-away dependent still ended up back at head_idx,
+            # its label must additionally exclude group_name THIS round
+            # (not yet persisted into excluded_groups)
+            for k, dep in enumerate(deps):
+                if k != keep_idx and trial_tree[dep] == head_idx:
+                    trial_ids[dep - 1], _ = label_for(dep, head_idx, extra_exclude=group_name)
+            trial_score = combined_score(trial_tree, trial_ids)
+            if best_candidate is None or trial_score > best_candidate[0]:
+                best_candidate = (trial_score, trial_tree, trial_ids, keep_idx)
+
+        tree = best_candidate[1]
+        raw_ids = best_candidate[2]
+        winning_keep_idx = best_candidate[3]
+
+        # persist the exclusion only for the dependents that yielded the
+        # group this round -- the one that kept it remains free to use it
+        # here again, since it was never part of the conflict being resolved
+        for k, dep in enumerate(deps):
+            if k != winning_keep_idx:
+                excluded_groups[(dep, head_idx)].add(group_name)
+
+    return tree, raw_ids

--- a/stanza/models/depparse/model.py
+++ b/stanza/models/depparse/model.py
@@ -18,6 +18,7 @@ from stanza.models.common.utils import attach_bert_model
 from stanza.models.common.vocab import CompositeVocab, VOCAB_PREFIX_SIZE
 from stanza.models.common.char_model import CharacterModel, CharacterLanguageModel
 from stanza.models.common import utils
+from stanza.models.depparse.head_constraints import resolve_head_constraint_violations
 
 logger = logging.getLogger('stanza')
 
@@ -266,9 +267,22 @@ class GraphParser(EmbeddingParser):
         self.crit = nn.CrossEntropyLoss(ignore_index=-1, reduction='sum') # ignore padding
 
     @staticmethod
-    def decode_graph_predictions(vocab, batch_size, preds, sentlens):
-        head_seqs = [chuliu_edmonds_one_root(adj[:l, :l])[1:] for adj, l in zip(preds[0], sentlens)] # remove attachment for the root
-        deprel_seqs = [vocab.unmap([preds[1][i][j+1][h] for j, h in enumerate(hs)]) for i, hs in enumerate(head_seqs)]
+    def decode_graph_predictions(vocab, batch_size, preds, sentlens, resolve_violations=False):
+        head_seqs = []
+        deprel_seqs = []
+        for i, l in enumerate(sentlens):
+            scores = preds[0][i][:l, :l]
+            labels = preds[1][i]
+            tree = chuliu_edmonds_one_root(scores)
+            if resolve_violations:
+                label_log_probs = preds[2][i][:l, :l, :]
+                tree, raw_label_ids = resolve_head_constraint_violations(scores, label_log_probs, tree, vocab)
+                deprels = vocab.unmap([r + VOCAB_PREFIX_SIZE for r in raw_label_ids])
+            else:
+                hs = tree[1:]
+                deprels = vocab.unmap([labels[j+1][h] for j, h in enumerate(hs)])
+            head_seqs.append(tree[1:]) # remove attachment for the root
+            deprel_seqs.append(deprels)
         pred_tokens = [[[head_seqs[i][j], deprel_seqs[i][j]] for j in range(sentlens[i]-1)] for i in range(batch_size)]
         return pred_tokens
 
@@ -344,6 +358,10 @@ class GraphParser(EmbeddingParser):
             loss = 0
             preds.append(F.log_softmax(unlabeled_scores, 2).detach().cpu().numpy())
             preds.append(deprel_scores.max(3)[1].detach().cpu().numpy() + VOCAB_PREFIX_SIZE)
+            # full per-arc label log-probs (not just the argmax) -- needed so a
+            # constraint-violation repair can consider "same arc, second-best
+            # label" as an alternative to rerouting the arc entirely
+            preds.append(F.log_softmax(deprel_scores, 3).detach().cpu().numpy())
 
         return loss, preds
 
@@ -356,10 +374,10 @@ class GraphParser(EmbeddingParser):
         loss, _ = self.forward(*args, **kwargs)
         return loss, None
 
-    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text):
+    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text, resolve_violations=False):
         batch_size = word.size(0)
         _, preds = self(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text)
-        pred_tokens = self.decode_graph_predictions(self.vocab['deprel'], batch_size, preds, sentlens)
+        pred_tokens = self.decode_graph_predictions(self.vocab['deprel'], batch_size, preds, sentlens, resolve_violations=resolve_violations)
         return pred_tokens
 
 class EnsembleGraphParser(BaseParser):
@@ -406,14 +424,15 @@ class EnsembleGraphParser(BaseParser):
             preds = []
             preds.append(F.log_softmax(unlabeled_scores, 2).detach().cpu().numpy())
             preds.append(deprel_scores.max(3)[1].detach().cpu().numpy())
+            preds.append(F.log_softmax(deprel_scores, 3).detach().cpu().numpy())
 
         return loss, preds
 
     # TODO: refactor this?
-    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text):
+    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text, resolve_violations=False):
         batch_size = word.size(0)
         _, preds = self(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text)
-        pred_tokens = GraphParser.decode_graph_predictions(self.vocab['deprel'], batch_size, preds, sentlens)
+        pred_tokens = GraphParser.decode_graph_predictions(self.vocab['deprel'], batch_size, preds, sentlens, resolve_violations=resolve_violations)
         return pred_tokens
 
     def get_device(self):

--- a/stanza/models/depparse/model.py
+++ b/stanza/models/depparse/model.py
@@ -267,14 +267,14 @@ class GraphParser(EmbeddingParser):
         self.crit = nn.CrossEntropyLoss(ignore_index=-1, reduction='sum') # ignore padding
 
     @staticmethod
-    def decode_graph_predictions(vocab, batch_size, preds, sentlens, resolve_violations=False):
+    def decode_graph_predictions(vocab, batch_size, preds, sentlens, resolve_head_constraints=False):
         head_seqs = []
         deprel_seqs = []
         for i, l in enumerate(sentlens):
             scores = preds[0][i][:l, :l]
             labels = preds[1][i]
             tree = chuliu_edmonds_one_root(scores)
-            if resolve_violations:
+            if resolve_head_constraints:
                 label_log_probs = preds[2][i][:l, :l, :]
                 tree, raw_label_ids = resolve_head_constraint_violations(scores, label_log_probs, tree, vocab)
                 deprels = vocab.unmap([r + VOCAB_PREFIX_SIZE for r in raw_label_ids])
@@ -374,10 +374,10 @@ class GraphParser(EmbeddingParser):
         loss, _ = self.forward(*args, **kwargs)
         return loss, None
 
-    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text, resolve_violations=False):
+    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text, resolve_head_constraints=False):
         batch_size = word.size(0)
         _, preds = self(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text)
-        pred_tokens = self.decode_graph_predictions(self.vocab['deprel'], batch_size, preds, sentlens, resolve_violations=resolve_violations)
+        pred_tokens = self.decode_graph_predictions(self.vocab['deprel'], batch_size, preds, sentlens, resolve_head_constraints=resolve_head_constraints)
         return pred_tokens
 
 class EnsembleGraphParser(BaseParser):
@@ -429,10 +429,10 @@ class EnsembleGraphParser(BaseParser):
         return loss, preds
 
     # TODO: refactor this?
-    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text, resolve_violations=False):
+    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text, resolve_head_constraints=False):
         batch_size = word.size(0)
         _, preds = self(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text)
-        pred_tokens = GraphParser.decode_graph_predictions(self.vocab['deprel'], batch_size, preds, sentlens, resolve_violations=resolve_violations)
+        pred_tokens = GraphParser.decode_graph_predictions(self.vocab['deprel'], batch_size, preds, sentlens, resolve_head_constraints=resolve_head_constraints)
         return pred_tokens
 
     def get_device(self):

--- a/stanza/models/depparse/scorer.py
+++ b/stanza/models/depparse/scorer.py
@@ -2,7 +2,7 @@
 Utils and wrappers for scoring parsers.
 """
 
-from collections import Counter
+from collections import Counter, defaultdict, namedtuple
 import logging
 
 from stanza.models.common.utils import ud_scores
@@ -60,6 +60,185 @@ def score_named_dependencies(pred_doc, gold_doc, output_latex=False):
     if output_latex:
         log_lines.append(r"\end{tabular}")
     logger.info("F1 scores for each dependency:\n  Note that unlabeled attachment errors hurt the labeled attachment scores\n%s" % "\n".join(log_lines))
+
+# groups of deprels which are mutually exclusive per head -- a single head
+# should never have more than one edge belonging to the same group.
+#
+# nsubj:pass / csubj:pass collapse into the ordinary subj group (a head
+# still shouldn't have two of nsubj/csubj/nsubj:pass/csubj:pass combined).
+#
+# nsubj:outer / csubj:outer are their own group instead, since a head can
+# legitimately have both a plain nsubj/csubj AND an nsubj:outer/csubj:outer
+# at once -- this is the "outer" clausal subject of a copula construction, eg:
+#   "The thing to keep in mind is that X, Y, and Z are more dangerous..."
+# where "thing" is nsubj:outer of "likely" and "nationalists" is a separate,
+# ordinary nsubj of the same head ("likely").
+SINGLETON_DEPREL_GROUPS = {
+    "subj": {"nsubj", "csubj", "nsubj:pass", "csubj:pass"},
+    "subj_outer": {"nsubj:outer", "csubj:outer"},
+    "obj": {"obj"},
+}
+
+# reverse lookup built from SINGLETON_DEPREL_GROUPS: exact deprel -> group name
+DEPREL_TO_GROUP = {deprel: group_name
+                    for group_name, deprels in SINGLETON_DEPREL_GROUPS.items()
+                    for deprel in deprels}
+
+def _deprel_group_key(deprel):
+    """ Maps a deprel to the SINGLETON_DEPREL_GROUPS key it belongs to, or None
+    if it isn't covered by any singleton constraint. """
+    return DEPREL_TO_GROUP.get(deprel)
+
+ViolationExample = namedtuple("ViolationExample", ["label", "sent_idx", "head_text", "group_name", "dep_desc"])
+
+def count_head_constraint_violations(pred_doc, collect_examples=True, label=None):
+    """
+    Pure counting pass over pred_doc: no logging, so this is safe (and cheap)
+    to call once per chunk when a large corpus has to be parsed and processed
+    in pieces rather than as a single Document.
+
+    Counts, for each SINGLETON_DEPREL_GROUPS entry, how many heads in pred_doc
+    have more than one dependent whose deprel maps to that group (see
+    _deprel_group_key for the exact mapping, including the nsubj:outer/
+    csubj:outer exception).
+
+    For example, a verb with both an nsubj and a csubj child is one violation
+    of the "subj" group, as is a verb with two nsubj children. A verb with one
+    nsubj:outer and one ordinary nsubj is NOT a violation (different groups).
+
+    Also tracks two extra things useful for deciding how to handle these:
+      - valency_counts[group_name]: a Counter of how many dependents were
+        actually involved in each violation (2, 3, ...), so eg "2 obj" and
+        "3 obj" violations aren't conflated -- helps answer "is it always
+        just doubled up, or does it go higher?"
+      - violations_per_sentence: a Counter of how many separate (head, group)
+        violations occurred together in the same sentence, across all
+        sentences (sentences with 0 violations are included too) -- helps
+        answer "when this happens, is it usually an isolated problem in the
+        sentence, or do several crop up at once?"
+
+    label is an optional identifier (eg a filename or chunk number) attached
+    to any collected examples, so that when results from many chunks get
+    merged together, debug output can still say which chunk an example came
+    from. If collect_examples is False, examples are skipped entirely --
+    worth doing for a very large corpus run where you only care about the
+    aggregate counts, since the violation rate is typically low (~1%) but
+    the raw text of every example can still add up over a huge corpus.
+
+    Returns a dict with keys:
+      'counts': Counter(group_name -> total violating heads)
+      'valency_counts': dict(group_name -> Counter(valency -> number of heads))
+      'violations_per_sentence': Counter(num_violations_in_sentence -> num_sentences)
+      'total_sentences': int
+      'examples': list of ViolationExample namedtuples (label, sent_idx, head_text, group_name, dep_desc)
+    """
+    violation_counts = Counter()
+    valency_counts = defaultdict(Counter)
+    violations_per_sentence = Counter()
+    examples = []
+    for sent_idx, sentence in enumerate(pred_doc.sentences):
+        # words indexed by id so we can report the head's text as well
+        words_by_id = {int(word.id): word for word in sentence.words}
+        # head_id -> group_name -> list of dependent words in that group
+        deps_per_head = defaultdict(lambda: defaultdict(list))
+        for word in sentence.words:
+            group_name = _deprel_group_key(word.deprel)
+            if group_name is not None:
+                deps_per_head[word.head][group_name].append(word)
+        sentence_violation_count = 0
+        for head_id, groups in deps_per_head.items():
+            for group_name, deps in groups.items():
+                if len(deps) > 1:
+                    violation_counts[group_name] += 1
+                    valency_counts[group_name][len(deps)] += 1
+                    sentence_violation_count += 1
+                    if collect_examples:
+                        head_text = words_by_id[head_id].text if head_id in words_by_id else "ROOT"
+                        dep_desc = ", ".join("{}/{}".format(w.text, w.deprel) for w in deps)
+                        examples.append(ViolationExample(label, sent_idx, head_text, group_name, dep_desc))
+        violations_per_sentence[sentence_violation_count] += 1
+
+    return {
+        'counts': violation_counts,
+        'valency_counts': dict(valency_counts),
+        'violations_per_sentence': violations_per_sentence,
+        'total_sentences': len(pred_doc.sentences),
+        'examples': examples,
+    }
+
+def merge_violation_results(results):
+    """
+    Combines multiple count_head_constraint_violations() outputs (eg one per
+    chunk of a large corpus that had to be parsed in pieces) into a single
+    aggregate dict with the same shape, suitable for passing to
+    log_head_constraint_violations().
+    """
+    merged_counts = Counter()
+    merged_valency = defaultdict(Counter)
+    merged_per_sentence = Counter()
+    merged_examples = []
+    total_sentences = 0
+    for result in results:
+        merged_counts.update(result['counts'])
+        for group_name, valency_counter in result['valency_counts'].items():
+            merged_valency[group_name].update(valency_counter)
+        merged_per_sentence.update(result['violations_per_sentence'])
+        merged_examples.extend(result['examples'])
+        total_sentences += result['total_sentences']
+    return {
+        'counts': merged_counts,
+        'valency_counts': dict(merged_valency),
+        'violations_per_sentence': merged_per_sentence,
+        'total_sentences': total_sentences,
+        'examples': merged_examples,
+    }
+
+def log_head_constraint_violations(result, log_examples=True):
+    """
+    Logging-only step: takes the dict returned by
+    count_head_constraint_violations() (or merge_violation_results(), for
+    a whole corpus processed in chunks) and logs a summary.
+    """
+    counts = result['counts']
+    valency_counts = result['valency_counts']
+    violations_per_sentence = result['violations_per_sentence']
+    total_sentences = result['total_sentences']
+    examples = result.get('examples', [])
+
+    if log_examples:
+        for example in examples:
+            if example.label is None:
+                logger.debug("Sentence %d: head '%s' has multiple '%s' dependents: %s",
+                             example.sent_idx, example.head_text, example.group_name, example.dep_desc)
+            else:
+                logger.debug("%s sentence %d: head '%s' has multiple '%s' dependents: %s",
+                             example.label, example.sent_idx, example.head_text, example.group_name, example.dep_desc)
+
+    for group_name, count in counts.items():
+        valency_desc = ", ".join("{}x{}: {}".format(valency, group_name, num)
+                                  for valency, num in sorted(valency_counts[group_name].items()))
+        logger.info("Head constraint violations for group '%s': %d (out of %d sentences) [%s]",
+                    group_name, count, total_sentences, valency_desc)
+    if not counts:
+        logger.info("No head constraint violations found (groups checked: %s)",
+                    ", ".join(SINGLETON_DEPREL_GROUPS.keys()))
+
+    sentence_dist_desc = ", ".join("{} violations: {} sentences".format(n, num)
+                                     for n, num in sorted(violations_per_sentence.items()))
+    logger.info("Violations per sentence: %s", sentence_dist_desc)
+
+def check_head_constraint_violations(pred_doc, log_examples=True):
+    """
+    Convenience wrapper: count + log in one call, for the common
+    single-document case (eg the normal train/dev/test eval loop).
+    For a corpus too large to hold as one Document, call
+    count_head_constraint_violations() per chunk, merge_violation_results()
+    to combine them, and log_head_constraint_violations() once at the end
+    instead.
+    """
+    result = count_head_constraint_violations(pred_doc, collect_examples=log_examples)
+    log_head_constraint_violations(result, log_examples=log_examples)
+    return result
 
 def score(system_conllu_file, gold_conllu_file, verbose=True):
     """ Wrapper for UD parser scorer. """

--- a/stanza/models/depparse/scorer.py
+++ b/stanza/models/depparse/scorer.py
@@ -6,6 +6,7 @@ from collections import Counter, defaultdict, namedtuple
 import logging
 
 from stanza.models.common.utils import ud_scores
+from stanza.models.depparse.head_constraints import SINGLETON_DEPREL_GROUPS, DEPREL_TO_GROUP
 
 logger = logging.getLogger('stanza')
 
@@ -60,29 +61,6 @@ def score_named_dependencies(pred_doc, gold_doc, output_latex=False):
     if output_latex:
         log_lines.append(r"\end{tabular}")
     logger.info("F1 scores for each dependency:\n  Note that unlabeled attachment errors hurt the labeled attachment scores\n%s" % "\n".join(log_lines))
-
-# groups of deprels which are mutually exclusive per head -- a single head
-# should never have more than one edge belonging to the same group.
-#
-# nsubj:pass / csubj:pass collapse into the ordinary subj group (a head
-# still shouldn't have two of nsubj/csubj/nsubj:pass/csubj:pass combined).
-#
-# nsubj:outer / csubj:outer are their own group instead, since a head can
-# legitimately have both a plain nsubj/csubj AND an nsubj:outer/csubj:outer
-# at once -- this is the "outer" clausal subject of a copula construction, eg:
-#   "The thing to keep in mind is that X, Y, and Z are more dangerous..."
-# where "thing" is nsubj:outer of "likely" and "nationalists" is a separate,
-# ordinary nsubj of the same head ("likely").
-SINGLETON_DEPREL_GROUPS = {
-    "subj": {"nsubj", "csubj", "nsubj:pass", "csubj:pass"},
-    "subj_outer": {"nsubj:outer", "csubj:outer"},
-    "obj": {"obj"},
-}
-
-# reverse lookup built from SINGLETON_DEPREL_GROUPS: exact deprel -> group name
-DEPREL_TO_GROUP = {deprel: group_name
-                    for group_name, deprels in SINGLETON_DEPREL_GROUPS.items()
-                    for deprel in deprels}
 
 def _deprel_group_key(deprel):
     """ Maps a deprel to the SINGLETON_DEPREL_GROUPS key it belongs to, or None

--- a/stanza/models/depparse/trainer.py
+++ b/stanza/models/depparse/trainer.py
@@ -155,13 +155,21 @@ class Trainer(BaseTrainer, ABC):
             opt.step()
         return loss_val, batch_stats
 
-    def predict(self, batch, unsort=True):
+    def predict(self, batch, unsort=True, resolve_head_constraints=False):
         device = self.model.get_device()
         inputs, orig_idx, word_orig_idx, sentlens, wordlens, text = unpack_batch(batch, device)
         word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel = inputs
 
         self.model.eval()
-        pred_tokens = self.model.predict(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text)
+        # resolve_head_constraints is accepted by every model's predict(),
+        # graph or transition -- the transition parser doesn't yet have a
+        # repair implemented for it (its greedy, locally-legal transitions
+        # can still produce head-constraint violations; it's just not
+        # something we've built a fix for there, since currently that
+        # parser is only used to build silver datasets rather than for
+        # user-facing parsing), but the parameter exists on both so this
+        # call doesn't need to dispatch on model type
+        pred_tokens = self.model.predict(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text, resolve_head_constraints=resolve_head_constraints)
         if unsort:
             pred_tokens = utils.unsort(pred_tokens, orig_idx)
         if self.args.get('reversed', False):

--- a/stanza/models/depparse/transition/model.py
+++ b/stanza/models/depparse/transition/model.py
@@ -1,5 +1,6 @@
 from collections import Counter, namedtuple
 from enum import Enum
+import warnings
 
 import torch
 from torch import nn
@@ -715,7 +716,22 @@ class TransitionParser(EmbeddingParser):
         self.update_partial_tree_lstm(states, range(len(states)), partial_tree_h0, partial_tree_c0)
         return states
 
-    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text):
+    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text, resolve_head_constraints=False):
+        # NOTE: the transition parser's greedy choose_transitions step only
+        # checks LOCAL legality (is_legal on the current parser state) --
+        # it has no equivalent to the graph parser's global rescoring, so
+        # head-constraint violations (more than one nsubj/csubj or obj on a
+        # single head) are NOT actually prevented here. Unlike the graph
+        # parser, there's no arc-score matrix to rerun Chu-Liu-Edmonds
+        # against, so the head_constraints repair mechanism doesn't carry
+        # over directly; a transition-parser-specific repair would need its
+        # own design (eg patching the finished parsed_graph post-hoc). Since
+        # this parser is currently only used to build silver datasets rather
+        # than for user-facing parsing, that gap matters less here than in
+        # the graph parser, but the parameter is accepted for interface
+        # parity with GraphParser/EnsembleGraphParser.predict.
+        if resolve_head_constraints:
+            warnings.warn("resolve_head_constraints=True was requested, but this is not yet implemented for the transition parser; predictions may still contain head-constraint violations.", stacklevel=2)
         lstm_outputs = self.embed(word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text)
         states = self.build_initial_states(head, deprel, text, lstm_outputs, sentlens)
         device = next(self.parameters()).device
@@ -833,7 +849,11 @@ class EnsembleTransitionParser(BaseParser):
         model_partial_tree_c0 = [x[6] for x in model_forwards]
         return output_hx, left_deprels, right_deprels, model_transition_h0, model_transition_c0, model_partial_tree_h0, model_partial_tree_c0
 
-    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text):
+    def predict(self, word, word_mask, wordchars, wordchars_mask, upos, xpos, ufeats, pretrained, lemma, head, deprel, word_orig_idx, sentlens, wordlens, text, resolve_head_constraints=False):
+        # see TransitionParser.predict -- not yet implemented for the
+        # transition-based parser, accepted here only for interface parity
+        if resolve_head_constraints:
+            warnings.warn("resolve_head_constraints=True was requested, but this is not yet implemented for the transition parser; predictions may still contain head-constraint violations.", stacklevel=2)
         device = self.get_device()
 
         model_states = []

--- a/stanza/models/depparse/utils.py
+++ b/stanza/models/depparse/utils.py
@@ -6,12 +6,12 @@ import torch
 
 from stanza.models.common import utils
 
-def predict_dataset(trainer, dev_batch):
+def predict_dataset(trainer, dev_batch, resolve_head_constraints=False):
     with torch.no_grad(), utils.evaluating(trainer.model):
         dev_preds = []
         if len(dev_batch) > 0:
             for batch in dev_batch:
-                preds = trainer.predict(batch)
+                preds = trainer.predict(batch, resolve_head_constraints=resolve_head_constraints)
                 dev_preds += preds
             dev_preds = utils.unsort(dev_preds, dev_batch.data_orig_idx)
     return dev_preds

--- a/stanza/models/parser.py
+++ b/stanza/models/parser.py
@@ -566,6 +566,11 @@ def evaluate_trainer(args, trainer, pretrain):
     if system_pred_file:
         CoNLL.write_doc2conll(batch.doc, system_pred_file)
 
+    # check the predicted parses for heads with more than one nsubj/csubj
+    # or more than one obj, since these are not enforced by the parsing
+    # algorithm itself (unlike the single root constraint)
+    scorer.check_head_constraint_violations(batch.doc)
+
     if args['gold_labels']:
         gold_doc = CoNLL.conll2doc(input_file=args['eval_file'])
 

--- a/stanza/models/parser.py
+++ b/stanza/models/parser.py
@@ -81,6 +81,7 @@ def build_argparse():
     parser.add_argument('--output_file', type=str, default=None, help='Output CoNLL-U file.')
     parser.add_argument('--no_gold_labels', dest='gold_labels', action='store_false', help="Don't score the eval file - perhaps it has no gold labels, for example.  Cannot be used at training time")
     parser.add_argument('--output_latex', default=False, action='store_true', help='Output the per-relation table in Latex form')
+    parser.add_argument('--resolve_head_constraints', default=False, action='store_true', help="Repair head-constraint violations (more than one nsubj/csubj or obj on a single head) in the predicted output. Off by default for eval, so LAS/UAS reflect the model's own raw output rather than a post-hoc repair; the running pipeline defaults this to on instead.")
     parser.add_argument('--mode', default='train', choices=['train', 'predict'])
     parser.add_argument('--lang', type=str, help='Language')
     parser.add_argument('--shorthand', type=str, help="Treebank shorthand")
@@ -559,7 +560,7 @@ def evaluate_trainer(args, trainer, pretrain):
     doc = CoNLL.conll2doc(input_file=args['eval_file'])
     batch = DataLoader(doc, args['batch_size'], loaded_args, pretrain, vocab=vocab, evaluation=True, sort_during_eval=True)
 
-    preds = predict_dataset(trainer, batch)
+    preds = predict_dataset(trainer, batch, resolve_head_constraints=args.get('resolve_head_constraints', False))
 
     # write to file and score
     batch.doc.set([HEAD, DEPREL], [y for x in preds for y in x])

--- a/stanza/pipeline/depparse_processor.py
+++ b/stanza/pipeline/depparse_processor.py
@@ -65,8 +65,9 @@ class DepparseProcessor(UDProcessor):
                                min_length_to_batch_separately=self.config.get('min_length_to_batch_separately', DEFAULT_SEPARATE_BATCH))
             with torch.no_grad():
                 preds = []
+                resolve_head_constraints = self.config.get('resolve_head_constraints', True)
                 for i, b in enumerate(batch):
-                    preds += self.trainer.predict(b)
+                    preds += self.trainer.predict(b, resolve_head_constraints=resolve_head_constraints)
             if batch.data_orig_idx is not None:
                 preds = unsort(preds, batch.data_orig_idx)
             batch.doc.set((doc.HEAD, doc.DEPREL), [y for x in preds for y in x])

--- a/stanza/tests/depparse/test_head_constraints.py
+++ b/stanza/tests/depparse/test_head_constraints.py
@@ -1,0 +1,267 @@
+"""
+Test the head-constraint violation detection and repair logic:
+heads that end up with more than one nsubj/csubj, or more than one obj,
+which the arc-factored graph parser and Chu-Liu-Edmonds do not enforce
+on their own.
+"""
+
+import numpy as np
+import pytest
+
+from stanza.models.common.chuliu_edmonds import chuliu_edmonds_one_root
+from stanza.models.common.vocab import VOCAB_PREFIX_SIZE
+from stanza.models.pos.vocab import WordVocab
+from stanza.models.depparse.head_constraints import (
+    find_head_constraint_violations,
+    resolve_head_constraint_violations,
+)
+
+pytestmark = [pytest.mark.travis, pytest.mark.pipeline]
+
+def make_deprel_vocab(labels):
+    """
+    Builds a real deprel WordVocab (the same class stanza.models.depparse.data
+    uses for the deprel vocab) from a plain list of label strings, so these
+    tests exercise the actual Vocab interface -- unit2id/unmap, and the real
+    VOCAB_PREFIX_SIZE offset -- rather than an approximation of it.
+    """
+    data = [[(label,) for label in labels]]
+    return WordVocab(data, idx=0, cutoff=0)
+
+
+def test_find_head_constraint_violations_basic():
+    """ A clean tree (one nsubj, one obj) has no violations """
+    tree = [0, 3, 3, 0]
+    deprels = ["nsubj", "obj", "root"]
+    assert find_head_constraint_violations(tree, deprels) == []
+
+def test_find_head_constraint_violations_double_obj():
+    """ Two objs on the same head is a violation """
+    tree = [0, 1, 1]
+    deprels = ["obj", "obj"]
+    violations = find_head_constraint_violations(tree, deprels)
+    assert len(violations) == 1
+    head_idx, group_name, deps = violations[0]
+    assert head_idx == 1
+    assert group_name == "obj"
+    assert deps == [1, 2]
+
+def test_find_head_constraint_violations_nsubj_csubj_mixed():
+    """ An nsubj and a csubj on the same head are still a single 'subj' violation """
+    tree = [0, 3, 3, 0]
+    deprels = ["nsubj", "csubj", "root"]
+    violations = find_head_constraint_violations(tree, deprels)
+    assert len(violations) == 1
+    assert violations[0][1] == "subj"
+
+def test_find_head_constraint_violations_outer_exception():
+    """
+    nsubj:outer/csubj:outer is a SEPARATE group from plain nsubj/csubj, so a
+    head with one of each is legal -- the "outer" clausal subject of a
+    copula construction, eg:
+      "The thing to keep in mind is that X, Y, and Z are more dangerous..."
+    where "thing" is nsubj:outer of "likely" and "nationalists" is a
+    separate, ordinary nsubj of that same head.
+    """
+    tree = [0, 19, 19, 0]
+    deprels = ["nsubj:outer", "nsubj", "root"]
+    assert find_head_constraint_violations(tree, deprels) == []
+
+    # but two nsubj:outer on the same head IS a violation
+    deprels_violating = ["nsubj:outer", "nsubj:outer", "root"]
+    violations = find_head_constraint_violations(tree, deprels_violating)
+    assert len(violations) == 1
+    assert violations[0][1] == "subj_outer"
+
+
+def test_resolve_label_swap():
+    """
+    "I gave the cat a fish": the model slightly (and wrongly) prefers
+    obj(gave, cat) over iobj(gave, cat), while obj(gave, fish) is genuinely
+    correct. Since the arc "cat -> gave" is highly confident on its own
+    (cat has no plausible alternative head), the correct repair is to
+    relabel cat to iobj IN PLACE, not to reroute it to a different head.
+    """
+    vocab = make_deprel_vocab(["root", "nsubj", "obj", "iobj", "det", "punct"])
+    n = 7  # 0=root, 1=I, 2=gave, 3=the, 4=cat, 5=a, 6=fish
+    scores = np.full((n, n), -30.0)
+    scores[0, 0] = 0
+    scores[2, 0] = -1.0
+    scores[1, 2] = -1.0
+    scores[3, 4] = -1.0
+    scores[5, 6] = -1.0
+    # cat's only plausible head is "gave"; everywhere else is a bad arc
+    scores[4, 2] = -1.0
+    for h in (0, 1, 3, 5, 6):
+        scores[4, h] = -20.0
+    # fish's only plausible head is also "gave"
+    scores[6, 2] = -1.2
+    for h in (0, 1, 3, 4, 5):
+        scores[6, h] = -20.0
+
+    label_log_probs = np.full((n, n, len(vocab) - VOCAB_PREFIX_SIZE), -10.0)
+    def set_label(dep, head, label, score):
+        label_log_probs[dep, head, vocab.unit2id(label) - VOCAB_PREFIX_SIZE] = score
+    set_label(2, 0, "root", -0.1)
+    set_label(1, 2, "nsubj", -0.1)
+    set_label(3, 4, "det", -0.1)
+    set_label(5, 6, "det", -0.1)
+    set_label(4, 2, "obj", -0.5)   # cat's best (wrong) label
+    set_label(4, 2, "iobj", -0.6)  # cat's correct label, a close second
+    set_label(6, 2, "obj", -0.2)   # fish's best (correct) label
+    set_label(6, 2, "iobj", -5.0)  # fish's alternative is clearly worse
+
+    tree = chuliu_edmonds_one_root(scores.copy())
+    fixed_tree, raw_ids = resolve_head_constraint_violations(scores, label_log_probs, tree, vocab)
+    labels = vocab.unmap([r + VOCAB_PREFIX_SIZE for r in raw_ids])
+
+    np.testing.assert_array_equal(fixed_tree, tree)  # structure is unchanged
+    assert labels[3] == "iobj"  # cat: relabeled
+    assert labels[5] == "obj"   # fish: unchanged
+    assert find_head_constraint_violations(fixed_tree, labels) == []
+
+def test_resolve_structural_reroute():
+    """
+    When relabeling in place would be a bad option (no decent non-group
+    label exists for one of the offending dependents on its current arc),
+    but a genuinely good alternative HEAD exists, the repair should reroute
+    that dependent structurally instead of forcing a poor label choice.
+    """
+    vocab = make_deprel_vocab(["root", "nsubj", "csubj", "obj", "advmod"])
+    n = 5  # 0=root, 1=verb, 2=subjA, 3=subjB, 4=otherhead
+    scores = np.full((n, n), -30.0)
+    scores[0, 0] = 0
+    scores[1, 0] = -1.0
+    scores[2, 1] = -1.0
+    scores[3, 1] = -1.05   # subjB's arc to verb is decent
+    scores[3, 4] = -1.1    # subjB's arc to otherhead is nearly as good
+    scores[4, 1] = -1.0
+
+    label_log_probs = np.full((n, n, len(vocab) - VOCAB_PREFIX_SIZE), -10.0)
+    def set_label(dep, head, label, score):
+        label_log_probs[dep, head, vocab.unit2id(label) - VOCAB_PREFIX_SIZE] = score
+    set_label(1, 0, "root", -0.1)
+    set_label(2, 1, "nsubj", -0.1)
+    set_label(3, 1, "nsubj", -0.15)     # subjB's current (conflicting) label
+    set_label(3, 1, "advmod", -8.0)     # subjB's only non-group option here is terrible
+    set_label(3, 4, "obj", -0.2)        # subjB's label if rerouted: great
+    set_label(4, 1, "obj", -0.1)
+
+    tree = chuliu_edmonds_one_root(scores.copy())
+    fixed_tree, raw_ids = resolve_head_constraint_violations(scores, label_log_probs, tree, vocab)
+    labels = vocab.unmap([r + VOCAB_PREFIX_SIZE for r in raw_ids])
+
+    assert fixed_tree[3] == 4  # subjB rerouted to otherhead
+    assert find_head_constraint_violations(fixed_tree, labels) == []
+
+def test_resolve_valency_three():
+    """ A head with THREE competing objs, not just two, should still resolve cleanly """
+    vocab = make_deprel_vocab(["root", "nsubj", "csubj", "obj", "advmod", "obl"])
+    n = 6  # 0=root, 1/2/3=competing objs, 4=verb, 5=harmless obl dependent
+    scores = np.full((n, n), -30.0)
+    scores[0, 0] = 0
+    scores[1, 4] = -0.5; scores[1, 5] = -3.0; scores[1, 0] = -10.0
+    scores[2, 4] = -1.0; scores[2, 5] = -1.2; scores[2, 0] = -10.0
+    scores[3, 4] = -1.5; scores[3, 5] = -1.6; scores[3, 0] = -10.0
+    scores[4, 0] = -1.0
+    for h in (1, 2, 3, 5):
+        scores[4, h] = -10.0
+    scores[5, 4] = -1.0
+    for h in (0, 1, 2, 3):
+        scores[5, h] = -10.0
+
+    label_log_probs = np.full((n, n, len(vocab) - VOCAB_PREFIX_SIZE), -10.0)
+    def set_label(dep, head, label, score):
+        label_log_probs[dep, head, vocab.unit2id(label) - VOCAB_PREFIX_SIZE] = score
+    set_label(1, 4, "obj", -0.2); set_label(1, 5, "advmod", -1.0); set_label(1, 0, "root", -0.1)
+    set_label(2, 4, "obj", -0.3); set_label(2, 5, "advmod", -1.5); set_label(2, 0, "root", -0.1)
+    set_label(3, 4, "obj", -0.4); set_label(3, 5, "advmod", -1.8); set_label(3, 0, "root", -0.1)
+    set_label(4, 0, "root", -0.1)
+    set_label(5, 4, "obl", -0.1)
+
+    tree = chuliu_edmonds_one_root(scores.copy())
+    initial_labels = vocab.unmap([r + VOCAB_PREFIX_SIZE for r in
+                                 [int(np.argmax(label_log_probs[j, tree[j]])) for j in range(1, len(tree))]])
+    assert len(find_head_constraint_violations(tree, initial_labels)) == 1  # sanity check on the fixture
+
+    fixed_tree, raw_ids = resolve_head_constraint_violations(scores, label_log_probs, tree, vocab)
+    labels = vocab.unmap([r + VOCAB_PREFIX_SIZE for r in raw_ids])
+    assert find_head_constraint_violations(fixed_tree, labels) == []
+
+def test_resolve_clean_sentence_is_a_noop():
+    """ A sentence with no violations should come back completely unchanged """
+    vocab = make_deprel_vocab(["root", "nsubj", "obj"])
+    n = 4
+    scores = np.full((n, n), -30.0)
+    scores[0, 0] = 0
+    scores[1, 3] = -1.0
+    scores[2, 3] = -1.1
+    scores[3, 0] = -1.0
+
+    label_log_probs = np.full((n, n, len(vocab) - VOCAB_PREFIX_SIZE), -10.0)
+    def set_label(dep, head, label, score):
+        label_log_probs[dep, head, vocab.unit2id(label) - VOCAB_PREFIX_SIZE] = score
+    set_label(1, 3, "nsubj", -0.1)
+    set_label(2, 3, "obj", -0.1)
+    set_label(3, 0, "root", -0.1)
+
+    tree = chuliu_edmonds_one_root(scores.copy())
+    fixed_tree, raw_ids = resolve_head_constraint_violations(scores, label_log_probs, tree, vocab)
+    labels = vocab.unmap([r + VOCAB_PREFIX_SIZE for r in raw_ids])
+
+    np.testing.assert_array_equal(fixed_tree, tree)
+    assert labels == ["nsubj", "obj", "root"]
+
+def test_resolve_two_independent_violations_dont_oscillate():
+    """
+    A sentence with two SEPARATE violations in different clauses: one that
+    needs a label swap ("I gave the cat a fish") and one, in a different
+    clause, that needs a structural reroute. Earlier versions of this
+    repair recomputed every word's label from scratch each round with no
+    memory of prior decisions, which caused the two fixes to repeatedly
+    undo each other (oscillating between states) instead of both holding.
+    This confirms both fixes survive together, in the same final tree.
+    """
+    vocab = make_deprel_vocab(["root", "nsubj", "csubj", "obj", "iobj", "det", "advmod"])
+    # 1=I 2=gave 3=the 4=cat 5=a 6=fish | 7=verb2 8=subjA 9=subjB 10=otherhead
+    n = 11
+    scores = np.full((n, n), -30.0)
+    scores[0, 0] = 0
+    scores[2, 0] = -1.0; scores[1, 2] = -1.0; scores[3, 4] = -1.0; scores[5, 6] = -1.0
+    scores[4, 2] = -1.0
+    for h in (0, 1, 3, 5, 6):
+        scores[4, h] = -20.0
+    scores[6, 2] = -1.2
+    for h in (0, 1, 3, 4, 5):
+        scores[6, h] = -20.0
+    scores[7, 0] = -1.0
+    scores[8, 7] = -1.0
+    scores[9, 7] = -1.05; scores[9, 10] = -1.1
+    scores[10, 7] = -1.0
+
+    label_log_probs = np.full((n, n, len(vocab) - VOCAB_PREFIX_SIZE), -10.0)
+    def set_label(dep, head, label, score):
+        label_log_probs[dep, head, vocab.unit2id(label) - VOCAB_PREFIX_SIZE] = score
+    set_label(2, 0, "root", -0.1)
+    set_label(1, 2, "nsubj", -0.1)
+    set_label(3, 4, "det", -0.1)
+    set_label(5, 6, "det", -0.1)
+    set_label(4, 2, "obj", -0.5)
+    set_label(4, 2, "iobj", -0.6)
+    set_label(6, 2, "obj", -0.2)
+    set_label(6, 2, "iobj", -5.0)
+    set_label(7, 0, "root", -0.1)
+    set_label(8, 7, "nsubj", -0.1)
+    set_label(9, 7, "nsubj", -0.15)
+    set_label(9, 7, "advmod", -8.0)
+    set_label(9, 10, "obj", -0.2)
+    set_label(10, 7, "obj", -0.1)
+
+    tree = chuliu_edmonds_one_root(scores.copy())
+    fixed_tree, raw_ids = resolve_head_constraint_violations(scores, label_log_probs, tree, vocab)
+    labels = vocab.unmap([r + VOCAB_PREFIX_SIZE for r in raw_ids])
+
+    assert labels[3] == "iobj"     # cat: label-swap fix survives
+    assert labels[5] == "obj"      # fish: unaffected, unchanged
+    assert fixed_tree[9] == 10     # subjB: reroute fix survives
+    assert find_head_constraint_violations(fixed_tree, labels) == []


### PR DESCRIPTION
Solve https://github.com/stanfordnlp/stanza/issues/1340 with the help of Claude.  Post-process a dependency parse (from the graph parser, at least) to remove any cases with multiple obj or nsubj from the same node.  Calls CLE multiple times to pick the best dependencies, but should be relatively cheap given that we can reuse the same neural scores each time.