### PR TITLE
Fix loading MIMIC no-CharLM lemma model

### DIFF
--- a/stanza/models/lemma/trainer.py
+++ b/stanza/models/lemma/trainer.py
@@ -370,8 +370,8 @@ class Trainer(object):
             raise
         self.args = checkpoint['config']
         if args is not None:
-            self.args['charlm_forward_file'] = args.get('charlm_forward_file', self.args['charlm_forward_file'])
-            self.args['charlm_backward_file'] = args.get('charlm_backward_file', self.args['charlm_backward_file'])
+            self.args['charlm_forward_file'] = args.get('charlm_forward_file', self.args.get('charlm_forward_file'))
+            self.args['charlm_backward_file'] = args.get('charlm_backward_file', self.args.get('charlm_backward_file'))
 
         dicts_version = checkpoint.get('dicts_version', _DICTS_VERSION_LEGACY)
         if dicts_version == _DICTS_VERSION_POS:

--- a/stanza/tests/lemma/test_lemma_trainer.py
+++ b/stanza/tests/lemma/test_lemma_trainer.py
@@ -496,3 +496,42 @@ class TestDictLemmatizer:
         assert loaded.predict_dict([("left", "VERB")]) == ["leave"]
         # unknown word
         assert loaded.predict_dict([("xyzzy", "NOUN")]) == ["xyzzy"]
+
+    def test_load_without_charlm_keys(self, tmp_path):
+        """
+        A checkpoint missing charlm_forward_file and charlm_backward_file keys
+        should load successfully (simulates mimic_nocharlm model checkpoints).
+        """
+        from stanza.models.lemma.vocab import MultiVocab, Vocab
+
+        word_dict      = {"running": "run", "left": "leave"}
+        composite_dict = {("left", "ADJ"): "left"}
+
+        char_vocab = Vocab("abcdefghijklmnopqrstuvwxyz", "en")
+        pos_vocab  = Vocab(["VERB", "ADJ"], "en")
+        vocab      = MultiVocab({'char': char_vocab, 'pos': pos_vocab})
+
+        # Config without charlm_forward_file and charlm_backward_file keys
+        legacy_checkpoint = {
+            'model':    None,
+            'dicts':    (word_dict, composite_dict),
+            # no 'dicts_version' key — simulates an old checkpoint
+            'vocab':    vocab.state_dict(),
+            'config':   {'dict_only': True, 'caseless': False},  # missing charlm keys
+            'contextual': [],
+        }
+        save_path = str(tmp_path / "no_charlm_keys_lemmatizer.pt")
+        torch.save(legacy_checkpoint, save_path, _use_new_zipfile_serialization=False)
+
+        # This should not raise KeyError
+        loaded = trainer.Trainer(model_file=save_path, device='cpu')
+
+        # Verify predictions still work
+        assert loaded.predict_dict([("running", "NOUN")]) == ["run"]
+        assert loaded.predict_dict([("left", "ADJ")])  == ["left"]
+        assert loaded.predict_dict([("left", "VERB")]) == ["leave"]
+        assert loaded.predict_dict([("xyzzy", "NOUN")]) == ["xyzzy"]
+
+        # Verify the args dict has None for the missing keys
+        assert loaded.args.get('charlm_forward_file') is None
+        assert loaded.args.get('charlm_backward_file') is None


### PR DESCRIPTION
Fixes a KeyError when loading the English MIMIC no-CharLM lemma model.
Changes
Treats charlm_forward_file and charlm_backward_file as optional checkpoint configuration keys.
Uses safe .get() access so checkpoints without CharLM configuration load correctly.
Adds a regression test covering checkpoints with missing CharLM keys.
Testing
python -m py_compile passes for the modified files.
git diff --check passes.
The full test suite could not be run on Windows due to a PyTorch DLL compatibility issue.
Issue
Fixes the reported failure when initializing:
stanza.Pipeline(
    lang="en",
    package="mimic",
    processors="tokenize,pos,lemma",
    use_gpu=False,
)
with the mimic_nocharlm model.