### PR TITLE
Lemma security

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,11 +80,12 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'emoji', 
+        'networkx',
         'numpy', 
+        'orjson',
         'platformdirs',
         'protobuf>=3.15.0',
         'requests', 
-        'networkx',
         'tomli;python_version<"3.11"',
         'torch>=1.13.0',
         'tqdm',

--- a/stanza/_version.py
+++ b/stanza/_version.py
@@ -1,4 +1,4 @@
 """ Single source of truth for version number """
 
-__version__ = "1.14.0"
-__resources_version__ = '1.14.0'
+__version__ = "1.15.0"
+__resources_version__ = '1.15.0'

--- a/stanza/models/lemma/trainer.py
+++ b/stanza/models/lemma/trainer.py
@@ -30,8 +30,12 @@ logger = logging.getLogger('stanza')
 _POS_INDEPENDENT = "*"
 
 # Version tag stored in the checkpoint to distinguish dict formats
-_DICTS_VERSION_LEGACY = 1   # old (word_dict, composite_dict) tuple
-_DICTS_VERSION_POS    = 2   # new {pos: {word: lemma}}, gzip-pickled bytes
+_DICTS_VERSION_LEGACY     = 1   # old (word_dict, composite_dict) tuple
+_DICTS_VERSION_POS_PICKLE = 2   # new {pos: {word: lemma}}, gzip+pickle bytes (security hole, replaced by v3)
+_DICTS_VERSION_POS        = 3   # new {pos: {word: lemma}}, gzip+json bytes
+
+
+import orjson
 
 
 def unpack_batch(batch, device):
@@ -43,8 +47,8 @@ def unpack_batch(batch, device):
 
 
 def _pack_pos_dict(pos_dict):
-    """Serialize pos_dict to gzip-compressed pickle bytes for storage."""
-    raw = pickle.dumps(pos_dict, protocol=4)
+    """Serialize pos_dict to gzip-compressed JSON bytes for storage."""
+    raw = orjson.dumps(pos_dict)
     buf = io.BytesIO()
     with gzip.GzipFile(fileobj=buf, mode="wb", compresslevel=9) as gz:
         gz.write(raw)
@@ -52,11 +56,12 @@ def _pack_pos_dict(pos_dict):
 
 
 def _unpack_pos_dict(data):
-    """Deserialize pos_dict from gzip-compressed pickle bytes."""
+    """Deserialize pos_dict from gzip-compressed JSON bytes (v3 format)."""
     buf = io.BytesIO(data)
     with gzip.GzipFile(fileobj=buf, mode="rb") as gz:
         raw = gz.read()
-    return pickle.loads(raw)
+    return orjson.loads(raw)
+
 
 
 def _legacy_dicts_to_pos_dict(word_dict, composite_dict):
@@ -376,6 +381,12 @@ class Trainer(object):
         dicts_version = checkpoint.get('dicts_version', _DICTS_VERSION_LEGACY)
         if dicts_version == _DICTS_VERSION_POS:
             self.pos_dict = _unpack_pos_dict(checkpoint['dicts'])
+        elif dicts_version == _DICTS_VERSION_POS_PICKLE:
+            raise ValueError(
+                f"Lemmatizer model {filename!r} uses a pickle-based dict format (v2) "
+                "that is no longer supported for security reasons. "
+                "Please re-download the model or run convert_lemma_dict.py to upgrade it to v3."
+            )
         else:
             # legacy format: (word_dict, composite_dict) tuple
             logger.debug("Loading legacy dict format (version %d), converting to pos_dict", dicts_version)

--- a/stanza/tests/lemma/test_lemma_trainer.py
+++ b/stanza/tests/lemma/test_lemma_trainer.py
@@ -17,6 +17,7 @@ from stanza.models.lemma.trainer import (
     _POS_INDEPENDENT,
     _DICTS_VERSION_LEGACY,
     _DICTS_VERSION_POS,
+    _DICTS_VERSION_POS_PICKLE,
     _pack_pos_dict,
     _unpack_pos_dict,
     _legacy_dicts_to_pos_dict,
@@ -496,3 +497,36 @@ class TestDictLemmatizer:
         assert loaded.predict_dict([("left", "VERB")]) == ["leave"]
         # unknown word
         assert loaded.predict_dict([("xyzzy", "NOUN")]) == ["xyzzy"]
+
+    def test_v2_pickle_load_raises(self, tmp_path):
+        """
+        A checkpoint in the v2 pickle format should raise a ValueError
+        with a message directing the user to convert_lemma_dict.py.
+        The v2 format was used briefly in 1.13.0 and replaced in 1.14.0
+        due to a security concern with pickle deserialization.
+        """
+        import gzip
+        import pickle
+        from stanza.models.lemma.vocab import MultiVocab, Vocab
+
+        pos_dict = {_POS_INDEPENDENT: {"running": "run"}}
+        packed = gzip.compress(pickle.dumps(pos_dict, protocol=4))
+
+        char_vocab = Vocab("abcdefghijklmnopqrstuvwxyz", "en")
+        pos_vocab  = Vocab(["VERB"], "en")
+        vocab      = MultiVocab({'char': char_vocab, 'pos': pos_vocab})
+
+        v2_checkpoint = {
+            'model':        None,
+            'dicts':        packed,
+            'dicts_version': _DICTS_VERSION_POS_PICKLE,
+            'vocab':        vocab.state_dict(),
+            'config':       {'dict_only': True, 'caseless': False,
+                             'charlm_forward_file': None, 'charlm_backward_file': None},
+            'contextual':   [],
+        }
+        save_path = str(tmp_path / "v2_lemmatizer.pt")
+        torch.save(v2_checkpoint, save_path, _use_new_zipfile_serialization=False)
+
+        with pytest.raises(ValueError, match="convert_lemma_dict.py"):
+            trainer.Trainer(model_file=save_path, device='cpu')

--- a/stanza/utils/lemma/convert_lemma_dict.py
+++ b/stanza/utils/lemma/convert_lemma_dict.py
@@ -1,18 +1,21 @@
 """
-Convert a lemmatizer .pt file from the legacy dict format to the new
-pos_direct gzip-compressed format, without loading the seq2seq model
-or any other heavyweight components.
+Convert a lemmatizer .pt file to the current dict format, without loading
+the seq2seq model or any other heavyweight components.
+
+Three dict formats have existed:
+  v1 (<=1.13): legacy (word_dict, composite_dict) tuple, plain pickle
+  v2 (1.14):   {pos: {word: lemma}}, gzip+pickle — security hole, no longer loadable
+  v3 (1.15+):  {pos: {word: lemma}}, gzip+orjson — current format
+
+This script converts v1 and v2 models to v3.  If you have a v2 model and
+try to load it without converting, Stanza will raise an error directing
+you here.
 
 Usage:
     python3 convert_lemma_dict.py path/to/model.pt [--output path/to/output.pt]
 
 If --output is not given, the input file is overwritten in place (after
 writing to a .tmp sibling first, so the original is safe until the rename).
-
-This is useful for converting lemmatizers from version 1.13.0 to 1.14.0.
-Otherwise, this script is not actually needed - the existing lemmatizer code
-is already written to load in old formats without failing and to write out
-the new format when saving.
 """
 
 import argparse
@@ -28,9 +31,12 @@ import torch
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+import orjson
+
 _POS_INDEPENDENT  = "*"
-_DICTS_VERSION_LEGACY = 1
-_DICTS_VERSION_POS    = 2
+_DICTS_VERSION_LEGACY     = 1
+_DICTS_VERSION_POS_PICKLE = 2   # gzip+pickle, replaced by v3
+_DICTS_VERSION_POS        = 3   # gzip+json
 
 
 def _legacy_dicts_to_pos_dict(word_dict, composite_dict):
@@ -56,8 +62,8 @@ def _legacy_dicts_to_pos_dict(word_dict, composite_dict):
 
 
 def _pack_pos_dict(pos_dict):
-    """Serialize pos_dict to gzip-compressed pickle bytes."""
-    raw = pickle.dumps(pos_dict, protocol=4)
+    """Serialize pos_dict to gzip-compressed JSON bytes."""
+    raw = orjson.dumps(pos_dict)
     buf = io.BytesIO()
     with gzip.GzipFile(fileobj=buf, mode="wb", compresslevel=9) as gz:
         gz.write(raw)
@@ -70,7 +76,20 @@ def convert(input_path, output_path):
 
     dicts_version = checkpoint.get('dicts_version', _DICTS_VERSION_LEGACY)
     if dicts_version == _DICTS_VERSION_POS:
-        logger.info("Already in new format (dicts_version=%d), nothing to do.", dicts_version)
+        logger.info("Already in JSON format (dicts_version=%d), nothing to do.", dicts_version)
+        return
+    if dicts_version == _DICTS_VERSION_POS_PICKLE:
+        # pickle-encoded v2 — re-encode as JSON v3
+        logger.info("Found pickle-encoded v2 format — re-encoding as JSON (v3)...")
+        inner = gzip.decompress(checkpoint['dicts'])
+        pos_dict = pickle.loads(inner)
+        checkpoint['dicts'] = _pack_pos_dict(pos_dict)
+        checkpoint['dicts_version'] = _DICTS_VERSION_POS
+        tmp_path = output_path + ".tmp"
+        logger.info("Writing to %s ...", tmp_path)
+        torch.save(checkpoint, tmp_path, _use_new_zipfile_serialization=False)
+        os.replace(tmp_path, output_path)
+        logger.info("Saved to %s", output_path)
         return
 
     logger.info("Converting from legacy format (dicts_version=%d)...", dicts_version)


### PR DESCRIPTION
Patch a security hole in the lemmatizer where using `pickle` is unsafe.  Use `orjson` instead.

https://github.com/stanfordnlp/stanza/security/advisories/GHSA-gh9r-c94j-cmp5