### PR TITLE
Keep empty words out of the token list when a Document is built from dicts

### DIFF
--- a/stanza/models/common/doc.py
+++ b/stanza/models/common/doc.py
@@ -629,16 +629,28 @@ class Sentence(StanzaObject):
         # with edges from the parent to the dependent
         # however, we set it to None until needed, as it is somewhat slow
         self._enhanced_dependencies = None
+        # _process_tokens appends here for any empty node it finds inline in
+        # the token list, which is how Sentence.to_dict() writes them
+        self._empty_words = []
         self._process_tokens(tokens)
 
         if empty_words is not None:
-            self._empty_words = [Word(self, entry) for entry in empty_words]
-        else:
-            self._empty_words = []
+            given = [Word(self, entry) for entry in empty_words]
+            if self._empty_words:
+                # both sources in play, so put them in index order.  the key
+                # tolerates an id that is not a tuple, since an explicitly
+                # supplied entry is not normalized the way _process_tokens
+                # normalizes the ones it finds inline
+                self._empty_words = sorted(
+                    given + self._empty_words,
+                    key=lambda x: tuple(x.id) if isinstance(x.id, (tuple, list)) else (x.id,))
+            else:
+                self._empty_words = given
 
     def _process_tokens(self, tokens):
         st, en = -1, -1
         self.tokens, self.words = [], []
+        word_ids = set()
         for i, entry in enumerate(tokens):
             if ID not in entry: # manually set a 1-based id for word if not exist
                 entry[ID] = (i+1, )
@@ -650,7 +662,15 @@ class Sentence(StanzaObject):
                 # code tests the id for tuple, so restore it here, which
                 # covers every path that builds a Document from dicts
                 entry[ID] = tuple(entry[ID])
-            if len(entry.get(ID)) > 1: # if this token is a multi-word token
+            if len(entry.get(ID)) > 1 and (entry[ID][0] == 0 or entry[ID][0] in word_ids):
+                # an empty node, not a range.  a range token comes before the
+                # words it spans, so its first index has not been seen yet,
+                # and no range can start at 0, so a 0 first index is always an
+                # empty node.  Sentence.to_dict() writes empty nodes inline in
+                # the token list, and this is what tells them apart on the way
+                # back in
+                self._empty_words.append(Word(self, entry))
+            elif len(entry.get(ID)) > 1: # if this token is a multi-word token
                 st, en = entry[ID]
                 self.tokens.append(Token(self, entry))
             else: # else this token is a word
@@ -668,6 +688,7 @@ class Sentence(StanzaObject):
                     continue
                 self.words.append(new_word)
                 idx = entry.get(ID)[0]
+                word_ids.add(idx)
                 if idx <= en:
                     self.tokens[-1].words.append(new_word)
                 else:

--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -423,6 +423,96 @@ def test_empty_deps_at_end_conversion():
     """
     check_empty_deps_conversion(ESTONIAN_EMPTY_END_DEPS, 5)
 
+EMPTY_AT_ZERO = """
+# text = likes cats
+0.1	likes	like	VERB	_	_	_	_	0:root	_
+1	likes	like	VERB	_	_	0	root	_	_
+2	cats	cat	NOUN	_	_	1	obj	_	_
+""".strip()
+
+# an empty node numbered 1.2 and a multi word token spanning 1-2 produce the
+# same id in the dict, so the only thing separating them is where they sit
+EMPTY_COLLIDES_WITH_MWT = """
+# text = He likes
+1	He	he	PRON	_	_	2	nsubj	_	_
+1.2	likes	like	VERB	_	_	_	_	0:root	_
+2	likes	like	VERB	_	_	0	root	_	_
+""".strip()
+
+MWT_1_2 = """
+# text = du chien
+1-2	du	_	_	_	_	_	_	_	_
+1	de	de	ADP	_	_	3	case	_	_
+2	le	le	DET	_	_	3	det	_	_
+3	chien	chien	NOUN	_	_	0	root	_	_
+""".strip()
+
+@pytest.mark.parametrize("input_str", [ESTONIAN_EMPTY_DEPS, ESTONIAN_EMPTY_END_DEPS,
+                                       EMPTY_AT_ZERO, EMPTY_COLLIDES_WITH_MWT, MWT_1_2],
+                         ids=["estonian", "estonian_at_end", "empty_at_zero",
+                              "empty_collides_with_mwt", "mwt_only"])
+def test_empty_words_survive_rebuild(input_str):
+    """
+    Empty words must survive a rebuild from the dicts to_dict() writes
+
+    to_dict() writes an empty word inline in the token list, and its id is a
+    2-tuple, the same shape a multi word token range has.  What separates them
+    is position: a range comes before the words it spans, an empty word comes
+    after the word it hangs off, and no range can start at 0
+    """
+    doc = CoNLL.conll2doc(input_str=input_str, ignore_gapping=False)
+    original = doc.sentences[0]
+
+    rebuilt = Document(doc.to_dict(), doc.text)
+    sentence = rebuilt.sentences[0]
+
+    assert len(sentence.tokens) == len(original.tokens)
+    assert len(sentence.words) == len(original.words)
+    assert len(sentence.empty_words) == len(original.empty_words)
+    assert [w.id for w in sentence.empty_words] == [w.id for w in original.empty_words]
+
+    lines = [x for x in "{:C}".format(rebuilt).split("\n") if not x.startswith("#")]
+    assert lines == [x for x in input_str.split("\n") if not x.startswith("#")]
+
+@pytest.mark.parametrize("input_str", [ESTONIAN_EMPTY_DEPS, EMPTY_AT_ZERO,
+                                       EMPTY_COLLIDES_WITH_MWT, MWT_1_2],
+                         ids=["estonian", "empty_at_zero",
+                              "empty_collides_with_mwt", "mwt_only"])
+def test_empty_words_survive_serialization(input_str):
+    """
+    The same must hold through to_serialized() and back
+    """
+    doc = CoNLL.conll2doc(input_str=input_str, ignore_gapping=False)
+    original = doc.sentences[0]
+
+    rebuilt = Document.from_serialized(doc.to_serialized())
+    sentence = rebuilt.sentences[0]
+
+    assert len(sentence.tokens) == len(original.tokens)
+    assert len(sentence.empty_words) == len(original.empty_words)
+
+    lines = [x for x in "{:C}".format(rebuilt).split("\n") if not x.startswith("#")]
+    assert lines == [x for x in input_str.split("\n") if not x.startswith("#")]
+
+@pytest.mark.parametrize("bad_id", [1, [1, 2]])
+def test_explicit_empty_words_with_unnormalized_ids(bad_id):
+    """
+    An explicitly supplied empty word keeps working when its id is not a tuple
+
+    _process_tokens normalizes the ids it finds inline in the token list, and
+    an explicit empty_words entry is not normalized, so the two lists can hold
+    different id types when both are in play
+    """
+    from stanza.models.common.doc import ID, TEXT
+
+    doc = CoNLL.conll2doc(input_str=EMPTY_COLLIDES_WITH_MWT, ignore_gapping=False)
+    sentences = doc.to_dict()
+    explicit = [[{ID: bad_id, TEXT: "zzz"}]]
+
+    rebuilt = Document(sentences, doc.text, empty_sentences=explicit)
+
+    assert len(rebuilt.sentences[0].empty_words) == 2
+
 def check_empty_deps_conversion(input_str, expected_words):
     doc = CoNLL.conll2doc(input_str=input_str, ignore_gapping=False)
     assert len(doc.sentences) == 1


### PR DESCRIPTION
## Description

`Sentence.to_dict()` writes an empty word inline in the token list, and its id is a 2-tuple, which is the same shape a multi word token range has. `1.2` and `1-2` produce the identical dict entry, `{'id': (1, 2), ...}`, and `[1, 2]` once json has been through it.

`_process_tokens` branched on the length of the id alone, so every 2-tuple became a range token. On `dev`, rebuilding a document from its own `to_dict()`:

```
original : tokens=7 words=7 empty_words=1
rebuilt  : tokens=8 words=7 empty_words=0
```

and the node rendered as `5-1 panna _ _ _ _ _ _ _ Empty=5.1` against `5.1 panna panema VERB V VerbForm=Inf _ _ 0:root Empty=5.1`, so the lemma, upos, xpos, feats and deps went with it, since a `Token` carries fewer fields than a `Word`.

The fix is the ordering, which you pointed at in #1662 and which the reader was simply not consulting. The UD format spec is what makes it exhaustive: a range line "is inserted before the first word in the range" and ranges "must not overlap", so for a range `a-b` the word `a` has not been seen yet; an empty node is indexed `i.1, i.2` and sits "immediately after a word with index i (where i = 0 for sentence-initial empty nodes)", so for `i >= 1` the word `i` has been seen, and no range can start at 0. The two clauses cover every legal ordering, including the `7 7.1 8-9 8 9` sequence the spec calls out, which `dev` turns into a bogus `8-1`.

`to_dict()` keeps its current shape and length, so `check_empty_deps_conversion` and anything else asserting `sentence_dict[5]['id'] == (5, 1)` is untouched.

## Fixes Issues

Fixes #1662

## Unit test coverage

Two parametrized tests in `stanza/tests/common/test_data_conversion.py` over five inputs: the two Estonian sentences already in the file, an empty node at `0.1`, an empty node at `1.2`, and a multi word token spanning `1-2`. They go through `Document(doc.to_dict(), text)` and through `to_serialized()` and back, and check the token count, the word count, the empty word count, the empty word ids, and the rendered CoNLL-U lines against the input. One more test covers an explicit `empty_sentences` entry whose id is not a tuple.

Nine of the eleven new cases fail on `dev` and all eleven pass here. `test_data_conversion.py` goes from 25 to 36 passed.

Across `stanza/tests/common/`, after `stanza/tests/setup.py` the way `stanza-tests.yaml` runs it, and ignoring `test_peft_gradient_checkpointing.py` which needs `peft`: `dev` is 217 passed and 20 failed with 3 errors, this branch is 228 passed with the identical failure set. Those failures are all in `test_foundation_cache.py` and `test_bert_embedding*.py` and need `transformers` with downloaded models. I also ran `stanza/tests/mwt/`, the tokenizer, pos, lemma, depparse, ner, constituency and pipeline tests on both trees, and the failure sets there are identical too.

## Known breaking changes/behaviors

A 2-tuple id in a dict handed to `Document` is now read as an empty word rather than a range token when its first index is 0 or has already appeared as a word in that sentence. Any caller relying on the old reading was getting a `Token` where the CoNLL-U said empty node, so it was already wrong at the point of rendering.

`empty_sentences` behaves as before whenever the token list carries no inline empty word, which is every document that comes through `CoNLL.conll2doc`. When both are present they are merged in index order, and the sort key tolerates an explicit entry whose id is an int or a list, since those are not normalized the way `_process_tokens` normalizes what it finds inline. That combination raised `TypeError` in an earlier draft of this branch and there is a test for it now.

One case this does not finish. The spec allows an empty node to sit between two words of the same multiword token, and the position is not preserved on either side:

```
input   3-4  3  3.1  4  5
dev     3-4  3  4    3-1  5
branch  3-4  3  4    3.1  5
```

The node keeps its identity and its fields here where `dev` turned it into a range token, but it still moves out of the span. That is `Sentence.to_dict()` and `Sentence.__format__` comparing `empty_words[i].id[0] < token.id[0]`, which predates this change and is untouched by it. I found no instance of it in 25,669 sentences across the es_ancora, nl_alpino, fr_gsd, de_hdt, pl_pdb and pt_bosque dev sets, so I left it alone rather than widen the patch. Happy to take it as a follow-up if you want it closed.

No model is involved, so there is nothing to retrain or re-evaluate.
