### PR TITLE
Generalize mixed_odia_dataset.py to any low-resource target language

### DIFF
--- a/stanza/utils/datasets/indic/mixed_odia_dataset.py
+++ b/stanza/utils/datasets/indic/mixed_odia_dataset.py
@@ -1,35 +1,37 @@
 """
-Build a combined POS training dataset for an Odia Stanza tagger.
+Build a combined POS training dataset for a low-resource target language.
 
-The Odia treebank (UD_Odia-ODTB) currently has only a test split, so this
-script first splits it deterministically into train/dev/test using a hash of
-each sentence's sent_id.  That way sentences keep their split assignment even
-if the file is later reordered.
+Originally written for Odia, this script now works for any target treebank
+that has only a test split.  It first splits that treebank deterministically
+into train/dev/test using a hash of each sentence's sent_id.  That way
+sentences keep their split assignment even if the file is later reordered.
 
-Additional languages supported in MuRIL that can be mixed in:
+Additional languages supported in MuRIL that can be mixed in as donors:
   Hindi   (UD_Hindi-HDTB)
   Urdu    (UD_Urdu-UDTB)
   Sindhi  (UD_Sindhi-Isra)
   Marathi (UD_Marathi-UFAL)
   Tamil   (UD_Tamil-TTB)
 
-For all extra languages, xpos and morphological features are stripped so the
-model learns only UPOS from them.  Odia keeps its full annotation.
+For all donor languages, xpos and morphological features are stripped so the
+model learns only UPOS from them.  The target language keeps its full
+annotation.
 
-The purpose of mixing in additional datasets is that while the Odia
+The purpose of mixing in additional datasets is that while the target
 dataset is quite small, there is the Muril transformer from Google
-which supports Odia along with several related languages.  Thus we can
+which supports several related South Asian languages.  Thus we can
 mix in those datasets and use only the Muril embedding (no fasttext or
 charlm) in order to get crosslingual training.  This worked quite well
-for Sindhi when building that dataset, should help here as well.
+for Sindhi when building that dataset, and for Odia after it, and should
+help for other low-resource targets as well.
 
 https://aclanthology.org/2025.udw-1.11/
 
 Usage examples:
 
-  # POS tagging dataset (default)
+  # POS tagging dataset (default), mixing in Hindi, Urdu, and Sindhi
   python mixed_odia_dataset.py \\
-      --use_hindi --use_urdu --use_sindhi --use_marathi \\
+      --donors hindi urdu sindhi \\
       --hindi_size 1000 --urdu_size 1000 --sindhi_size 1000
 
   # Dependency parsing dataset
@@ -38,6 +40,10 @@ Usage examples:
   # All languages, both modes
   python mixed_odia_dataset.py --mode pos      --use_all_languages
   python mixed_odia_dataset.py --mode depparse --use_all_languages
+
+  # A different target language
+  python mixed_odia_dataset.py --target_file path/to/bho_bhtb-ud-test.conllu \\
+      --target_shortname bho_bhtb --donors hindi
 
 Adapted from the Sindhi build script in UD_Sindhi-Isra by the original authors.
 
@@ -55,6 +61,20 @@ import zipfile
 from stanza.models.common.doc import Document
 from stanza.utils.conll import CoNLL
 from stanza.utils.default_paths import get_default_paths
+
+
+# ---------------------------------------------------------------------------
+# Donor language configuration
+# ---------------------------------------------------------------------------
+
+# name -> path to the train conllu file relative to UDBASE
+DONOR_CONFIGS = {
+    "hindi":   "UD_Hindi-HDTB/hi_hdtb-ud-train.conllu",
+    "urdu":    "UD_Urdu-UDTB/ur_udtb-ud-train.conllu",
+    "sindhi":  "UD_Sindhi-Isra/sd_isra-ud-train.conllu",
+    "marathi": "UD_Marathi-UFAL/mr_ufal-ud-train.conllu",
+    "tamil":   "UD_Tamil-TTB/ta_ttb-ud-train.conllu",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -120,7 +140,7 @@ def _sent_bucket(sent, weights=(0.8, 0.1, 0.1)):
     return len(weights) - 1  # safety
 
 
-def split_by_sent_id(doc, weights=(0.8, 0.1, 0.1)):
+def split_by_sent_id(doc, weights=(0.8, 0.1, 0.1), label="target"):
     """
     Split *doc* into (train, dev, test) Documents deterministically using
     sent_id hashing so that split membership is stable across file reorderings.
@@ -146,8 +166,8 @@ def split_by_sent_id(doc, weights=(0.8, 0.1, 0.1)):
     dev   = Document(dev_sents,   comments=dev_comments)
     test  = Document(test_sents,  comments=test_comments)
 
-    print("Odia split: %d train / %d dev / %d test" % (
-        len(train.sentences), len(dev.sentences), len(test.sentences)))
+    print("%s split: %d train / %d dev / %d test" % (
+        label, len(train.sentences), len(dev.sentences), len(test.sentences)))
     return train, dev, test
 
 
@@ -160,7 +180,7 @@ def main():
     udbase = paths["UDBASE"]
 
     parser = argparse.ArgumentParser(
-        description="Build a combined POS or dependency parsing training set for an Odia Stanza tagger"
+        description="Build a combined POS or dependency parsing training set for a low-resource target language's Stanza models"
     )
 
     # --- Mode ---
@@ -169,36 +189,34 @@ def main():
         help="Build a POS tagging dataset or a dependency parsing dataset (default: pos)",
     )
 
-    # --- Odia source ---
+    # --- Target language source ---
     parser.add_argument(
-        "--odia_file",
+        "--target_file",
         default=os.path.join(udbase, "UD_Odia-ODTB/or_odtb-ud-test.conllu"),
-        help="Path to the Odia conllu file (currently the test split only)",
+        help="Path to the target-language conllu file (currently the test split only)",
+    )
+    parser.add_argument(
+        "--odia_file", dest="target_file", default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--train_weight", type=float, default=0.8,
-        help="Fraction of Odia sentences for train (default 0.8)",
+        help="Fraction of target-language sentences for train (default 0.8)",
     )
     parser.add_argument(
         "--dev_weight", type=float, default=0.1,
-        help="Fraction of Odia sentences for dev (default 0.1)",
+        help="Fraction of target-language sentences for dev (default 0.1)",
     )
     # test gets the remainder
 
-    # --- Extra languages ---
+    # --- Donor languages ---
     parser.add_argument("--use_all_languages", default=False, action="store_true",
-                        help="Include all five extra languages (Hindi, Urdu, Sindhi, Marathi, Tamil). "
-                             "Individual --use_* flags are still respected and override this.")
-    parser.add_argument("--use_hindi",   default=False, action="store_true",
-                        help="Include Hindi trees")
-    parser.add_argument("--use_urdu",    default=False, action="store_true",
-                        help="Include Urdu trees")
-    parser.add_argument("--use_sindhi",  default=False, action="store_true",
-                        help="Include Sindhi trees")
-    parser.add_argument("--use_marathi", default=False, action="store_true",
-                        help="Include Marathi trees")
-    parser.add_argument("--use_tamil",   default=False, action="store_true",
-                        help="Include Tamil trees")
+                        help="Include all donor languages (Hindi, Urdu, Sindhi, Marathi, Tamil). "
+                             "--donors is still respected and adds to this.")
+    parser.add_argument("--donors", nargs="+", default=[], metavar="LANG",
+                        choices=sorted(DONOR_CONFIGS.keys()),
+                        help="Donor languages to mix in. Choices: %s (default: none)" %
+                             ", ".join(sorted(DONOR_CONFIGS.keys())))
 
     # --- Per-language size caps ---
     parser.add_argument("--hindi_size",   type=int, default=1000,
@@ -219,8 +237,12 @@ def main():
              "Defaults to data/pos or data/depparse depending on --mode.",
     )
     parser.add_argument(
-        "--dataset_name", default="or_odtb",
+        "--target_shortname", default="or_odtb",
         help="Short name used in output filenames (default: or_odtb)",
+    )
+    parser.add_argument(
+        "--dataset_name", dest="target_shortname", default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
     )
 
     args = parser.parse_args()
@@ -231,43 +253,45 @@ def main():
     os.makedirs(args.output_dir, exist_ok=True)
 
     # ------------------------------------------------------------------
-    # 1. Load and split the Odia data.
+    # 1. Load and split the target-language data.
     #    Always keep full annotation (xpos, feats, head, deprel) so the
     #    same split is usable for both pos and depparse modes.
     # ------------------------------------------------------------------
-    print("Reading Odia data from: %s" % args.odia_file)
-    odia_doc = read_conllu(args.odia_file, strip_xpos=False)
-    print("Total Odia sentences: %d" % len(odia_doc.sentences))
+    print("Reading target-language data from: %s" % args.target_file)
+    target_doc = read_conllu(args.target_file, strip_xpos=False)
+    print("Total target-language sentences: %d" % len(target_doc.sentences))
 
     weights = (args.train_weight, args.dev_weight,
                1.0 - args.train_weight - args.dev_weight)
-    train, dev, test = split_by_sent_id(odia_doc, weights=weights)
+    train, dev, test = split_by_sent_id(target_doc, weights=weights, label=args.target_shortname)
 
     # ------------------------------------------------------------------
-    # 2. Load extra-language training data.
+    # 2. Load donor-language training data.
     #
-    #    Always strip xpos/feats from extra languages regardless of mode.
+    #    Always strip xpos/feats from donor languages regardless of mode.
     #    For depparse, we want the parser to generalize on UPOS and tree
     #    structure rather than language-specific xpos tagsets.
-    #    Odia always retains full annotation since it is the target language.
+    #    The target language always retains full annotation since it is
+    #    the target language.
     # ------------------------------------------------------------------
-    extra_datasets = {}  # name -> Document
+    donor_datasets = {}  # name -> Document
 
+    donors = set(args.donors)
     if args.use_all_languages:
-        args.use_hindi = args.use_urdu = args.use_sindhi = \
-            args.use_marathi = args.use_tamil = True
+        donors |= set(DONOR_CONFIGS.keys())
+
+    size_overrides = {
+        "hindi": args.hindi_size,
+        "urdu": args.urdu_size,
+        "sindhi": args.sindhi_size,
+        "marathi": args.marathi_size,
+        "tamil": args.tamil_size,
+    }
 
     lang_configs = [
-        ("hindi",   args.use_hindi,   args.hindi_size,
-         os.path.join(udbase, "UD_Hindi-HDTB/hi_hdtb-ud-train.conllu")),
-        ("urdu",    args.use_urdu,    args.urdu_size,
-         os.path.join(udbase, "UD_Urdu-UDTB/ur_udtb-ud-train.conllu")),
-        ("sindhi",  args.use_sindhi,  args.sindhi_size,
-         os.path.join(udbase, "UD_Sindhi-Isra/sd_isra-ud-train.conllu")),
-        ("marathi", args.use_marathi, args.marathi_size,
-         os.path.join(udbase, "UD_Marathi-UFAL/mr_ufal-ud-train.conllu")),
-        ("tamil",   args.use_tamil,   args.tamil_size,
-         os.path.join(udbase, "UD_Tamil-TTB/ta_ttb-ud-train.conllu")),
+        (lang_name, lang_name in donors, size_overrides[lang_name],
+         os.path.join(udbase, lang_path))
+        for lang_name, lang_path in DONOR_CONFIGS.items()
     ]
 
     for lang_name, use_lang, size_cap, lang_path in lang_configs:
@@ -279,12 +303,12 @@ def main():
         if size_cap is not None and len(lang_doc.sentences) > size_cap:
             lang_doc = random_select(lang_doc, size_cap)
             print("  down-sampled to %d sentences" % len(lang_doc.sentences))
-        extra_datasets[lang_name] = lang_doc
+        donor_datasets[lang_name] = lang_doc
 
     # ------------------------------------------------------------------
     # 3. Write output
     # ------------------------------------------------------------------
-    shortname = args.dataset_name
+    shortname = args.target_shortname
     out = args.output_dir
 
     print("Mode: %s  ->  writing to %s" % (args.mode, out))
@@ -300,7 +324,7 @@ def main():
     # train is a zip containing one conllu per source
     train_zip_path = os.path.join(out, "%s.train.in.zip" % shortname)
     train_datasets = {"%s_train.in.conllu" % shortname: train}
-    for lang_name, lang_doc in extra_datasets.items():
+    for lang_name, lang_doc in donor_datasets.items():
         train_datasets["%s.conllu" % lang_name] = lang_doc
 
     print("Writing training zip -> %s" % train_zip_path)


### PR DESCRIPTION
@AngledLuffa, as discussed in #1654 , here's the generalization.

`--odia_file` is now `--target_file` and `--dataset_name` is now
`--target_shortname`, and the five `--use_*` flags are replaced by a single
`--donors` taking a list. Donor paths moved into a `DONOR_CONFIGS` dict at the
top so adding a language is a one-line change. Size caps and donor order are
unchanged. `--odia_file` and `--dataset_name` still work as hidden aliases.

Split logic, sent_id hashing, xpos/feats stripping and output formats are
untouched.

Verified: on Odia with default args and with `--use_all_languages`, both modes,
the extracted train zip contents and the dev/test conllu files are identical to
the original script. Also ran UD_Bhojpuri-BHTB with the new arg names, both
modes are giving exit 0, 278/45/34.

One thing I left alone: The filename is still `mixed_odia_dataset.py`. Happy to rename it if you
  want.

That's the whole change. I'll follow up in #1654  on the transformer question. Hope that helps!