### PR TITLE
Preserve MWT feats across Document serialization

### DIFF
--- a/stanza/models/common/doc.py
+++ b/stanza/models/common/doc.py
@@ -1191,6 +1191,7 @@ class Token(StanzaObject):
             raise ValueError('id not included for the token')
         if not self._text:
             raise ValueError('text not included for the token')
+        self._feats = token_entry.get(FEATS, None)
         self._misc = token_entry.get(MISC, None)
         self._ner = token_entry.get(NER, None)
         self._multi_ner = token_entry.get(MULTI_NER, None)
@@ -1235,6 +1236,16 @@ class Token(StanzaObject):
     def text(self, value):
         """ Set the token's text value. Example: 'The' """
         self._text = value
+
+    @property
+    def feats(self):
+        """ Access the morphological features of this token. Example: 'Gender=Fem'"""
+        return self._feats
+
+    @feats.setter
+    def feats(self, value):
+        """ Set this token's morphological features. Example: 'Gender=Fem'"""
+        self._feats = value if self._is_null(value) == False else None
 
     @property
     def misc(self):

--- a/stanza/tests/common/test_data_conversion.py
+++ b/stanza/tests/common/test_data_conversion.py
@@ -636,3 +636,21 @@ def test_coref_chains_misc_key():
     # NER and coref must remain distinct keys when both are present
     misc = dict_to_conll_text({ID: (1,), TEXT: "Joe", NER: "S-PERSON", COREF_CHAINS: [attachment]}).split("\t")[-1]
     assert misc == "ner=S-PERSON|coref_chains=unit-repr-id3"
+
+
+MWT_FEATS = """
+# text = au chien
+1-2	au	_	_	_	Typo=Yes	_	_	_	_
+1	a	_	ADP	_	_	3	case	_	_
+2	le	_	DET	_	_	3	det	_	_
+3	chien	chien	NOUN	_	_	0	root	_	_
+""".strip()
+
+def test_mwt_feats_survive_serialization():
+    """Morphological features on a multi-word token must survive serialization."""
+    doc = CoNLL.conll2doc(input_str=MWT_FEATS)
+    assert doc.sentences[0].tokens[0].feats == "Typo=Yes"
+
+    rebuilt = Document.from_serialized(doc.to_serialized())
+    assert rebuilt.sentences[0].tokens[0].feats == "Typo=Yes"
+    assert '1-2\tau\t_\t_\t_\tTypo=Yes\t_\t_\t_\t_' in "{:C}".format(rebuilt)


### PR DESCRIPTION
## Summary

Multi-word token `feats` (for example `Typo=Yes`) were dropped on `Token` construction, so they did not survive `Document.to_serialized()` / `from_serialized()` round trips.

- Store and expose `feats` on `Token`, matching `Word`.
- `Token.to_dict` already emits populated default output fields, so retaining the value is enough.
- Add a regression test.

Prior #1674 closed unmerged; this reopens the same fix against current main.

## Test plan

- [ ] `python -m pytest -q stanza/tests/common/test_data_conversion.py`

Fixes #1658.