### PR TITLE
Add columns for some additional features we can use to distinguish ad…

### DIFF
--- a/stanza/models/tokenization/data.py
+++ b/stanza/models/tokenization/data.py
@@ -262,6 +262,10 @@ class TokenizationDataset:
             if feat_func == 'end_of_para' or feat_func == 'start_of_para':
                 # skip for position-dependent features
                 continue
+            if feat_func in STRUCTURAL_FEATURES:
+                # skip here -- these are window-based, computed separately
+                # below rather than as a per-character lambda
+                continue
             if feat_func == 'space_before':
                 func = lambda x: 1 if x.startswith(' ') else 0
             elif feat_func == 'capitalized':
@@ -285,6 +289,24 @@ class TokenizationDataset:
         use_end_of_para = 'end_of_para' in self.args['feat_funcs']
         use_start_of_para = 'start_of_para' in self.args['feat_funcs']
         use_dictionary = self.args['use_dictionary']
+
+        # Structural/tabular features: computed once per paragraph
+        # as regex passes over the reconstructed raw text, rather than
+        # per character, since they need surrounding context (a phone number,
+        # date, or "Label:" span) that a single character can't see.
+        active_structural = [name for name in STRUCTURAL_FEATURES
+                              if name in self.args['feat_funcs']]
+        structural_masks = None
+        if active_structural:
+            raw_text = ''.join(c for c, _ in para)
+            structural_masks = {}
+            for name in active_structural:
+                mask = [0] * len(para)
+                for m in STRUCTURAL_FEATURES[name].finditer(raw_text):
+                    for pos in range(m.start(), m.end()):
+                        mask[pos] = 1
+                structural_masks[name] = mask
+
         current_units = []
         current_labels = []
         current_feats = []
@@ -297,6 +319,11 @@ class TokenizationDataset:
             if use_start_of_para:
                 f = 1 if i == 0 else 0
                 feats.append(f)
+
+            # structural/tabular window features
+            if structural_masks is not None:
+                for name in active_structural:
+                    feats.append(structural_masks[name][i])
 
             #if dictionary feature is selected
             if use_dictionary:
@@ -406,6 +433,82 @@ MID_SENT_AUGMENT_PAIRS = [
     (",", "\u2013"),   # comma -> en dash
     (",", "\u2014"),   # comma -> em dash
 ]
+
+# --------------------------------------------------------------------------
+# Structural / tabular text features
+#   (see https://github.com/stanfordnlp/stanza/issues/1640)
+#
+# These target the finding that gold English tokenizer training data contains
+# many genuinely-correct sentence boundaries in document-structural text
+# (news datelines, email signature blocks, tabular salary listings) that end
+# in a digit immediately followed by a capitalized word with no intervening
+# punctuation -- the exact surface pattern that was over-generalized into
+# false splits on ordinary prose ("Pope Leo X used...", "Franz Joseph I
+# ruled..."). Unlike the existing feat_funcs (space_before/capitalized/
+# numeric), these need a local window of context rather than a single
+# character, so they're computed once per paragraph as regex passes rather
+# than as per-character lambdas.
+#
+# Each regex is matched against the whole paragraph's raw text; every
+# character position falling inside a match span gets feature value 1,
+# every other position gets 0. There is deliberately no scan radius/window
+# added around a match, and no smoothing or decay -- membership in the match
+# span is all this computes.
+#
+# NOTE ON WHY THERE'S NO EXPLICIT WINDOW PARAMETER HERE:
+# This is a boolean-per-character signal, same as the existing feat_funcs,
+# and it's fed into a *bidirectional* LSTM (see model.py). A bidirectional
+# LSTM's hidden state at any position has access to both a forward pass that
+# has already seen everything up to that point and a backward pass that has
+# already seen everything from the end back to that point, so a feature
+# turned on at one character can inform the model's decision at a different
+# character on either side, as far as the LSTM's own gates choose to carry
+# it. In other words, the "window" isn't a fixed constant anywhere in this
+# code -- it's whatever the recurrence learns to propagate, the same way it
+# already has to for space_before/capitalized/numeric. This isn't free,
+# though: the model has to see enough training examples of the pattern to
+# learn how far (and whether) to project it; a hardcoded window would
+# guarantee reach regardless of training data volume, a learned one doesn't.
+# --------------------------------------------------------------------------
+
+# Capitalized word (up to 3 title-cased words) immediately followed by a
+# colon -- "Fax:", "Cell:", "Job Group:", "Notice Regarding:". Essentially
+# never occurs in narrative prose; very common in structured/tabular fields.
+STRUCTURAL_LABELED_FIELD_RE = re.compile(
+    r'\b[A-Z][a-zA-Z]*(?:\s[A-Z][a-zA-Z]*){0,2}\s*:'
+)
+
+# Phone-number-like or short ID-like digit groups: (713) 571-9571,
+# 713-654-0365, x365. Deliberately narrow (hyphen/paren/x-prefixed digit
+# groups only) to avoid firing on ordinary numeric expressions like page
+# counts or years.
+STRUCTURAL_PHONE_ID_RE = re.compile(
+    r'\(\d{3}\)\s?\d{3}-\d{4}'      # (713) 571-9571
+    r'|\b\d{3}-\d{3}-\d{4}\b'       # 713-654-0365
+    r'|\bx\d{3,5}\b'                # x365
+)
+
+# Numeric dates: 28/10/2004, 16/11/2004, or "November 5, 1999" style.
+STRUCTURAL_DATE_RE = re.compile(
+    r'\b\d{1,2}/\d{1,2}/\d{2,4}\b'
+    r'|\b(?:January|February|March|April|May|June|July|August|September'
+    r'|October|November|December)\s+\d{1,2},?\s+\d{4}\b'
+)
+
+# Currency amounts: $62,500 / $47,500.00
+STRUCTURAL_CURRENCY_RE = re.compile(
+    r'\$\s?\d[\d,]*(?:\.\d+)?'
+)
+
+# Registry mapping feat_func name (as it would appear in args['feat_funcs'])
+# to its compiled regex. Kept separate from the per-character funcs handled
+# in para_to_sentences's composite_func, since these operate on a window.
+STRUCTURAL_FEATURES = {
+    'labeled_field': STRUCTURAL_LABELED_FIELD_RE,
+    'phone_id': STRUCTURAL_PHONE_ID_RE,
+    'date_pattern': STRUCTURAL_DATE_RE,
+    'currency': STRUCTURAL_CURRENCY_RE,
+}
 
 
 class DataLoader(TokenizationDataset):
@@ -1070,4 +1173,3 @@ class SortedDataset(Dataset):
             raw_units.append(r_ + ['<PAD>'])
 
         return units, labels, features, raw_units
-

--- a/stanza/models/tokenization/data.py
+++ b/stanza/models/tokenization/data.py
@@ -259,23 +259,16 @@ class TokenizationDataset:
         res = []
         funcs = []
         for feat_func in self.args['feat_funcs']:
-            if feat_func == 'end_of_para' or feat_func == 'start_of_para':
+            if feat_func in POSITION_FEAT_FUNCS:
                 # skip for position-dependent features
                 continue
             if feat_func in STRUCTURAL_FEATURES:
                 # skip here -- these are window-based, computed separately
                 # below rather than as a per-character lambda
                 continue
-            if feat_func == 'space_before':
-                func = lambda x: 1 if x.startswith(' ') else 0
-            elif feat_func == 'capitalized':
-                func = lambda x: 1 if x[0].isupper() else 0
-            elif feat_func == 'numeric':
-                func = lambda x: 1 if (NUMERIC_RE.match(x) is not None) else 0
-            else:
+            if feat_func not in PER_CHAR_FEAT_FUNCS:
                 raise ValueError('Feature function "{}" is undefined.'.format(feat_func))
-
-            funcs.append(func)
+            funcs.append(PER_CHAR_FEAT_FUNCS[feat_func])
 
         # stacking all featurize functions
         composite_func = lambda x: [f(x) for f in funcs]
@@ -509,6 +502,28 @@ STRUCTURAL_FEATURES = {
     'date_pattern': STRUCTURAL_DATE_RE,
     'currency': STRUCTURAL_CURRENCY_RE,
 }
+
+# The three per-character feat_funcs, as a dict rather than an if/elif
+# chain, so this dict is the actual source of truth para_to_sentences
+# dispatches from -- not a second hand-typed copy of the same three names.
+PER_CHAR_FEAT_FUNCS = {
+    'space_before': lambda x: 1 if x.startswith(' ') else 0,
+    'capitalized': lambda x: 1 if x[0].isupper() else 0,
+    'numeric': lambda x: 1 if (NUMERIC_RE.match(x) is not None) else 0,
+}
+
+# The two position-dependent feat_funcs, handled separately in
+# para_to_sentences since they depend on index rather than character.
+POSITION_FEAT_FUNCS = frozenset({'end_of_para', 'start_of_para'})
+
+# Every feat_func name para_to_sentences recognizes, derived from the three
+# registries above rather than re-typed. This is what other code (eg
+# run_tokenizer.py's EXTRA_FEAT_FUNCS, and its tests) should check against.
+KNOWN_FEAT_FUNCS = (
+    frozenset(PER_CHAR_FEAT_FUNCS.keys())
+    | POSITION_FEAT_FUNCS
+    | frozenset(STRUCTURAL_FEATURES.keys())
+)
 
 
 class DataLoader(TokenizationDataset):
@@ -1173,3 +1188,4 @@ class SortedDataset(Dataset):
             raw_units.append(r_ + ['<PAD>'])
 
         return units, labels, features, raw_units
+

--- a/stanza/models/tokenizer.py
+++ b/stanza/models/tokenizer.py
@@ -59,6 +59,7 @@ def build_argparse():
     parser.add_argument('--conv_res', type=str, default=None, help="Convolutional residual layers for the RNN")
     parser.add_argument('--rnn_layers', type=int, default=1, help="Layers of RNN in the tokenizer")
     parser.add_argument('--use_dictionary', action='store_true', help="Use dictionary feature. The lexicon is created using the training data and external dict (if any) expected to be found under the same folder of training dataset, formatted as SHORTHAND-externaldict.txt where each line in this file is a word. For example, data/tokenize/zh_gsdsimp-externaldict.txt")
+    parser.add_argument('--feat_funcs', type=str, default=None, help="Comma-separated list of feature functions to use, overriding the default set (space_before,capitalized,numeric,end_of_para,start_of_para). Leave unset to keep the existing default behavior unchanged. See #1640 for the structural features (labeled_field, phone_id, date_pattern, currency) added to help the English tokenizer distinguish tabular/header text (datelines, signatures, salary tables) from narrative prose near digit-capital boundaries.")
 
     parser.add_argument('--max_grad_norm', type=float, default=1.0, help="Maximum gradient norm to clip to")
     parser.add_argument('--anneal', type=float, default=.999, help="Anneal the learning rate by this amount when dev performance deteriorate")
@@ -133,7 +134,13 @@ def main(args=None):
 
     logger.info("Running tokenizer in {} mode".format(args['mode']))
 
-    args['feat_funcs'] = ['space_before', 'capitalized', 'numeric', 'end_of_para', 'start_of_para']
+    DEFAULT_FEAT_FUNCS = ['space_before', 'capitalized', 'numeric', 'end_of_para', 'start_of_para']
+    if args.get('feat_funcs'):
+        # opt-in override -- see --feat_funcs help text / #1640.
+        # Every other invocation that doesn't pass --feat_funcs is unaffected.
+        args['feat_funcs'] = [f.strip() for f in args['feat_funcs'].split(',') if f.strip()]
+    else:
+        args['feat_funcs'] = DEFAULT_FEAT_FUNCS
     args['feat_dim'] = len(args['feat_funcs'])
     args['save_name'] = model_file_name(args)
     utils.ensure_dir(os.path.split(args['save_name'])[0])
@@ -273,3 +280,4 @@ def evaluate(args):
 
 if __name__ == '__main__':
     main()
+

--- a/stanza/models/tokenizer.py
+++ b/stanza/models/tokenizer.py
@@ -127,6 +127,12 @@ def model_file_name(args):
         return save_name
     return os.path.join(args['save_dir'], save_name)
 
+# Base feat_funcs used when nothing else is specified. Kept at module level
+# (rather than local to main()) so other scripts -- eg run_tokenizer.py's
+# per-language additions -- can import and compose with it instead of
+# re-typing it, which would otherwise go stale silently if this list changes.
+DEFAULT_FEAT_FUNCS = ['space_before', 'capitalized', 'numeric', 'end_of_para', 'start_of_para']
+
 def main(args=None):
     args = parse_args(args=args)
 
@@ -134,7 +140,6 @@ def main(args=None):
 
     logger.info("Running tokenizer in {} mode".format(args['mode']))
 
-    DEFAULT_FEAT_FUNCS = ['space_before', 'capitalized', 'numeric', 'end_of_para', 'start_of_para']
     if args.get('feat_funcs'):
         # opt-in override -- see --feat_funcs help text / #1640.
         # Every other invocation that doesn't pass --feat_funcs is unaffected.
@@ -280,4 +285,3 @@ def evaluate(args):
 
 if __name__ == '__main__':
     main()
-

--- a/stanza/tests/tokenization/test_tokenize_data_structural_features.py
+++ b/stanza/tests/tokenization/test_tokenize_data_structural_features.py
@@ -1,0 +1,261 @@
+"""
+Tests for the structural/tabular text features added to tokenization/data.py
+for GitHub #1640 (English tokenizer over-splitting at [digit][capitalized
+word], eg "Pope Leo X used" -> "Pope Leo | X used").
+
+These features (labeled_field, phone_id, date_pattern, currency) exist to let
+the tokenizer distinguish document-structural text (news datelines, email
+signature blocks, tabular listings -- where a sentence boundary right after
+a bare digit really is correct) from narrative prose (where it usually isn't).
+
+Two layers of coverage here:
+  - regex-only tests, isolated from DataLoader/vocab machinery, mirroring the
+    style of test_numeric_re in test_tokenize_data.py
+  - DataLoader integration tests, confirming the features actually reach the
+    per-character feature vectors with the right values at the right
+    positions, and don't fire on ordinary prose (including the exact
+    sentences from the #1640 bug report)
+
+No pipeline download is required: like test_has_mwt in test_tokenize_data.py,
+DataLoader builds its own vocab from the input data when none is passed.
+"""
+
+import pytest
+import tempfile
+import numpy as np
+
+from stanza.tests import *
+from stanza.models.tokenization.data import DataLoader, STRUCTURAL_FEATURES
+
+pytestmark = [pytest.mark.travis]
+
+# Column order matches insertion order of STRUCTURAL_FEATURES in data.py.
+# If that dict's definition order ever changes, these indices need updating.
+STRUCTURAL_FEAT_PROPERTIES = {
+    "lang": "en",
+    "feat_funcs": ("space_before", "capitalized", "numeric",
+                   "labeled_field", "phone_id", "date_pattern", "currency"),
+    "max_seqlen": 1000,
+    "use_dictionary": False,
+}
+LABELED_FIELD_COL = 3
+PHONE_ID_COL = 4
+DATE_PATTERN_COL = 5
+CURRENCY_COL = 6
+STRUCTURAL_COLS = [LABELED_FIELD_COL, PHONE_ID_COL, DATE_PATTERN_COL, CURRENCY_COL]
+
+
+def write_tokenizer_input(test_dir, raw_text, labels):
+    """
+    Same helper as in test_tokenize_data.py -- writes raw_text and labels to
+    randomly named files in test_dir. Tempfiles are not auto-cleaned; put
+    them in a tempdir.
+    """
+    with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', dir=test_dir, delete=False) as fout:
+        txt_file = fout.name
+        fout.write(raw_text)
+
+    with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', dir=test_dir, delete=False) as fout:
+        label_file = fout.name
+        fout.write(labels)
+
+    return txt_file, label_file
+
+
+def get_feats(test_dir, raw_text):
+    """
+    Builds a DataLoader in evaluation mode (so the whole input is treated as
+    a single "sentence", per TokenizationDataset's docstring) using
+    STRUCTURAL_FEAT_PROPERTIES, and returns the (seq_len, num_feats) feature
+    array along with the raw character list, for inspecting specific
+    positions in a test.
+
+    Labels are irrelevant in evaluation mode (para_to_sentences doesn't cut
+    on label==2/4 when self.eval is True), so we just supply all zeros.
+    """
+    labels = "0" * len(raw_text)
+    txt_file, label_file = write_tokenizer_input(test_dir, raw_text, labels)
+    data = DataLoader(args=STRUCTURAL_FEAT_PROPERTIES,
+                       input_files={'txt': txt_file, 'label': label_file},
+                       evaluation=True)
+    assert len(data.sentences) == 1
+    assert len(data.sentences[0]) == 1
+    _, _, feats, raw_units = data.sentences[0][0]
+    return np.array(feats), raw_units
+
+
+# ---------------------------------------------------------------------------
+# Regex-only tests (no DataLoader/vocab needed)
+# ---------------------------------------------------------------------------
+
+LABELED_FIELD_MATCHES = [
+    "Fax: 713-654-1281",
+    "Cell: 281-435-0295",
+    "Job Group: Specialist",
+    "Notice Regarding Entry of Orders:",
+]
+LABELED_FIELD_NON_MATCHES = [
+    "Pope Leo X used his influence to reshape the papal court.",
+    "The 5th Amendment protects against compelled self-incrimination.",
+]
+
+def test_labeled_field_regex():
+    for text in LABELED_FIELD_MATCHES:
+        assert STRUCTURAL_FEATURES['labeled_field'].search(text) is not None, text
+    for text in LABELED_FIELD_NON_MATCHES:
+        assert STRUCTURAL_FEATURES['labeled_field'].search(text) is None, text
+
+
+PHONE_ID_MATCHES = [
+    "(713) 571-9571",
+    "713-654-0365",
+    "x365",
+]
+PHONE_ID_NON_MATCHES = [
+    "Chapter 7 for details on installation requirements.",
+    "Apollo 11 landed on the moon in July of 1969.",
+]
+
+def test_phone_id_regex():
+    for text in PHONE_ID_MATCHES:
+        assert STRUCTURAL_FEATURES['phone_id'].search(text) is not None, text
+    for text in PHONE_ID_NON_MATCHES:
+        assert STRUCTURAL_FEATURES['phone_id'].search(text) is None, text
+
+
+DATE_PATTERN_MATCHES = [
+    "Washington Times 28/10/2004",
+    "Asia Times Online 16/11/2004",
+    "November 5, 1999",
+]
+DATE_PATTERN_NON_MATCHES = [
+    "Luther's 95 Theses remain a foundational document of the Reformation.",
+    "Team 7 Alpha advanced to the semifinal round.",
+]
+
+def test_date_pattern_regex():
+    for text in DATE_PATTERN_MATCHES:
+        assert STRUCTURAL_FEATURES['date_pattern'].search(text) is not None, text
+    for text in DATE_PATTERN_NON_MATCHES:
+        assert STRUCTURAL_FEATURES['date_pattern'].search(text) is None, text
+
+
+CURRENCY_MATCHES = [
+    "Maria Valdes superior $62,500",
+    "Current Salary: $47,500",
+    "$47,500.00",
+]
+CURRENCY_NON_MATCHES = [
+    "Emperor Franz Joseph I ruled for nearly seven decades.",
+    "Case 12 Doe v. Smith was cited repeatedly in the appeal.",
+]
+
+def test_currency_regex():
+    for text in CURRENCY_MATCHES:
+        assert STRUCTURAL_FEATURES['currency'].search(text) is not None, text
+    for text in CURRENCY_NON_MATCHES:
+        assert STRUCTURAL_FEATURES['currency'].search(text) is None, text
+
+
+# ---------------------------------------------------------------------------
+# DataLoader integration tests: confirm the regexes actually reach the
+# per-character feature vectors at the right columns and positions
+# ---------------------------------------------------------------------------
+
+def test_feat_dim_matches_feat_funcs():
+    """
+    Sanity check on the plumbing between args['feat_funcs'] and the actual
+    per-character feature vector width -- this is the invariant tokenizer.py
+    relies on when it sets args['feat_dim'] = len(args['feat_funcs']).
+    """
+    with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+        feats, _ = get_feats(test_dir, "Pope Leo X used his influence.")
+        assert feats.shape[1] == len(STRUCTURAL_FEAT_PROPERTIES['feat_funcs'])
+
+
+def test_labeled_field_feature_positions():
+    with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+        text = "Fax: 7136541281"
+        feats, raw_units = get_feats(test_dir, text)
+        # "Fax:" (indices 0-3, inclusive of the colon) should be flagged
+        assert all(feats[i, LABELED_FIELD_COL] == 1 for i in range(0, 4))
+        # a plain digit run with no label shouldn't be
+        assert all(feats[i, LABELED_FIELD_COL] == 0 for i in range(5, len(text)))
+
+
+def test_phone_id_feature_positions():
+    with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+        text = "Call (713) 571-9571 today"
+        feats, raw_units = get_feats(test_dir, text)
+        phone_start = text.index("(713)")
+        phone_end = text.index("9571") + len("9571")
+        assert all(feats[i, PHONE_ID_COL] == 1 for i in range(phone_start, phone_end))
+        # "Call" and "today" shouldn't be flagged
+        assert all(feats[i, PHONE_ID_COL] == 0 for i in range(0, phone_start))
+        assert all(feats[i, PHONE_ID_COL] == 0 for i in range(phone_end + 1, len(text)))
+
+
+def test_date_pattern_feature_positions():
+    with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+        text = "Filed on 28/10/2004 today"
+        feats, raw_units = get_feats(test_dir, text)
+        date_start = text.index("28/10/2004")
+        date_end = date_start + len("28/10/2004")
+        assert all(feats[i, DATE_PATTERN_COL] == 1 for i in range(date_start, date_end))
+        assert all(feats[i, DATE_PATTERN_COL] == 0 for i in range(0, date_start))
+        assert all(feats[i, DATE_PATTERN_COL] == 0 for i in range(date_end, len(text)))
+
+
+def test_currency_feature_positions():
+    with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+        text = "Salary was $62,500 last year"
+        feats, raw_units = get_feats(test_dir, text)
+        cur_start = text.index("$62,500")
+        cur_end = cur_start + len("$62,500")
+        assert all(feats[i, CURRENCY_COL] == 1 for i in range(cur_start, cur_end))
+        assert all(feats[i, CURRENCY_COL] == 0 for i in range(0, cur_start))
+        assert all(feats[i, CURRENCY_COL] == 0 for i in range(cur_end, len(text)))
+
+
+def test_all_four_features_combined():
+    """
+    All four patterns in one paragraph, checking each fires independently
+    without interfering with the others.
+    """
+    with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+        text = "Fax: 713-654-1281 filed 28/10/2004 for $62,500 total"
+        feats, raw_units = get_feats(test_dir, text)
+        assert feats[:, LABELED_FIELD_COL].sum() > 0
+        assert feats[:, PHONE_ID_COL].sum() > 0
+        assert feats[:, DATE_PATTERN_COL].sum() > 0
+        assert feats[:, CURRENCY_COL].sum() > 0
+
+
+# ---------------------------------------------------------------------------
+# No false positives on the #1640 bug report sentences, or on ordinary prose
+# from the corrective training examples
+# ---------------------------------------------------------------------------
+
+BUG_REPORT_SENTENCES = [
+    "Pope Leo X used his position to influence the papal court.",
+    "Luther's 95 Theses remain a foundational document of the Reformation.",
+    "Henry VIII had six wives over the course of his reign.",
+    "Chapter 7 for details on installation requirements.",
+    "Apollo 11 landed on the moon in July of 1969.",
+    "Emperor Franz Joseph I ruled for nearly seven decades.",
+]
+
+PROSE_SENTENCES = [
+    "The 5th Amendment protects against compelled self-incrimination.",
+    "Team 7 Alpha advanced to the semifinal round.",
+    "Case 12 Doe v. Smith was cited repeatedly in the appeal.",
+    "Chapter 9 Methodology explains how the samples were gathered.",
+]
+
+@pytest.mark.parametrize("text", BUG_REPORT_SENTENCES + PROSE_SENTENCES)
+def test_no_false_positives_on_prose(text):
+    with tempfile.TemporaryDirectory(dir=TEST_WORKING_DIR) as test_dir:
+        feats, _ = get_feats(test_dir, text)
+        for col in STRUCTURAL_COLS:
+            assert feats[:, col].sum() == 0, \
+                "structural column {} unexpectedly fired on {!r}".format(col, text)

--- a/stanza/tests/tokenization/test_tokenize_data_structural_features.py
+++ b/stanza/tests/tokenization/test_tokenize_data_structural_features.py
@@ -25,7 +25,7 @@ import tempfile
 import numpy as np
 
 from stanza.tests import *
-from stanza.models.tokenization.data import DataLoader, STRUCTURAL_FEATURES
+from stanza.models.tokenization.data import DataLoader, STRUCTURAL_FEATURES, KNOWN_FEAT_FUNCS
 
 pytestmark = [pytest.mark.travis]
 
@@ -272,11 +272,6 @@ def test_no_false_positives_on_prose(text):
 from stanza.models import tokenizer as tokenizer_module
 from stanza.utils.training import run_tokenizer
 
-KNOWN_FEAT_FUNC_NAMES = (
-    {'space_before', 'capitalized', 'numeric', 'end_of_para', 'start_of_para'}
-    | set(STRUCTURAL_FEATURES.keys())
-)
-
 def test_extra_feat_funcs_are_recognized():
     """
     Every name in run_tokenizer.EXTRA_FEAT_FUNCS must be something data.py's
@@ -285,7 +280,7 @@ def test_extra_feat_funcs_are_recognized():
     """
     for lang, extras in run_tokenizer.EXTRA_FEAT_FUNCS.items():
         for name in extras:
-            assert name in KNOWN_FEAT_FUNC_NAMES, \
+            assert name in KNOWN_FEAT_FUNCS, \
                 "{!r} (added for {!r}) is not a recognized feat_func name".format(name, lang)
 
 

--- a/stanza/tests/tokenization/test_tokenize_data_structural_features.py
+++ b/stanza/tests/tokenization/test_tokenize_data_structural_features.py
@@ -259,3 +259,61 @@ def test_no_false_positives_on_prose(text):
         for col in STRUCTURAL_COLS:
             assert feats[:, col].sum() == 0, \
                 "structural column {} unexpectedly fired on {!r}".format(col, text)
+
+
+# ---------------------------------------------------------------------------
+# Guard tests for run_tokenizer.py's EXTRA_FEAT_FUNCS staying in sync with
+# what data.py actually recognizes and with tokenizer.py's base defaults.
+# Without these, a rename/removal in data.py or a change to
+# tokenizer.DEFAULT_FEAT_FUNCS could go stale in run_tokenizer.py silently
+# (or only surface as a ValueError deep into an actual training run).
+# ---------------------------------------------------------------------------
+
+from stanza.models import tokenizer as tokenizer_module
+from stanza.utils.training import run_tokenizer
+
+KNOWN_FEAT_FUNC_NAMES = (
+    {'space_before', 'capitalized', 'numeric', 'end_of_para', 'start_of_para'}
+    | set(STRUCTURAL_FEATURES.keys())
+)
+
+def test_extra_feat_funcs_are_recognized():
+    """
+    Every name in run_tokenizer.EXTRA_FEAT_FUNCS must be something data.py's
+    para_to_sentences dispatch actually recognizes (else it raises
+    ValueError at training time, not at test time).
+    """
+    for lang, extras in run_tokenizer.EXTRA_FEAT_FUNCS.items():
+        for name in extras:
+            assert name in KNOWN_FEAT_FUNC_NAMES, \
+                "{!r} (added for {!r}) is not a recognized feat_func name".format(name, lang)
+
+
+def test_extra_feat_funcs_do_not_duplicate_base_defaults():
+    """
+    A name listed in both tokenizer.DEFAULT_FEAT_FUNCS and
+    run_tokenizer.EXTRA_FEAT_FUNCS would silently duplicate that feature
+    column in the model's input vector.
+    """
+    base = set(tokenizer_module.DEFAULT_FEAT_FUNCS)
+    for lang, extras in run_tokenizer.EXTRA_FEAT_FUNCS.items():
+        overlap = base & set(extras)
+        assert not overlap, \
+            "{} in EXTRA_FEAT_FUNCS[{!r}] duplicates a base default".format(overlap, lang)
+
+
+def test_default_feat_funcs_composition():
+    """
+    default_feat_funcs(lang) should compose tokenizer.py's base defaults
+    with the language-specific additions -- this is the actual mechanism
+    that replaces re-typing the full list in run_tokenizer.py, so it's
+    worth pinning down directly rather than only via the two tests above.
+    """
+    # a language with no additions falls back to None, letting
+    # tokenizer.py's own default apply unchanged
+    assert run_tokenizer.default_feat_funcs("de") is None
+
+    en_funcs = run_tokenizer.default_feat_funcs("en")
+    assert en_funcs is not None
+    assert en_funcs[:len(tokenizer_module.DEFAULT_FEAT_FUNCS)] == list(tokenizer_module.DEFAULT_FEAT_FUNCS)
+    assert set(en_funcs) == set(tokenizer_module.DEFAULT_FEAT_FUNCS) | set(run_tokenizer.EXTRA_FEAT_FUNCS["en"])

--- a/stanza/utils/training/run_tokenizer.py
+++ b/stanza/utils/training/run_tokenizer.py
@@ -31,13 +31,30 @@ from stanza.utils.training.common import Mode, add_charlm_args, build_tokenizer_
 
 logger = logging.getLogger('stanza')
 
-DEFAULT_FEAT_FUNCS = {
-    # adds some extra feature functions specifically for English
-    # in issue https://github.com/stanfordnlp/stanza/issues/1640,
-    # this helped with the training data in EWT have addresses etc.
-    # which made it hard to distinguish true sentence separations
-    "en": "space_before,capitalized,numeric,labeled_field,phone_id,date_pattern,currency,end_of_para,start_of_para",
+# Per-language *additions* to tokenizer.DEFAULT_FEAT_FUNCS (imported, not
+# re-typed, so a change to the base list there doesn't go stale here).
+# See https://github.com/stanfordnlp/stanza/issues/1640: these structural/
+# tabular features help English distinguish document-structural text
+# (datelines, email signatures, tabular listings) from narrative prose near
+# digit-capital boundaries. The regexes are Latin-script/English-oriented
+# (month names, US-style phone/currency formatting), so this stays opt-in
+# per language rather than a blanket default -- add a language here only
+# after confirming it helps (ideally across multiple seeds, and against that
+# language's own reported bug examples, not just an aggregate dev/test bump).
+EXTRA_FEAT_FUNCS = {
+    "en": ["labeled_field", "phone_id", "date_pattern", "currency"],
 }
+
+def default_feat_funcs(short_language):
+    """
+    Returns the full feat_funcs list for short_language: tokenizer.py's base
+    defaults plus any language-specific additions, or None if there are no
+    additions (in which case tokenizer.py's own default applies as normal).
+    """
+    extra = EXTRA_FEAT_FUNCS.get(short_language)
+    if not extra:
+        return None
+    return tokenizer.DEFAULT_FEAT_FUNCS + extra
 
 def add_tokenizer_args(parser):
     add_charlm_args(parser)
@@ -115,8 +132,10 @@ def run_treebank(mode, paths, treebank, short_name, command_args, extra_args):
                       ["--dev_conll_gold", dev_gold, "--shorthand", short_name])
 
         feat_funcs = command_args.feat_funcs
-        if feat_funcs is None and short_language in DEFAULT_FEAT_FUNCS:
-            feat_funcs = DEFAULT_FEAT_FUNCS[short_language]
+        if feat_funcs is None:
+            default_funcs = default_feat_funcs(short_language)
+            if default_funcs is not None:
+                feat_funcs = ",".join(default_funcs)
         if feat_funcs is not None:
             train_args.extend(['--feat_funcs', feat_funcs])
 

--- a/stanza/utils/training/run_tokenizer.py
+++ b/stanza/utils/training/run_tokenizer.py
@@ -32,6 +32,10 @@ from stanza.utils.training.common import Mode, add_charlm_args, build_tokenizer_
 logger = logging.getLogger('stanza')
 
 DEFAULT_FEAT_FUNCS = {
+    # adds some extra feature functions specifically for English
+    # in issue https://github.com/stanfordnlp/stanza/issues/1640,
+    # this helped with the training data in EWT have addresses etc.
+    # which made it hard to distinguish true sentence separations
     "en": "space_before,capitalized,numeric,labeled_field,phone_id,date_pattern,currency,end_of_para,start_of_para",
 }
 

--- a/stanza/utils/training/run_tokenizer.py
+++ b/stanza/utils/training/run_tokenizer.py
@@ -31,8 +31,14 @@ from stanza.utils.training.common import Mode, add_charlm_args, build_tokenizer_
 
 logger = logging.getLogger('stanza')
 
+DEFAULT_FEAT_FUNCS = {
+    "en": "space_before,capitalized,numeric,labeled_field,phone_id,date_pattern,currency,end_of_para,start_of_para",
+}
+
 def add_tokenizer_args(parser):
     add_charlm_args(parser)
+
+    parser.add_argument('--feat_funcs', default=None, type=str, help='Which feature functions to use - otherwise, will use language-specific defaults')
 
 
 def build_model_filename(paths, short_name, command_args, extra_args):
@@ -103,6 +109,13 @@ def run_treebank(mode, paths, treebank, short_name, command_args, extra_args):
                        "--max_seqlen", seqlen, "--mwt_json_file", dev_mwt] +
                       train_dev_args +
                       ["--dev_conll_gold", dev_gold, "--shorthand", short_name])
+
+        feat_funcs = command_args.feat_funcs
+        if feat_funcs is None and short_language in DEFAULT_FEAT_FUNCS:
+            feat_funcs = DEFAULT_FEAT_FUNCS[short_language]
+        if feat_funcs is not None:
+            train_args.extend(['--feat_funcs', feat_funcs])
+
         if uses_dictionary(short_language):
             train_args = train_args + ["--use_dictionary"]
         train_args = train_args + charlm_args + extra_args


### PR DESCRIPTION
Add columns for some additional features we can use to distinguish address lines etc from normal text.  The goal is to separate when something is an address line vs text such as in this issue: https://github.com/stanfordnlp/stanza/issues/1640

Add a unit test as well
