### PR TITLE
Set max length for IA roberta models

### DIFF
--- a/stanza/models/common/bert_embedding.py
+++ b/stanza/models/common/bert_embedding.py
@@ -34,7 +34,9 @@ def update_max_length(model_name, tokenizer):
                       'hfl/chinese-macbert-large',
                       'rmihaylov/bert-base-bg',
                       'rmihaylov/bert-base-theseus-bg',
-                      'NYTK/electra-small-discriminator-hungarian'):
+                      'NYTK/electra-small-discriminator-hungarian',
+                      'ibm-research/ia-multilingual-original-script-roberta',
+                      'ibm-research/ia-multilingual-transliterated-roberta'):
         tokenizer.model_max_length = 512
 
 


### PR DESCRIPTION
@AngledLuffa  as discussed in #1654 . Both `ibm-research/ia-multilingual-*-roberta`
models report the sentinel value, so added them to `update_max_length()`.

Verified `load_tokenizer` returns 512 for both after the change.