### PR TITLE
Preserve MWT features across CoNLL-U round trips

### DIFF
--- a/stanza/models/common/doc.py
+++ b/stanza/models/common/doc.py
@@ -1191,6 +1191,7 @@ class Token(StanzaObject):
             raise ValueError('id not included for the token')
         if not self._text:
             raise ValueError('text not included for the token')
+        self._feats = token_entry.get(FEATS, None)
         self._misc = token_entry.get(MISC, None)
         self._ner = token_entry.get(NER, None)
         self._multi_ner = token_entry.get(MULTI_NER, None)
@@ -1235,6 +1236,16 @@ class Token(StanzaObject):
     def text(self, value):
         """ Set the token's text value. Example: 'The' """
         self._text = value
+
+    @property
+    def feats(self):
+        """ Access the morphological features of this token. Example: 'Typo=Yes' """
+        return self._feats
+
+    @feats.setter
+    def feats(self, value):
+        """ Set this token's morphological features. Example: 'Typo=Yes' """
+        self._feats = value if self._is_null(value) == False else None
 
     @property
     def misc(self):

--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -305,6 +305,24 @@ def test_mwt_ner_conversion():
     conll = "{:C}".format(doc)
     assert conll == MWT_NER
 
+
+MWT_FEATS = """
+# text = don't
+# sent_id = 0
+1-2\tdon't\t_\t_\t_\tTypo=Yes\t_\t_\t_\t_
+1\tdo\tdo\tAUX\t_\t_\t0\troot\t_\t_
+2\tn't\tnot\tPART\t_\t_\t1\tadvmod\t_\t_
+""".strip()
+
+
+def test_mwt_feats_conversion():
+    """Test that morphological features on multi-word tokens survive a round trip."""
+    doc = CoNLL.conll2doc(input_str=MWT_FEATS)
+
+    assert doc.sentences[0].tokens[0].feats == "Typo=Yes"
+    assert format(doc, "C") == MWT_FEATS
+
+
 ALL_OFFSETS_CONLLU = """
 # text = This makes John's headache worse
 # sent_id = 0


### PR DESCRIPTION
## Description

Store the CoNLL-U FEATS field on `Token` objects and expose it through a property, matching the existing field handling on `Word`. `Token.to_dict` already serializes populated output fields, so retaining this value is enough to preserve multi-word token features without changing the serialization path.

A regression test parses a multi-word token carrying `Typo=Yes`, verifies the token property, and checks that formatting the document recreates the same CoNLL-U text.

## Fixes Issues

Fixes #1658.

## Unit test coverage

- [x] Proved the new test fails against the unchanged source because the token has no `feats` attribute.
- [x] `python -m pytest -q stanza/tests/common/test_data_conversion.py` produced 24 passing tests.
- [x] `python -m compileall -q stanza/models/common/doc.py stanza/tests/common/test_data_conversion.py`
- [x] `git diff --check`

## Known breaking changes/behaviors

None. Existing word features and token serialization behavior remain unchanged. Multi-word token features that were previously discarded are now retained.

## Disclosure

This pull request was prepared with AI assistance. Shreyansh Goyal reviewed every changed line and the design rationale before the commit was created and pushed.