### PR TITLE
Preserve MWT features across CoNLL-U round trips

### DIFF
--- a/stanza/models/common/doc.py
+++ b/stanza/models/common/doc.py
@@ -1544,6 +1544,7 @@ class Token(StanzaObject):
             raise ValueError('id not included for the token')
         if not self._text:
             raise ValueError('text not included for the token')
+        self._feats = token_entry.get(FEATS, None)
         self._misc = token_entry.get(MISC, None)
         self._ner = token_entry.get(NER, None)
         self._multi_ner = token_entry.get(MULTI_NER, None)
@@ -1588,6 +1589,16 @@ class Token(StanzaObject):
     def text(self, value):
         """ Set the token's text value. Example: 'The' """
         self._text = value
+
+    @property
+    def feats(self):
+        """ Access the morphological features of this token. Example: 'Gender=Fem'"""
+        return self._feats
+
+    @feats.setter
+    def feats(self, value):
+        """ Set this token's morphological features. Example: 'Gender=Fem'"""
+        self._feats = value if self._is_null(value) == False else None
 
     @property
     def misc(self):

--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -830,6 +830,23 @@ FRENCH_MWT = """
 5	chien	chien	NOUN	_	_	2	obl	_	_
 """.strip()
 
+MWT_FEATS = """
+# text = au chien
+1-2\tau\t_\t_\t_\tTypo=Yes\t_\t_\t_\t_
+1\ta\t_\tADP\t_\t_\t3\tcase\t_\t_
+2\tle\t_\tDET\t_\t_\t3\tdet\t_\t_
+3\tchien\tchien\tNOUN\t_\t_\t0\troot\t_\t_
+""".strip()
+
+def test_mwt_feats_survive_serialization():
+    """Morphological features on a multi-word token must survive serialization."""
+    doc = CoNLL.conll2doc(input_str=MWT_FEATS)
+    assert doc.sentences[0].tokens[0].feats == "Typo=Yes"
+
+    rebuilt = Document.from_serialized(doc.to_serialized())
+    assert rebuilt.sentences[0].tokens[0].feats == "Typo=Yes"
+    assert "1-2\tau\t_\t_\t_\tTypo=Yes\t_\t_\t_\t_" in "{:C}".format(rebuilt)
+
 def test_serialized_mwt_id():
     """
     A multi word token id must survive to_serialized() and back


### PR DESCRIPTION
## Summary

Multi-word token entries now retain their `feats` field when a `Document` is serialized and loaded again. This preserves CoNLL-U features such as `Typo=Yes` during round trips.

## Root cause

`Token` objects stored the MWT id, text, and misc fields but did not store or expose `feats`. `Token.to_dict()` therefore omitted MWT morphological features even though `feats` is part of the default CoNLL-U output fields.

## Changes

- Store and expose `feats` on `Token`, matching the existing `Word` interface.
- Add a regression test covering parsing, JSON serialization round-trip, and CoNLL-U output.

## Acceptance behavior

A MWT line containing `Typo=Yes` retains that feature after `Document.to_serialized()` followed by `Document.from_serialized()`, and the feature is emitted again in CoNLL-U output.

## Validation

- `python -m pytest -q stanza/tests/common/test_data_conversion.py` — 42 passed
- `python -m compileall -q stanza/models/common/doc.py stanza/tests/common/test_data_conversion.py`
- `git diff --check`

The repository CI workflow runs the full test suite on its configured self-hosted runner. Black, Ruff, Flake8, and Mypy are not configured as repository CI gates; local Black/Ruff/Flake8 checks report pre-existing issues in the touched files, and Mypy did not complete locally. The model-backed `test_data_objects.py` path was not used for acceptance because this fix is a model-free document conversion path and the local model fixture is unavailable.