### PR TITLE
Interleave empty words per word rather than per token

### DIFF
--- a/stanza/models/common/doc.py
+++ b/stanza/models/common/doc.py
@@ -604,6 +604,19 @@ class Document(StanzaObject):
         return cls(sentences, text, comments)
 
 
+def _empty_word_sort_key(word):
+    """Sort empty words by index, tolerating an id that is not a tuple.
+
+    An empty word built by _process_tokens carries a normalized tuple id, and
+    one supplied through the empty_words argument is whatever the caller put
+    there.
+    """
+    word_id = word.id
+    if isinstance(word_id, (tuple, list)):
+        return tuple(word_id)
+    return (word_id, )
+
+
 class Sentence(StanzaObject):
     """ A sentence class that stores attributes of a sentence and carries a list of tokens.
     """
@@ -641,9 +654,8 @@ class Sentence(StanzaObject):
                 # tolerates an id that is not a tuple, since an explicitly
                 # supplied entry is not normalized the way _process_tokens
                 # normalizes the ones it finds inline
-                self._empty_words = sorted(
-                    given + self._empty_words,
-                    key=lambda x: tuple(x.id) if isinstance(x.id, (tuple, list)) else (x.id,))
+                self._empty_words = sorted(given + self._empty_words,
+                                           key=_empty_word_sort_key)
             else:
                 self._empty_words = given
 
@@ -1065,19 +1077,61 @@ class Sentence(StanzaObject):
         self.print_words(file=wrds_string)
         return wrds_string.getvalue().strip()
 
+    def _ordered_dicts(self, fields=DEFAULT_OUTPUT_FIELDS):
+        """ Yield (dict, is_empty_word) for this sentence in CoNLL-U order.
+
+        An empty word i.j goes immediately after the word with index i.  That
+        word can sit inside a multiword token, so the interleaving has to
+        happen per word rather than per token: for 8-9 8 8.1 9 the empty word
+        belongs between the two words of the range.  An empty word with index
+        0 goes before everything, including a range line that starts at 1.
+
+        to_dict() and __format__() both read from here so that the two cannot
+        drift apart.
+        """
+        if not self._empty_words:
+            # the common case, and the only one that ignore_gapping=True can
+            # produce.  keep it on the old path so nothing pays for the
+            # interleaving that has nothing to interleave
+            for token in self.tokens:
+                for entry in token.to_dict(fields):
+                    yield entry, False
+            return
+
+        # a caller can append to empty_words without keeping it in order, so
+        # do not rely on it: coref_processor builds its zero anaphora nodes
+        # cluster by cluster rather than in word order
+        empties = sorted(self._empty_words, key=_empty_word_sort_key)
+        empty_idx = 0
+        while empty_idx < len(empties) and empties[empty_idx].id[0] == 0:
+            yield empties[empty_idx].to_dict(fields), True
+            empty_idx += 1
+        for token in self.tokens:
+            token_dicts = token.to_dict(fields)
+            offset = 1 if len(token.id) > 1 else 0
+            if offset:
+                yield token_dicts[0], False
+            for word, word_dict in zip(token.words, token_dicts[offset:]):
+                yield word_dict, False
+                while empty_idx < len(empties) and empties[empty_idx].id[0] == word.id:
+                    yield empties[empty_idx].to_dict(fields), True
+                    empty_idx += 1
+        while empty_idx < len(empties):
+            yield empties[empty_idx].to_dict(fields), True
+            empty_idx += 1
+
     def to_dict(self):
         """ Dumps the sentence into a list of dictionary for each token in the sentence.
         """
-        ret = []
-        empty_idx = 0
-        for token_idx, token in enumerate(self.tokens):
-            while empty_idx < len(self._empty_words) and self._empty_words[empty_idx].id[0] < token.id[0]:
-                ret.append(self._empty_words[empty_idx].to_dict())
-                empty_idx += 1
-            ret += token.to_dict()
-        for empty_word in self._empty_words[empty_idx:]:
-            ret.append(empty_word.to_dict())
-        return ret
+        if not self._empty_words:
+            # _ordered_dicts guards this case as well, so the two agree either
+            # way.  the guard is here so that the common path does not go
+            # through the generator to reach the same answer
+            ret = []
+            for token in self.tokens:
+                ret += token.to_dict()
+            return ret
+        return [entry for entry, _ in self._ordered_dicts()]
 
     def __repr__(self):
         return json.dumps(self.to_dict(), indent=2, ensure_ascii=False, cls=DocJSONEncoder)
@@ -1092,15 +1146,8 @@ class Sentence(StanzaObject):
         else:
             fields = DEFAULT_OUTPUT_FIELDS
 
-        pieces = []
-        empty_idx = 0
-        for token_idx, token in enumerate(self.tokens):
-            while empty_idx < len(self._empty_words) and self._empty_words[empty_idx].id[0] < token.id[0]:
-                pieces.append(self._empty_words[empty_idx].to_conll_text(fields))
-                empty_idx += 1
-            pieces.append(token.to_conll_text(fields))
-        for empty_word in self._empty_words[empty_idx:]:
-            pieces.append(empty_word.to_conll_text(fields))
+        pieces = [dict_to_conll_text(entry, "." if is_empty else "-")
+                  for entry, is_empty in self._ordered_dicts(fields)]
 
         if spec[0] == 'c':
             return "\n".join(pieces)

--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -10,7 +10,7 @@ from zipfile import ZipFile
 
 import stanza
 from stanza.utils.conll import CoNLL
-from stanza.models.common.doc import Document
+from stanza.models.common.doc import Document, Word, ID, TEXT
 from stanza.tests import *
 
 pytestmark = pytest.mark.pipeline
@@ -503,8 +503,6 @@ def test_explicit_empty_words_with_unnormalized_ids(bad_id):
     an explicit empty_words entry is not normalized, so the two lists can hold
     different id types when both are in play
     """
-    from stanza.models.common.doc import ID, TEXT
-
     doc = CoNLL.conll2doc(input_str=EMPTY_COLLIDES_WITH_MWT, ignore_gapping=False)
     sentences = doc.to_dict()
     explicit = [[{ID: bad_id, TEXT: "zzz"}]]
@@ -512,6 +510,98 @@ def test_explicit_empty_words_with_unnormalized_ids(bad_id):
     rebuilt = Document(sentences, doc.text, empty_sentences=explicit)
 
     assert len(rebuilt.sentences[0].empty_words) == 2
+    if isinstance(bad_id, list):
+        # a list id renders the way it did before, as the literal text in the
+        # ID column.  what must not happen is the merge raising on the sort
+        assert "{:C}".format(rebuilt)
+
+# the UD format section on empty nodes gives 7 7.1 8-9 8 9 as valid, and an
+# empty node may also sit between two words of one multiword token
+EMPTY_BEFORE_MWT = """
+# text = g a b
+7	g	g	NOUN	_	_	0	root	_	_
+7.1	zz	zz	VERB	_	_	_	_	0:root	_
+8-9	ab	_	_	_	_	_	_	_	_
+8	a	a	ADP	_	_	7	case	_	_
+9	b	b	DET	_	_	7	det	_	_
+""".strip()
+
+EMPTY_INSIDE_MWT = """
+# text = g a b
+7	g	g	NOUN	_	_	0	root	_	_
+8-9	ab	_	_	_	_	_	_	_	_
+8	a	a	ADP	_	_	7	case	_	_
+8.1	zz	zz	VERB	_	_	_	_	0:root	_
+9	b	b	DET	_	_	7	det	_	_
+""".strip()
+
+EMPTY_AT_ZERO_BEFORE_MWT = """
+# text = du chien
+0.1	zz	zz	VERB	_	_	_	_	0:root	_
+1-2	du	_	_	_	_	_	_	_	_
+1	de	de	ADP	_	_	3	case	_	_
+2	le	le	DET	_	_	3	det	_	_
+3	chien	chien	NOUN	_	_	0	root	_	_
+""".strip()
+
+@pytest.mark.parametrize("input_str", [EMPTY_BEFORE_MWT, EMPTY_INSIDE_MWT,
+                                       EMPTY_AT_ZERO_BEFORE_MWT],
+                         ids=["before_mwt", "inside_mwt", "at_zero_before_mwt"])
+def test_empty_words_keep_their_place_around_mwt(input_str):
+    """
+    An empty word keeps its position relative to a multiword token
+
+    An empty word hangs off the word with the matching index, and that word
+    can be inside a range, so 8-9 8 8.1 9 has to come back in that order
+    rather than with the empty word pushed past the end of the range
+    """
+    doc = CoNLL.conll2doc(input_str=input_str, ignore_gapping=False)
+    expected = [x for x in input_str.split("\n") if not x.startswith("#")]
+
+    assert [x for x in "{:C}".format(doc).split("\n") if not x.startswith("#")] == expected
+
+    for rebuilt in (Document(doc.to_dict(), doc.text),
+                    Document.from_serialized(doc.to_serialized())):
+        lines = [x for x in "{:C}".format(rebuilt).split("\n") if not x.startswith("#")]
+        assert lines == expected
+        assert len(rebuilt.sentences[0].empty_words) == 1
+
+EMPTY_ON_LAST_WORD_OF_MWT = """
+# text = g a b
+7	g	g	NOUN	_	_	0	root	_	_
+8-9	ab	_	_	_	_	_	_	_	_
+8	a	a	ADP	_	_	7	case	_	_
+9	b	b	DET	_	_	7	det	_	_
+9.1	zz	zz	VERB	_	_	_	_	0:root	_
+""".strip()
+
+def test_empty_word_after_a_range_stays_after_it():
+    """
+    An empty word on the last word of a range still follows the whole range
+    """
+    doc = CoNLL.conll2doc(input_str=EMPTY_ON_LAST_WORD_OF_MWT, ignore_gapping=False)
+    expected = [x for x in EMPTY_ON_LAST_WORD_OF_MWT.split("\n") if not x.startswith("#")]
+
+    rebuilt = Document(doc.to_dict(), doc.text)
+
+    assert [x for x in "{:C}".format(rebuilt).split("\n") if not x.startswith("#")] == expected
+
+def test_empty_words_out_of_order_are_placed_by_index():
+    """
+    empty_words is not required to be sorted
+
+    coref_processor appends its zero anaphora nodes cluster by cluster rather
+    than in word order, so the ordering cannot assume the list is sorted
+    """
+    doc = CoNLL.conll2doc(input_str=ESTONIAN_EMPTY_DEPS, ignore_gapping=False)
+    sentence = doc.sentences[0]
+    extra = Word(sentence, {ID: (2, 1), TEXT: "zz"})
+    sentence.empty_words = sentence.empty_words + [extra]
+
+    ids = [x.split("\t")[0] for x in "{:C}".format(doc).split("\n") if not x.startswith("#")]
+
+    assert ids.index("2.1") < ids.index("3")
+    assert ids.index("5.1") > ids.index("5")
 
 def check_empty_deps_conversion(input_str, expected_words):
     doc = CoNLL.conll2doc(input_str=input_str, ignore_gapping=False)


### PR DESCRIPTION
## Description

Following on from #1664 and your note about the empty node between 3 and 4.

An empty word hangs off the word whose index it carries, and that word can sit inside a multiword token, so `7 8-9 8 8.1 9` is valid, as you guessed at the end of #1662. `Sentence.to_dict` and `Sentence.__format__` both walked the tokens and flushed pending empty words while `empty.id[0] < token.id[0]`, which can never place anything inside a range. An empty word attached to a word in the middle of a range came out after the whole range:

```
input   3-4  3  3.1  4  5
dev     3-4  3  4    3.1  5
here    3-4  3  3.1  4  5
```

This is not only a round trip problem. On `dev` the misordering happens on the parse, so `"{:C}".format(doc)` straight after `conll2doc` already moves the node.

Interleaving per word fixes it. `Token.to_dict` already returns the range line followed by one dict per word in order, so the words can be walked alongside that list and an empty word emitted as soon as the word it names has been. An empty word indexed `0` goes before everything, including a range line that starts at 1, which is the "must also occur before the multiword token range line" rule you quoted.

`to_dict` and `__format__` both read from the generator, which early-returns when the sentence has no empty words and so neither sorts nor interleaves for the common case. With no empty words it yields exactly the dicts `Token.to_dict` yields, in the same order. `to_dict` keeps a copy of that guard of its own so that the common case does not go through the generator at all. What changed in `__format__` is that the per token join inside `Token.to_conll_text` is gone and every line goes through `dict_to_conll_text` directly. Timed with three bodies installed as `Sentence.to_dict` in one process, `dev`'s among them, plus a byte identical copy of one of them as a fourth arm to show the resolution floor, the arm order reshuffled every round and three seeds each, on 400 sentences each of en_ewt, et_edt, fr_gsd and ru_syntagrus and on 50 synthetic sentences of 30 words: `to_dict` here is faster than `dev` on every corpus and every seed, median 1.55 percent. Dropping the guard measures between -0.35 and 2.25 percent across the four treebanks, median 1.25, against a floor of 0.47 percent median and 1.03 worst, so five of those twelve runs sit inside the floor. On the synthetic set it is 2.7 to 3.0 percent with the guardless arm slower in 55, 59 and 58 of 60 rounds. Separately, and by the earlier method of 10 alternating process runs of the best of 7 batches of 20 calls, `{:C}` measured 4.044 against 4.250 on the synthetic set.

The empty words are sorted by index before use rather than assumed to be in order. `coref_processor._handle_zero_anaphora` appends its zero anaphora nodes as it walks `word_clusters`, which is cluster order and not word order. On `dev` an out of order entry stays wherever the scan has got to: append `1.1` after `2.1` on a three word sentence and `dev` renders `1 2 2.1 1.1 3` where this gives `1 1.1 2 2.1 3`.

That sort key is the one `Sentence.__init__` already uses for the same list, moved to module scope so there is one of it rather than two. It only affects the sort: an explicit `empty_sentences` entry whose id is a plain `1` rather than `(1, 1)` still raises `TypeError: 'int' object is not subscriptable` from `to_dict()`, here and on `dev` alike, and a list id still renders as the literal text in the ID column on both. Garbage in behaves as it did.

The two methods carried near identical copies of the interleaving, which is how they managed to agree on the wrong answer. They now share one generator and differ only in whether they render the dicts.

## Fixes Issues

Fixes #1662. Follows #1663 and #1664, and closes the case those two left open.

## Unit test coverage

Five cases in `stanza/tests/common/test_data_conversion.py`: the `7 7.1 8-9 8 9` sequence the format page gives as valid, an empty word inside a range, `0.1` before a range line, an empty word on the last word of a range, which is the case that must not move, and an `empty_words` list that is not in index order. The first three are each checked on the parse, on a rebuild from `to_dict`, and through `to_serialized` and back. `test_explicit_empty_words_with_unnormalized_ids`, which came in with #1664, gains one line: it renders the document now instead of only counting the merged list.

`test_data_conversion.py` goes from 36 to 41 passed. With the tests in place and `stanza/models/common/doc.py` alone reverted to `dev`, 2 of the 41 fail: the empty word inside a range, and the unsorted list. The other 39 pass on `dev` as well, which is the point of most of them.

Across `stanza/tests/common/`, ignoring `test_peft_gradient_checkpointing.py` which needs `peft`: `dev` is 228 passed, 20 failed, 1 skipped, 3 errors, and this branch is 233 passed with the same 23 names failing or erroring. All 23 are in `test_bert_embedding.py`, `test_bert_embedding_gradient_checkpointing.py` and `test_foundation_cache.py`, and want `transformers` with downloaded models.

Two things I ran beyond the test file.

Every sentence of 1 to 5 words, every way of grouping consecutive words into multiword tokens, and every subset of the n+1 legal empty node anchors. 1364 shapes, each checked straight after the parse and after a rebuild from `to_dict`:

```
        parse exact   rebuild exact
dev        484/1364        484/1364
here      1364/1364       1364/1364
```

`dev` gets the same 880 wrong on both checks. Since this branch is exact on all 1364, the shapes whose output moves are exactly the shapes `dev` renders wrongly, and nothing else moves.

Four UD dev files read with `ignore_gapping=False`: en_ewt, fr_gsd, et_edt and ru_syntagrus, 15505 sentences carrying 1416 range lines and 337 empty nodes. `"{:C}".format(doc)` is byte identical between `dev` and this branch on all four, and so is the render of `Document(doc.to_dict(), doc.text)`. None of those 337 empty nodes hangs off a word inside a range, which is why nothing on them moves.

## Known breaking changes/behaviors

A sentence with an empty word attached to a word inside a multiword token now renders with the empty word in that position rather than after the range. That is the change, and it is what the format page asks for.

`__format__` is built from the same dicts rather than from `Token.to_conll_text`, so a token line and a word line go through `dict_to_conll_text` exactly as they did, with `.` as the connector only for empty words.

Two smaller differences.

An empty word whose index matches no word in the sentence used to be emitted before the first token with a larger index and now goes to the end. The reader does not check that the base word exists, so a file with words 1, 3, 5 and an empty node `2.1` reaches this: `dev` renders `1 2.1 3 5` and this renders `1 3 5 2.1`. That file is not valid CoNLL-U to begin with and neither ordering is right for it.

A token with a single element id and an emptied word list used to render as a blank line and now renders nothing. `_process_tokens` gives every single index entry exactly one word, so this one needs a caller that empties `token.words` on a live object.

No model is involved, so there is nothing to retrain or re-evaluate.
