### PR TITLE
Convert a multi word token id back to a tuple when a Document is built from dicts

### DIFF
--- a/stanza/models/common/doc.py
+++ b/stanza/models/common/doc.py
@@ -644,6 +644,12 @@ class Sentence(StanzaObject):
                 entry[ID] = (i+1, )
             if isinstance(entry[ID], int):
                 entry[ID] = (entry[ID], )
+            elif isinstance(entry[ID], list):
+                # json has no tuple type, so an id written by to_dict() as
+                # (3, 4) reads back as [3, 4].  the rest of the Document
+                # code tests the id for tuple, so restore it here, which
+                # covers every path that builds a Document from dicts
+                entry[ID] = tuple(entry[ID])
             if len(entry.get(ID)) > 1: # if this token is a multi-word token
                 st, en = entry[ID]
                 self.tokens.append(Token(self, entry))

--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -3,6 +3,7 @@ Basic tests of the data conversion
 """
 
 import io
+import json
 import pytest
 import tempfile
 from zipfile import ZipFile
@@ -636,3 +637,56 @@ def test_coref_chains_misc_key():
     # NER and coref must remain distinct keys when both are present
     misc = dict_to_conll_text({ID: (1,), TEXT: "Joe", NER: "S-PERSON", COREF_CHAINS: [attachment]}).split("\t")[-1]
     assert misc == "ner=S-PERSON|coref_chains=unit-repr-id3"
+
+# "du" is the contraction of "de" and "le", so it is a multi word token
+FRENCH_MWT = """
+# text = On parle du chien
+# sent_id = 0
+1	On	on	PRON	_	_	2	nsubj	_	_
+2	parle	parler	VERB	_	_	0	root	_	_
+3-4	du	_	_	_	_	_	_	_	_
+3	de	de	ADP	_	_	5	case	_	_
+4	le	le	DET	_	_	5	det	_	_
+5	chien	chien	NOUN	_	_	2	obl	_	_
+""".strip()
+
+def test_serialized_mwt_id():
+    """
+    A multi word token id must survive to_serialized() and back
+
+    to_dict() writes the id of the "du" token as the tuple (3, 4), and json
+    has no tuple type, so it is read back as a list unless it is converted.
+    A list id is written to the ID column as "[3, 4]" instead of "3-4"
+    """
+    doc = CoNLL.conll2doc(input_str=FRENCH_MWT)
+    doc = Document.from_serialized(doc.to_serialized())
+    assert "{:C}".format(doc) == FRENCH_MWT
+
+    token = doc.sentences[0].tokens[2]
+    assert isinstance(token.id, tuple)
+    assert token.id == (3, 4)
+
+def test_list_mwt_id():
+    """
+    A Document built from dicts whose ids are lists must behave the same
+
+    json.loads of a to_dict() payload gives lists rather than tuples, so a
+    Document can be handed list ids without going through from_serialized
+    """
+    from stanza.models.common.doc import ID
+
+    doc = CoNLL.conll2doc(input_str=FRENCH_MWT)
+    as_lists = json.loads(json.dumps(doc.to_dict()))
+    assert as_lists[0][2][ID] == [3, 4]
+
+    rebuilt = Document(as_lists, doc.text)
+
+    # the comments are not part of this construction path, so compare the
+    # token lines rather than the whole document
+    conll = "{:C}".format(rebuilt)
+    assert "3-4\tdu" in conll
+    assert "[3, 4]" not in conll
+
+    token = rebuilt.sentences[0].tokens[2]
+    assert isinstance(token.id, tuple)
+    assert token.id == (3, 4)


### PR DESCRIPTION
## Description

`Document.to_dict()` writes the id of a multi word token as a tuple. json has no tuple type, so after `to_serialized()` and `from_serialized()` the id is `[3, 4]`, and `dict_to_conll_text` tests it with `isinstance(..., tuple)`, falls through, and writes `str([3, 4])` into the ID column. The range line renders as `[3, 4]` instead of `3-4`, and since `-` is then absent from that string the branch below it inserts a dummy `HEAD` on a line that had none. A list id is also unhashable and does not compare equal to `(3, 4)`.

This is the guard you sketched in #1662, placed next to the existing `int` case in `_process_tokens`:

```python
if isinstance(entry[ID], int):
    entry[ID] = (entry[ID], )
elif isinstance(entry[ID], list):
    entry[ID] = tuple(entry[ID])
```

On the second half of your question, whether the round trip should be fixed as well: it is, by this one change. `Document.__init__` reaches `_process_tokens` through `_process_sentences` and `Sentence`, so `from_serialized` passes through the same guard. I first wrote the conversion inside `from_serialized` and moved it here instead, because `_process_tokens` also covers a `Document` built straight from a `json.loads` payload, which `from_serialized` never sees, and it keeps one conversion rather than two that can drift apart. If you would rather have an explicit conversion in `from_serialized` too, say so and I will add it.

Two other placements I considered and did not take. Converting inside `dict_to_conll_text` would fix the rendering but leave `token.id` a list, so the unhashable and comparison problems would remain. Making `to_dict` write a list instead of a tuple would make the round trip symmetric, but tuples are what the rest of the code tests for and it would change a public return type.

## Fixes Issues

Fixes #1662

## Unit test coverage

Two tests in `stanza/tests/common/test_data_conversion.py`, both on a French sentence whose `du` is a multi word token:

- `test_serialized_mwt_id` goes through `to_serialized()` and `from_serialized()` and asserts the document renders back to the original CoNLL-U and that the id is the tuple `(3, 4)`.
- `test_list_mwt_id` builds a `Document` directly from `json.loads(json.dumps(doc.to_dict()))`, which is the path `from_serialized` does not cover, and asserts the range line is `3-4` and the id is a tuple.

Both fail on `dev` and pass with the change. `stanza/tests/common/test_data_conversion.py` is 25 passed.

Across `stanza/tests/common/`, after running `stanza/tests/setup.py` the way `stanza-tests.yaml` does, and ignoring `test_peft_gradient_checkpointing.py` which cannot be collected without `peft`: `dev` is 215 passed and 20 failed with 3 errors, this branch is 217 passed with the identical failure set, and the difference of two is the two new tests. Every one of those failures is in `test_foundation_cache.py` or `test_bert_embedding*.py` and needs `transformers` and downloaded BERT models, which I do not have here.

## Known breaking changes/behaviors

A list id becomes a tuple. A list id was already broken everywhere it was used: it rendered as invalid CoNLL-U, it could not be hashed, and it did not compare equal to the tuple form.

One interaction is worth flagging, which this change makes visible rather than causes. `to_dict()` emits an empty node inline in the sentence with the 2-tuple id `(5, 1)`, which is the same shape an MWT range has, so `_process_tokens` cannot tell the two apart. Measured on `ESTONIAN_EMPTY_DEPS` from the test file, with `ignore_gapping=False`:

```
                                       dev            this branch
Document(doc.to_dict(), text)          5-1            5-1
Document(json round trip of that)      [5, 1] + HEAD  5-1
```

So `Document(doc.to_dict())` already renders that node as a range rather than `5.1` on `dev`, with no json involved. The effect of the guard is that the json path lands on the same output as the dict path rather than a third one. The `[5, 1]` form raises `CoNLLError` when read back and the `5-1` form does not, so for that one input a caller now gets a wrong document where they previously got an exception.

I would rather fix that separately, because it needs `_process_tokens` to be able to tell an empty node from a range and that is a design decision rather than a guard. `MISC` carries `Empty=5.1` on those rows, which looks like the handle. Say the word and I will open an issue for it, or fold it into this PR if you would rather have one change.

No model is involved in any of this, so there is nothing to retrain or re-evaluate.
